### PR TITLE
fix: devcontainer feature tar self-reference error

### DIFF
--- a/.github/workflows/publish-devcontainer-feature.yml
+++ b/.github/workflows/publish-devcontainer-feature.yml
@@ -48,8 +48,8 @@ jobs:
         if: inputs.mode == 'preview'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
-          cd packages/devcontainer-feature/src/generacy
-          tar czf generacy-feature.tgz .
+          cd packages/devcontainer-feature/src
+          tar czf generacy-feature.tgz -C generacy .
           oras push ghcr.io/generacy-ai/generacy/generacy:preview \
             --config /dev/null:application/vnd.devcontainers \
             generacy-feature.tgz:application/vnd.devcontainers.layer.v1+tar


### PR DESCRIPTION
## Summary
- The previous oras absolute path fix (#282) switched to a relative path, but the tarball was still being created inside the directory being archived
- This caused `tar: .: file changed as we read it` (exit code 1) because tar detected its own output file
- Fix: run `tar` from the parent directory using `-C generacy .` so the tarball is created outside the archived directory

## Context
Follow-up to #282. The `Publish Feature (preview)` step was still failing after the absolute path fix.

## Test plan
- [ ] Merge and verify the Publish Preview workflow succeeds
- [ ] Verify the devcontainer feature is published to `ghcr.io/generacy-ai/generacy/generacy:preview`