### PR TITLE
fix: hardcode single worker per container

### DIFF
--- a/docs/docs/architecture/internals.md
+++ b/docs/docs/architecture/internals.md
@@ -286,11 +286,12 @@ Level 4 scales horizontally with multiple orchestrator instances behind a load b
 
 ### Worker Pool Configuration
 
-The worker dispatcher controls concurrency and resilience through these settings:
+Each worker container processes exactly one job at a time to ensure full isolation. Scale by adding container replicas, not by increasing concurrency within a single container.
+
+The worker dispatcher controls polling and resilience through these settings:
 
 | Setting | Default | Range | Description |
 |---------|---------|-------|-------------|
-| `maxConcurrentWorkers` | 3 | 1–20 | Maximum workers processing jobs in parallel |
 | `pollIntervalMs` | 5000 | ≥ 1000 | Interval between queue polls (ms) |
 | `heartbeatTtlMs` | 30000 | ≥ 5000 | Worker heartbeat TTL — stale workers are reaped after expiry |
 | `heartbeatCheckIntervalMs` | 15000 | ≥ 5000 | Interval between heartbeat/reaper checks (ms) |

--- a/packages/orchestrator/src/config/schema.ts
+++ b/packages/orchestrator/src/config/schema.ts
@@ -163,8 +163,6 @@ export type EpicMonitorConfig = z.infer<typeof EpicMonitorConfigSchema>;
 export const DispatchConfigSchema = z.object({
   /** Interval between queue polls in milliseconds */
   pollIntervalMs: z.number().int().min(1000).default(5000),
-  /** Maximum number of concurrent workers */
-  maxConcurrentWorkers: z.number().int().min(0).max(20).default(3),
   /** Worker heartbeat TTL in milliseconds */
   heartbeatTtlMs: z.number().int().min(5000).default(30000),
   /** Interval between heartbeat/reaper checks in milliseconds */

--- a/packages/orchestrator/src/services/worker-dispatcher.ts
+++ b/packages/orchestrator/src/services/worker-dispatcher.ts
@@ -17,8 +17,12 @@ interface Logger {
 }
 
 /**
- * Worker dispatcher that polls the queue, enforces concurrency limits,
+ * Worker dispatcher that polls the queue, processes one job at a time,
  * manages heartbeats, reaps stale workers, and handles graceful shutdown.
+ *
+ * Each worker container replica runs exactly one job at a time to ensure
+ * full isolation. Scaling is achieved by adding container replicas, not
+ * by increasing concurrency within a single container.
  *
  * Supports both Redis-based and in-memory heartbeat tracking.
  * When Redis is null, heartbeats are tracked via an in-memory Map with timestamps.
@@ -70,7 +74,6 @@ export class WorkerDispatcher {
     this.logger.info(
       {
         pollIntervalMs: this.config.pollIntervalMs,
-        maxConcurrentWorkers: this.config.maxConcurrentWorkers,
         heartbeatTtlMs: this.config.heartbeatTtlMs,
       },
       'Starting worker dispatcher',
@@ -159,11 +162,12 @@ export class WorkerDispatcher {
   }
 
   private async pollOnce(): Promise<void> {
-    // Don't claim if at concurrency limit
-    if (this.activeWorkers.size >= this.config.maxConcurrentWorkers) {
+    // Each container processes exactly one job at a time for full isolation.
+    // Scale by adding container replicas, not concurrent workers.
+    if (this.activeWorkers.size >= 1) {
       this.logger.debug(
-        { active: this.activeWorkers.size, max: this.config.maxConcurrentWorkers },
-        'At concurrency limit, skipping claim',
+        { active: this.activeWorkers.size },
+        'Already processing a job, skipping claim',
       );
       return;
     }

--- a/packages/orchestrator/tests/unit/services/worker-dispatcher.test.ts
+++ b/packages/orchestrator/tests/unit/services/worker-dispatcher.test.ts
@@ -55,7 +55,6 @@ const sampleItem: QueueItem = {
 // Use very short intervals so tests run fast with real timers
 const testConfig: DispatchConfig = {
   pollIntervalMs: 10,
-  maxConcurrentWorkers: 3,
   heartbeatTtlMs: 200,
   heartbeatCheckIntervalMs: 20,
   shutdownTimeoutMs: 100,
@@ -154,7 +153,7 @@ describe('WorkerDispatcher', () => {
   });
 
   describe('concurrency limit', () => {
-    it('should not claim when at maxConcurrentWorkers', async () => {
+    it('should not claim when already processing a job', async () => {
       const blockers: Array<{ resolve: () => void }> = [];
 
       handler.mockImplementation(
@@ -176,17 +175,14 @@ describe('WorkerDispatcher', () => {
       // Wait long enough for several poll cycles
       await tick(100);
 
-      // Active workers should be capped at max
-      expect(dispatcher.getActiveWorkerCount()).toBe(
-        testConfig.maxConcurrentWorkers,
-      );
+      // Only one job should be active at a time (1 per container)
+      expect(dispatcher.getActiveWorkerCount()).toBe(1);
 
       expect(logger.debug).toHaveBeenCalledWith(
         expect.objectContaining({
-          active: testConfig.maxConcurrentWorkers,
-          max: testConfig.maxConcurrentWorkers,
+          active: 1,
         }),
-        'At concurrency limit, skipping claim',
+        'Already processing a job, skipping claim',
       );
 
       // Resolve all blockers to allow cleanup


### PR DESCRIPTION
## Summary
- Removed `maxConcurrentWorkers` config parameter from `DispatchConfigSchema`
- Hardcoded worker dispatcher to process exactly 1 job at a time per container
- Each worker container replica gets full isolation — scaling is via replicas, not in-container concurrency
- The previous default of 3 concurrent workers could cause collisions/conflicts in the shared workspace

## Test plan
- [x] All 20 worker-dispatcher unit tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify worker container processes one job at a time with a labeled issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)