### PR TITLE
fix: move simple-git from devDependencies to dependencies

### DIFF
--- a/packages/workflow-engine/package.json
+++ b/packages/workflow-engine/package.json
@@ -29,6 +29,7 @@
   "author": "Generacy AI",
   "license": "Apache-2.0",
   "dependencies": {
+    "simple-git": "^3.30.0",
     "uuid": "^9.0.0",
     "yaml": "^2.4.0",
     "zod": "^3.23.0"
@@ -47,7 +48,6 @@
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "@typescript-eslint/parser": "^7.13.0",
     "eslint": "^8.57.0",
-    "simple-git": "^3.30.0",
     "typescript": "^5.4.5",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,9 @@ importers:
       '@octokit/rest':
         specifier: ^20.0.0 || ^21.0.0
         version: 21.1.1
+      simple-git:
+        specifier: ^3.30.0
+        version: 3.32.3
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -470,9 +473,6 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
-      simple-git:
-        specifier: ^3.30.0
-        version: 3.32.3
       typescript:
         specifier: ^5.4.5
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Moves `simple-git` from `devDependencies` to `dependencies` in `packages/workflow-engine/package.json`
- `simple-git` is used at runtime in `validateBranchState()` but was only available during development, causing `ERR_MODULE_NOT_FOUND` when running the published/installed package (e.g. in orchestrator containers)

## Test plan
- [ ] Verify orchestrator container starts without `ERR_MODULE_NOT_FOUND` for `simple-git`
- [ ] Run `pnpm build` in workflow-engine to confirm no build regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)