### PR TITLE
fix: use REST API for issue comments to get numeric IDs

### DIFF
--- a/packages/workflow-engine/src/actions/github/client/gh-cli.ts
+++ b/packages/workflow-engine/src/actions/github/client/gh-cli.ts
@@ -194,34 +194,35 @@ export class GhCliGitHubClient implements GitHubClient {
   }
 
   async getIssueComments(owner: string, repo: string, number: number): Promise<Comment[]> {
+    // Use REST API to get numeric comment IDs (gh issue view --json returns GraphQL node IDs)
     const result = await executeCommand('gh', [
-      'issue', 'view', String(number),
-      '-R', `${owner}/${repo}`,
-      '--json', 'comments',
+      'api',
+      `/repos/${owner}/${repo}/issues/${number}/comments`,
+      '--paginate',
     ], { cwd: this.workdir });
 
     if (result.exitCode !== 0) {
       throw new Error(`Failed to get comments for issue #${number}: ${result.stderr}`);
     }
 
-    const data = parseJSONSafe(result.stdout) as { comments: Array<{
-      id: string;
+    const data = parseJSONSafe(result.stdout) as Array<{
+      id: number;
       body: string;
-      author: { login: string };
-      createdAt: string;
-      updatedAt: string;
-    }> } | null;
+      user: { login: string };
+      created_at: string;
+      updated_at: string;
+    }> | null;
 
     if (!data) {
       return [];
     }
 
-    return data.comments.map(c => ({
-      id: parseInt(c.id.split('/').pop() ?? '0', 10),
+    return data.map(c => ({
+      id: c.id,
       body: c.body,
-      author: c.author.login,
-      created_at: c.createdAt,
-      updated_at: c.updatedAt,
+      author: c.user.login,
+      created_at: c.created_at,
+      updated_at: c.updated_at,
     }));
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `getIssueComments` used `gh issue view --json comments` which returns GraphQL node IDs (`IC_kwDON...`), not numeric REST API IDs. `parseInt()` on these strings yielded `NaN`, causing `updateComment` to hit `/repos/.../issues/comments/NaN` → 404.
- **Fix**: Switched to `gh api /repos/{owner}/{repo}/issues/{number}/comments` which returns proper numeric `id` fields directly.
- All 71 existing tests pass.

Closes #305

## Test plan
- [x] Type-check passes (`tsc --noEmit`)
- [x] `update-stage.test.ts` — 13 tests pass
- [x] `claude-cli-worker.test.ts` — 58 tests pass
- [ ] Re-test in production: remove dead-letter state for `cluster-templates#3` in Redis, re-apply trigger label

🤖 Generated with [Claude Code](https://claude.com/claude-code)