### PR TITLE
fix: update license from MIT to Apache-2.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,7 @@
   "name": "generacy-docs",
   "version": "0.0.1",
   "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "humancy"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git"

--- a/packages/devcontainer-feature/package.json
+++ b/packages/devcontainer-feature/package.json
@@ -1,5 +1,6 @@
 {
   "name": "devcontainer-feature",
   "private": true,
+  "license": "Apache-2.0",
   "description": "Generacy Dev Container Feature (published to GHCR, not npm)"
 }

--- a/packages/generacy-extension/package.json
+++ b/packages/generacy-extension/package.json
@@ -4,7 +4,7 @@
   "description": "Workflow development IDE for local development and cloud orchestration management",
   "version": "0.1.0",
   "publisher": "generacy-ai",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "icon": "resources/icon.png",
   "repository": {
     "type": "git",

--- a/packages/generacy-plugin-claude-code/package.json
+++ b/packages/generacy-plugin-claude-code/package.json
@@ -46,7 +46,7 @@
     "docker",
     "generacy"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/generacy-plugin-cloud-build/package.json
+++ b/packages/generacy-plugin-cloud-build/package.json
@@ -46,7 +46,7 @@
     "plugin",
     "generacy"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/generacy-plugin-copilot/package.json
+++ b/packages/generacy-plugin-copilot/package.json
@@ -46,7 +46,7 @@
     "github",
     "generacy"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/generacy/package.json
+++ b/packages/generacy/package.json
@@ -36,7 +36,7 @@
     "headless"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "@clack/prompts": "^0.9",
     "@generacy-ai/orchestrator": "workspace:*",

--- a/packages/github-actions/package.json
+++ b/packages/github-actions/package.json
@@ -33,7 +33,7 @@
     "automation"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/github-issues/package.json
+++ b/packages/github-issues/package.json
@@ -31,7 +31,7 @@
     "automation"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/jira/package.json
+++ b/packages/jira/package.json
@@ -32,7 +32,7 @@
     "automation"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/knowledge-store/package.json
+++ b/packages/knowledge-store/package.json
@@ -37,7 +37,7 @@
     "store",
     "generacy"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -55,7 +55,7 @@
     "fastify",
     "generacy"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -30,7 +30,7 @@
     "handlebars"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",

--- a/packages/workflow-engine/package.json
+++ b/packages/workflow-engine/package.json
@@ -27,7 +27,7 @@
     "automation"
   ],
   "author": "Generacy AI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "uuid": "^9.0.0",
     "yaml": "^2.4.0",


### PR DESCRIPTION
## Summary
- Updates all `package.json` files from MIT to Apache-2.0 license
- Adds missing `license` field to `docs/package.json` and `packages/devcontainer-feature/package.json`
- 15 files updated total

## Test plan
- [ ] Verify all package.json files show `"license": "Apache-2.0"`
- [ ] No functional changes — license metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)