### PR TITLE
fix: use relative path for oras push in devcontainer feature publish

### DIFF
--- a/.github/workflows/publish-devcontainer-feature.yml
+++ b/.github/workflows/publish-devcontainer-feature.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
           cd packages/devcontainer-feature/src/generacy
-          tar czf /tmp/generacy-feature.tgz .
+          tar czf generacy-feature.tgz .
           oras push ghcr.io/generacy-ai/generacy/generacy:preview \
             --config /dev/null:application/vnd.devcontainers \
-            /tmp/generacy-feature.tgz:application/vnd.devcontainers.layer.v1+tar
+            generacy-feature.tgz:application/vnd.devcontainers.layer.v1+tar


### PR DESCRIPTION
## Summary

- Fix `oras push` failure in the "Publish Feature (preview)" workflow step by switching from an absolute path to a relative path for the tarball

## Root Cause

oras v1.2.0 rejects absolute file paths by default. The workflow was creating and referencing the tarball at `/tmp/generacy-feature.tgz`, which caused the following error:

```
Error: absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check: /tmp/generacy-feature.tgz
```

## Fix

Changed the tarball creation and reference from `/tmp/generacy-feature.tgz` (absolute) to `generacy-feature.tgz` (relative). Since the step already `cd`s into `packages/devcontainer-feature/src/generacy`, the tarball is created in that directory and referenced with a relative path, which oras v1.2.0 accepts without issue.

## Test plan

- [ ] Trigger a preview publish workflow run and verify the `oras push` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)