### PR TITLE
fix: install speckit commands and Agency MCP during setup build

### DIFF
--- a/packages/generacy/src/cli/commands/setup/build.ts
+++ b/packages/generacy/src/cli/commands/setup/build.ts
@@ -5,9 +5,11 @@
  */
 import { Command } from 'commander';
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -237,6 +239,72 @@ function buildGeneracy(config: BuildConfig): void {
 }
 
 /**
+ * Phase 4: Install speckit commands and configure Agency MCP for Claude Code.
+ * Copies speckit slash command definitions to ~/.claude/commands/ and adds the
+ * Agency MCP server to the user-level Claude config so that spec_kit tools and
+ * /specify, /clarify, /plan, /tasks, /implement commands are available in all
+ * Claude Code sessions (including worker containers).
+ */
+function installClaudeCodeIntegration(config: BuildConfig): void {
+  const logger = getLogger();
+  const home = homedir();
+
+  logger.info('Phase 4: Installing Claude Code integration (speckit commands + Agency MCP)');
+
+  // Copy speckit command definitions to ~/.claude/commands/
+  const pluginCommandsDir = join(
+    config.agencyDir,
+    'packages',
+    'claude-plugin-agency-spec-kit',
+    'commands',
+  );
+  const userCommandsDir = join(home, '.claude', 'commands');
+
+  if (existsSync(pluginCommandsDir)) {
+    mkdirSync(userCommandsDir, { recursive: true });
+    const files = readdirSync(pluginCommandsDir).filter((f) => f.endsWith('.md'));
+    for (const file of files) {
+      copyFileSync(join(pluginCommandsDir, file), join(userCommandsDir, file));
+    }
+    logger.info({ count: files.length, dest: userCommandsDir }, 'Copied speckit command definitions');
+  } else {
+    logger.warn({ dir: pluginCommandsDir }, 'Speckit commands directory not found, skipping');
+  }
+
+  // Add Agency MCP server to user-level Claude config (~/.claude.json)
+  const claudeJsonPath = join(home, '.claude.json');
+  const agencyCli = join(config.agencyDir, 'packages', 'agency', 'dist', 'cli.js');
+
+  if (!existsSync(agencyCli)) {
+    logger.warn('Agency CLI not found, skipping MCP configuration');
+    return;
+  }
+
+  try {
+    let claudeJson: Record<string, unknown> = {};
+    if (existsSync(claudeJsonPath)) {
+      claudeJson = JSON.parse(readFileSync(claudeJsonPath, 'utf-8')) as Record<string, unknown>;
+    }
+
+    const mcpServers = (claudeJson['mcpServers'] ?? {}) as Record<string, unknown>;
+    mcpServers['agency'] = {
+      type: 'stdio',
+      command: 'node',
+      args: [agencyCli],
+      cwd: config.agencyDir,
+    };
+    claudeJson['mcpServers'] = mcpServers;
+
+    writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
+    logger.info('Configured Agency MCP server in user-level Claude config');
+  } catch (error) {
+    logger.warn({ error: String(error) }, 'Failed to configure Agency MCP server');
+  }
+
+  logger.info('Phase 4 complete: Claude Code integration installed');
+}
+
+/**
  * Create the `setup build` subcommand.
  */
 export function setupBuildCommand(): Command {
@@ -272,6 +340,13 @@ export function setupBuildCommand(): Command {
         buildGeneracy(config);
       } else {
         logger.info('Skipping Phase 3: Generacy build (--skip-generacy)');
+      }
+
+      // Phase 4: Install Claude Code integration (speckit commands + Agency MCP)
+      if (!config.skipAgency) {
+        installClaudeCodeIntegration(config);
+      } else {
+        logger.info('Skipping Phase 4: Claude Code integration (--skip-agency)');
       }
 
       logger.info('Build process complete');

--- a/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
@@ -300,7 +300,7 @@ describe('ClaudeCliWorker (integration)', () => {
       // First CLI spawn should be for 'plan' (GATE_MAPPING: clarification → resumeFrom: plan)
       const firstSpawnArgs = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
       const promptArg = firstSpawnArgs[firstSpawnArgs.length - 1]!;
-      expect(promptArg).toContain('/speckit:plan');
+      expect(promptArg).toContain('/plan');
     });
   });
 
@@ -974,10 +974,10 @@ describe('ClaudeCliWorker (integration)', () => {
         const args = call[1] as string[];
         return args[args.length - 1] ?? null;
       });
-      expect(prompts[0]).toContain('/speckit:specify');
-      expect(prompts[1]).toContain('/speckit:clarify');
-      expect(prompts[2]).toContain('/speckit:plan');
-      expect(prompts[3]).toContain('/speckit:tasks');
+      expect(prompts[0]).toContain('/specify');
+      expect(prompts[1]).toContain('/clarify');
+      expect(prompts[2]).toContain('/plan');
+      expect(prompts[3]).toContain('/tasks');
 
       // Verify workflow completed (not failed)
       const completedEvent = sseEvents.find(
@@ -1066,7 +1066,7 @@ describe('ClaudeCliWorker (integration)', () => {
       expect(spawnFn).toHaveBeenCalledTimes(2);
 
       const firstPrompt = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
-      expect(firstPrompt[firstPrompt.length - 1]).toContain('/speckit:plan');
+      expect(firstPrompt[firstPrompt.length - 1]).toContain('/plan');
     });
   });
 

--- a/packages/orchestrator/src/worker/types.ts
+++ b/packages/orchestrator/src/worker/types.ts
@@ -35,11 +35,11 @@ export function getPhaseSequence(workflowName: string): WorkflowPhase[] {
  * Map each phase to its Claude CLI slash command (null = no CLI command)
  */
 export const PHASE_TO_COMMAND: Record<WorkflowPhase, string | null> = {
-  specify: '/speckit:specify',
-  clarify: '/speckit:clarify',
-  plan: '/speckit:plan',
-  tasks: '/speckit:tasks',
-  implement: '/speckit:implement',
+  specify: '/specify',
+  clarify: '/clarify',
+  plan: '/plan',
+  tasks: '/tasks',
+  implement: '/implement',
   validate: null,
 };
 


### PR DESCRIPTION
## Summary

- **Root cause**: Worker Claude CLI sessions returned "Unknown skill: speckit:specify" because the speckit slash commands were never installed as Claude Code custom commands, and the Agency MCP server wasn't configured at user level
- **Fix PHASE_TO_COMMAND**: Update from `/speckit:specify` → `/specify` (user-level custom commands don't carry a namespace prefix)
- **Add Phase 4 to `generacy setup build`**: Copies speckit command `.md` files from `claude-plugin-agency-spec-kit/commands/` to `~/.claude/commands/` and configures Agency MCP server in `~/.claude.json`

## Test plan

- [x] All 1016 orchestrator tests pass (14 pre-existing pr-feedback-integration failures unchanged)
- [x] Both orchestrator and generacy CLI compile cleanly
- [x] Verified `/specify` command works from `/tmp` directory in worker container
- [ ] After merge: restart worker container, verify `generacy setup build` installs commands
- [ ] Retry cluster-templates#3 to verify full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)