### PR TITLE
fix: resolve duplicate JSON content type parser in orchestrator

### DIFF
--- a/packages/orchestrator/src/routes/pr-webhooks.ts
+++ b/packages/orchestrator/src/routes/pr-webhooks.ts
@@ -51,21 +51,6 @@ export async function setupPrWebhookRoutes(
 ): Promise<void> {
   const { monitorService, webhookSecret, watchedRepos } = options;
 
-  // Register a custom content type parser to capture raw body for signature verification
-  server.addContentTypeParser(
-    'application/json',
-    { parseAs: 'string' },
-    (_req, body, done) => {
-      try {
-        const json = JSON.parse(body as string);
-        // Attach raw body for signature verification
-        done(null, { parsed: json, raw: body });
-      } catch (err) {
-        done(err as Error, undefined);
-      }
-    },
-  );
-
   // Auth is skipped for /webhooks/github/pr-review via server.ts skipRoutes config.
   // Authentication is handled via HMAC-SHA256 signature verification.
   server.post(

--- a/packages/orchestrator/src/routes/webhooks.ts
+++ b/packages/orchestrator/src/routes/webhooks.ts
@@ -51,21 +51,6 @@ export async function setupWebhookRoutes(
 ): Promise<void> {
   const { monitorService, webhookSecret, watchedRepos, clusterGithubUsername } = options;
 
-  // Register a custom content type parser to capture raw body for signature verification
-  server.addContentTypeParser(
-    'application/json',
-    { parseAs: 'string' },
-    (_req, body, done) => {
-      try {
-        const json = JSON.parse(body as string);
-        // Attach raw body for signature verification
-        done(null, { parsed: json, raw: body });
-      } catch (err) {
-        done(err as Error, undefined);
-      }
-    },
-  );
-
   // Auth is skipped for /webhooks/github via server.ts skipRoutes config.
   // Authentication is handled via HMAC-SHA256 signature verification.
   server.post(

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -253,29 +253,51 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
       integrationRegistry,
     });
 
-    // Register webhook routes (if monitor service is available)
-    if (labelMonitorService) {
-      const watchedRepos = new Set(
-        config.repositories.map(r => `${r.owner}/${r.repo}`)
-      );
-      await setupWebhookRoutes(server, {
-        monitorService: labelMonitorService,
-        webhookSecret: config.monitor.webhookSecret,
-        watchedRepos,
-        clusterGithubUsername,
-      });
-    }
+    // Register webhook routes inside an encapsulated plugin so the custom
+    // application/json content-type parser (needed for raw-body signature
+    // verification) is scoped to webhook routes only and registered exactly once.
+    const hasWebhookRoutes = labelMonitorService || prFeedbackMonitorService;
+    if (hasWebhookRoutes) {
+      await server.register(async (webhookScope) => {
+        // Replace the default JSON parser with one that preserves the raw body
+        // for HMAC-SHA256 signature verification.
+        webhookScope.removeContentTypeParser('application/json');
+        webhookScope.addContentTypeParser(
+          'application/json',
+          { parseAs: 'string' },
+          (_req, body, done) => {
+            try {
+              const json = JSON.parse(body as string);
+              done(null, { parsed: json, raw: body });
+            } catch (err) {
+              done(err as Error, undefined);
+            }
+          },
+        );
 
-    // Register PR webhook routes (if PR feedback monitor service is available)
-    if (prFeedbackMonitorService) {
-      const watchedRepos = new Set(
-        config.repositories.map(r => `${r.owner}/${r.repo}`)
-      );
-      await setupPrWebhookRoutes(server, {
-        monitorService: prFeedbackMonitorService,
-        webhookSecret: config.prMonitor.webhookSecret,
-        watchedRepos,
-        clusterGithubUsername,
+        if (labelMonitorService) {
+          const watchedRepos = new Set(
+            config.repositories.map(r => `${r.owner}/${r.repo}`)
+          );
+          await setupWebhookRoutes(webhookScope, {
+            monitorService: labelMonitorService,
+            webhookSecret: config.monitor.webhookSecret,
+            watchedRepos,
+            clusterGithubUsername,
+          });
+        }
+
+        if (prFeedbackMonitorService) {
+          const watchedRepos = new Set(
+            config.repositories.map(r => `${r.owner}/${r.repo}`)
+          );
+          await setupPrWebhookRoutes(webhookScope, {
+            monitorService: prFeedbackMonitorService,
+            webhookSecret: config.prMonitor.webhookSecret,
+            watchedRepos,
+            clusterGithubUsername,
+          });
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- Both `webhooks.ts` and `pr-webhooks.ts` registered their own `application/json` content type parser on the same Fastify instance, causing the orchestrator to crash on startup with: `Content type parser 'application/json' already present`
- Moved the custom raw-body-preserving JSON parser into a single encapsulated Fastify plugin in `server.ts`, registered once and scoped to webhook routes only
- Non-webhook routes continue using Fastify's default JSON parser

## Test plan
- [ ] Verify orchestrator starts without crash-looping in the dev container
- [ ] Verify GitHub webhook signature verification still works on `/webhooks/github`
- [ ] Verify PR review webhook signature verification still works on `/webhooks/github/pr-review`
- [ ] Verify non-webhook API routes still parse JSON bodies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)