### PR TITLE
fix: update Claude CLI flags for current CLI version

### DIFF
--- a/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
+++ b/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
@@ -1760,7 +1760,6 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     const handler = new PrFeedbackHandler(
       {
         workspaceDir: '/tmp/workspace',
-        maxTurns: 10,
         phaseTimeoutMs: 60000,
         shutdownGracePeriodMs: 5000,
         validateCommand: 'echo ok',
@@ -1800,14 +1799,11 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     expect(processFactory.spawn).toHaveBeenCalledWith(
       'claude',
       expect.arrayContaining([
-        '--headless',
-        '--output',
-        'json',
-        '--print',
-        'all',
-        '--max-turns',
-        '10',
-        '--prompt',
+        '-p',
+        '--output-format',
+        'stream-json',
+        '--dangerously-skip-permissions',
+        '--verbose',
         expect.stringContaining('PR #100'),
       ]),
       expect.objectContaining({
@@ -1817,7 +1813,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
 
     // Verify prompt contains all unresolved comments with file paths and line numbers
     const spawnCall = processFactory.spawn.mock.calls[0];
-    const prompt = spawnCall[1][spawnCall[1].indexOf('--prompt') + 1];
+    const prompt = spawnCall[1][spawnCall[1].length - 1];
     expect(prompt).toContain('src/index.ts:10');
     expect(prompt).toContain('src/util.ts:20');
     expect(prompt).toContain('reviewer');
@@ -1929,7 +1925,6 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     const handler = new PrFeedbackHandler(
       {
         workspaceDir: '/tmp/workspace',
-        maxTurns: 10,
         phaseTimeoutMs: 60000,
         shutdownGracePeriodMs: 5000,
         validateCommand: 'echo ok',
@@ -1985,7 +1980,6 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     const handler = new PrFeedbackHandler(
       {
         workspaceDir: '/tmp/workspace',
-        maxTurns: 10,
         phaseTimeoutMs: 60000,
         shutdownGracePeriodMs: 5000,
         validateCommand: 'echo ok',
@@ -2051,7 +2045,6 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     const handler = new PrFeedbackHandler(
       {
         workspaceDir: '/tmp/workspace',
-        maxTurns: 10,
         phaseTimeoutMs: 60000,
         shutdownGracePeriodMs: 5000,
         validateCommand: 'echo ok',
@@ -2078,7 +2071,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     await handler.handle(queueItem, '/tmp/workspace/test-org/test-repo');
 
     const spawnCall = processFactory.spawn.mock.calls[0];
-    const prompt = spawnCall[1][spawnCall[1].indexOf('--prompt') + 1];
+    const prompt = spawnCall[1][spawnCall[1].length - 1];
 
     // Verify PR and issue numbers
     expect(prompt).toContain('PR #200');
@@ -2120,7 +2113,6 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     const handler = new PrFeedbackHandler(
       {
         workspaceDir: '/tmp/workspace',
-        maxTurns: 10,
         phaseTimeoutMs: 60000,
         shutdownGracePeriodMs: 5000,
         validateCommand: 'echo ok',
@@ -2203,7 +2195,6 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     const handler = new PrFeedbackHandler(
       {
         workspaceDir: '/tmp/workspace',
-        maxTurns: 10,
         phaseTimeoutMs: 60000,
         shutdownGracePeriodMs: 5000,
         validateCommand: 'echo ok',

--- a/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
@@ -115,7 +115,6 @@ function createConfig(overrides: Partial<WorkerConfig> = {}): WorkerConfig {
     workspaceDir: '/tmp/test-workspaces',
     shutdownGracePeriodMs: 5000,
     validateCommand: 'pnpm test && pnpm build',
-    maxTurns: 100,
     gates: {
       'speckit-feature': [
         {
@@ -300,7 +299,7 @@ describe('ClaudeCliWorker (integration)', () => {
 
       // First CLI spawn should be for 'plan' (GATE_MAPPING: clarification → resumeFrom: plan)
       const firstSpawnArgs = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
-      const promptArg = firstSpawnArgs[firstSpawnArgs.indexOf('--prompt') + 1]!;
+      const promptArg = firstSpawnArgs[firstSpawnArgs.length - 1]!;
       expect(promptArg).toContain('/speckit:plan');
     });
   });
@@ -973,8 +972,7 @@ describe('ClaudeCliWorker (integration)', () => {
       const spawnCalls = spawnFn.mock.calls as [string, string[], unknown][];
       const prompts = spawnCalls.map((call) => {
         const args = call[1] as string[];
-        const promptIdx = args.indexOf('--prompt');
-        return promptIdx >= 0 ? args[promptIdx + 1] : null;
+        return args[args.length - 1] ?? null;
       });
       expect(prompts[0]).toContain('/speckit:specify');
       expect(prompts[1]).toContain('/speckit:clarify');
@@ -1068,8 +1066,7 @@ describe('ClaudeCliWorker (integration)', () => {
       expect(spawnFn).toHaveBeenCalledTimes(2);
 
       const firstPrompt = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
-      const promptIdx = firstPrompt.indexOf('--prompt');
-      expect(firstPrompt[promptIdx + 1]).toContain('/speckit:plan');
+      expect(firstPrompt[firstPrompt.length - 1]).toContain('/speckit:plan');
     });
   });
 

--- a/packages/orchestrator/src/worker/__tests__/cli-spawner.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/cli-spawner.test.ts
@@ -72,7 +72,6 @@ function defaultOptions(overrides: Partial<CliSpawnOptions> = {}): CliSpawnOptio
     prompt: 'do something',
     cwd: '/tmp/repo',
     env: { PATH: '/usr/bin' },
-    maxTurns: 5,
     timeoutMs: 60_000,
     signal: new AbortController().signal,
     ...overrides,
@@ -138,7 +137,7 @@ describe('CliSpawner', () => {
       expect(spawnArgs[resumeIndex + 1]).toBe('ses-abc-123');
     });
 
-    it('places --resume before --prompt in args', async () => {
+    it('places --resume before the prompt positional arg', async () => {
       const { handle } = createMockProcess(0, 10);
       spawnFn.mockReturnValue(handle);
       const capture = createMockCapture();
@@ -151,8 +150,8 @@ describe('CliSpawner', () => {
 
       const spawnArgs = spawnFn.mock.calls[0]![1] as string[];
       const resumeIndex = spawnArgs.indexOf('--resume');
-      const promptIndex = spawnArgs.indexOf('--prompt');
-      expect(resumeIndex).toBeLessThan(promptIndex);
+      // Prompt is always the last positional argument
+      expect(resumeIndex).toBeLessThan(spawnArgs.length - 1);
     });
 
     it('includes sessionId from capture in PhaseResult', async () => {

--- a/packages/orchestrator/src/worker/__tests__/gate-checker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/gate-checker.test.ts
@@ -17,7 +17,6 @@ function makeConfig(gates: WorkerConfig['gates']): WorkerConfig {
     workspaceDir: '/tmp/orchestrator-workspaces',
     shutdownGracePeriodMs: 5000,
     validateCommand: 'pnpm test && pnpm build',
-    maxTurns: 100,
     gates,
   };
 }

--- a/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.test.ts
@@ -88,7 +88,6 @@ function createMockProcess(exitCode = 0, exitDelay = 10) {
 // ---------------------------------------------------------------------------
 const defaultConfig: WorkerConfig = {
   workspaceDir: '/tmp/workspace',
-  maxTurns: 10,
   phaseTimeoutMs: 60_000,
   shutdownGracePeriodMs: 5_000,
   validateCommand: 'pnpm test && pnpm build',
@@ -246,11 +245,11 @@ describe('PrFeedbackHandler', () => {
       expect(spawnFn).toHaveBeenCalledWith(
         'claude',
         expect.arrayContaining([
-          '--headless',
-          '--output', 'json',
-          '--print', 'all',
-          '--max-turns', '10',
-          '--prompt', expect.stringContaining('PR #100'),
+          '-p',
+          '--output-format', 'stream-json',
+          '--dangerously-skip-permissions',
+          '--verbose',
+          expect.stringContaining('PR #100'),
         ]),
         expect.objectContaining({
           cwd: checkoutPath,
@@ -587,7 +586,6 @@ describe('PrFeedbackHandler', () => {
       expect(spawnFn).toHaveBeenCalledWith(
         'claude',
         expect.arrayContaining([
-          '--prompt',
           expect.stringContaining('src/index.ts:15'),
         ]),
         expect.any(Object),
@@ -596,7 +594,6 @@ describe('PrFeedbackHandler', () => {
       expect(spawnFn).toHaveBeenCalledWith(
         'claude',
         expect.arrayContaining([
-          '--prompt',
           expect.stringContaining('src/util.ts:20'),
         ]),
         expect.any(Object),
@@ -619,7 +616,6 @@ describe('PrFeedbackHandler', () => {
       expect(spawnFn).toHaveBeenCalledWith(
         'claude',
         expect.arrayContaining([
-          '--prompt',
           expect.stringContaining('**alice**'),
         ]),
         expect.any(Object),
@@ -643,7 +639,6 @@ describe('PrFeedbackHandler', () => {
       expect(spawnFn).toHaveBeenCalledWith(
         'claude',
         expect.arrayContaining([
-          '--prompt',
           expect.stringContaining('Do NOT resolve any review threads'),
         ]),
         expect.any(Object),

--- a/packages/orchestrator/src/worker/cli-spawner.ts
+++ b/packages/orchestrator/src/worker/cli-spawner.ts
@@ -44,10 +44,10 @@ export class CliSpawner {
     const prompt = `${command} ${options.prompt}`;
 
     const args = [
-      '--headless',
-      '--output', 'json',
-      '--print', 'all',
-      '--max-turns', String(options.maxTurns),
+      '-p',
+      '--output-format', 'stream-json',
+      '--dangerously-skip-permissions',
+      '--verbose',
     ];
 
     // Resume a previous session to keep MCP servers warm and carry context
@@ -55,13 +55,12 @@ export class CliSpawner {
       args.push('--resume', options.resumeSessionId);
     }
 
-    args.push('--prompt', prompt);
+    args.push(prompt);
 
     this.logger.info(
       {
         phase,
         cwd: options.cwd,
-        maxTurns: options.maxTurns,
         timeoutMs: options.timeoutMs,
         resumeSessionId: options.resumeSessionId ?? null,
       },

--- a/packages/orchestrator/src/worker/config.ts
+++ b/packages/orchestrator/src/worker/config.ts
@@ -25,8 +25,6 @@ export const WorkerConfigSchema = z.object({
   shutdownGracePeriodMs: z.number().int().min(1000).default(5000),
   /** Command to run during the validate phase */
   validateCommand: z.string().default('pnpm test && pnpm build'),
-  /** Maximum Claude CLI turns per phase */
-  maxTurns: z.number().int().min(10).default(100),
   /** Gate definitions keyed by issue label */
   gates: z.record(z.string(), z.array(GateDefinitionSchema)).default({
     'speckit-feature': [

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -127,7 +127,6 @@ export class PhaseLoop {
               prompt: context.issueUrl,
               cwd: context.checkoutPath,
               env: {},
-              maxTurns: config.maxTurns,
               timeoutMs: config.phaseTimeoutMs,
               signal: context.signal,
               resumeSessionId: currentSessionId,

--- a/packages/orchestrator/src/worker/pr-feedback-handler.ts
+++ b/packages/orchestrator/src/worker/pr-feedback-handler.ts
@@ -288,15 +288,15 @@ Please proceed with addressing the feedback.`;
     workflowId: string,
   ): Promise<boolean> {
     const args = [
-      '--headless',
-      '--output', 'json',
-      '--print', 'all',
-      '--max-turns', String(this.config.maxTurns),
-      '--prompt', prompt,
+      '-p',
+      '--output-format', 'stream-json',
+      '--dangerously-skip-permissions',
+      '--verbose',
+      prompt,
     ];
 
     this.logger.info(
-      { cwd: checkoutPath, maxTurns: this.config.maxTurns, timeoutMs: this.config.phaseTimeoutMs },
+      { cwd: checkoutPath, timeoutMs: this.config.phaseTimeoutMs },
       'Spawning Claude CLI for PR feedback',
     );
 

--- a/packages/orchestrator/src/worker/types.ts
+++ b/packages/orchestrator/src/worker/types.ts
@@ -134,8 +134,6 @@ export interface CliSpawnOptions {
   cwd: string;
   /** Environment variables to pass */
   env: Record<string, string>;
-  /** Maximum turns */
-  maxTurns: number;
   /** Timeout in milliseconds */
   timeoutMs: number;
   /** Abort signal for graceful shutdown */


### PR DESCRIPTION
## Summary

The CLI spawner was using flags from an older/different version of Claude Code that don't exist in the current CLI (v2.1.68), causing every phase to immediately exit with code 1 (`error: unknown option '--headless'`).

### Flag changes

| Old (broken) | New (correct) |
|---|---|
| `--headless` | removed (not a valid flag) |
| `--output json` | `--output-format stream-json` |
| `--print all` | `-p` (boolean flag) |
| `--max-turns N` | removed (no CLI equivalent) |
| `--prompt <text>` | positional argument (last arg) |

Added:
- `--dangerously-skip-permissions` — required for headless/automated operation
- `--verbose` — full output including tool use

### Config cleanup
- Removed `maxTurns` from `WorkerConfigSchema` and `CliSpawnOptions` since it has no CLI equivalent

### Files changed
- `cli-spawner.ts` — fixed spawn args
- `pr-feedback-handler.ts` — same fix for PR feedback CLI spawning
- `config.ts` — removed `maxTurns` from schema
- `types.ts` — removed `maxTurns` from `CliSpawnOptions`
- `phase-loop.ts` — removed `maxTurns` from options
- All related test files updated

### Test plan
- [x] All 92 worker tests pass
- [x] TypeScript compiles cleanly
- [x] Verified `claude -p --output-format stream-json --dangerously-skip-permissions --verbose` works in worker container
- [ ] Re-test cluster-templates#3 end-to-end after merge

### Note
14 pre-existing failures in `pr-feedback-integration.test.ts` (500 status codes from server setup) were present before this change and are unrelated.

Closes #307 (if you create an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)