### PR TITLE
fix: remove unsupported --json flag from gh pr create

### DIFF
--- a/packages/workflow-engine/src/actions/github/client/gh-cli.ts
+++ b/packages/workflow-engine/src/actions/github/client/gh-cli.ts
@@ -258,32 +258,31 @@ export class GhCliGitHubClient implements GitHubClient {
       args.push('--draft');
     }
 
-    // Add JSON output for details
-    args.push('--json', 'number,url,state,headRefName,baseRefName,isDraft,title,body,createdAt,updatedAt');
-
     const result = await executeCommand('gh', args, { cwd: this.workdir });
     if (result.exitCode !== 0) {
       throw new Error(`Failed to create PR: ${result.stderr}`);
     }
 
+    // gh pr create outputs the PR URL on stdout (--json is not supported)
+    const urlMatch = result.stdout.match(/https:\/\/github\.com\/[^\s]+\/pull\/(\d+)/);
+    if (urlMatch) {
+      return {
+        number: parseInt(urlMatch[1]!, 10),
+        title: data.title,
+        body: data.body ?? '',
+        state: 'open',
+        draft: data.draft ?? false,
+        head: { ref: data.head, sha: '', repo: `${owner}/${repo}` },
+        base: { ref: data.base, sha: '', repo: `${owner}/${repo}` },
+        labels: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+    }
+
+    // Fallback: try parsing as JSON in case future gh versions add support
     const parsed = parseJSONSafe(result.stdout) as Record<string, unknown> | null;
     if (!parsed) {
-      // Try to extract URL from output
-      const urlMatch = result.stdout.match(/https:\/\/github\.com\/[^\s]+\/pull\/(\d+)/);
-      if (urlMatch) {
-        return {
-          number: parseInt(urlMatch[1]!, 10),
-          title: data.title,
-          body: data.body ?? '',
-          state: data.draft ? 'open' : 'open',
-          draft: data.draft ?? false,
-          head: { ref: data.head, sha: '', repo: `${owner}/${repo}` },
-          base: { ref: data.base, sha: '', repo: `${owner}/${repo}` },
-          labels: [],
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        };
-      }
       throw new Error('Failed to parse PR creation response');
     }
 


### PR DESCRIPTION
## Summary

- `gh pr create` does not support `--json` (only `gh pr view` and `gh pr list` do)
- This caused every worker draft PR creation to fail with `unknown flag: --json`
- The code already had a fallback to parse the PR URL from stdout — promoted this to the primary path
- JSON parsing kept as a future-compatibility fallback

Closes #308

## Test plan

- [x] workflow-engine builds cleanly
- [x] All 653 workflow-engine tests pass
- [ ] After merge + restart: verify draft PR is created when worker processes an issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)