### PR TITLE
fix: suppress health check log noise in orchestrator

### DIFF
--- a/packages/orchestrator/src/middleware/request-logger.ts
+++ b/packages/orchestrator/src/middleware/request-logger.ts
@@ -5,6 +5,9 @@ import type { FastifyRequest, FastifyReply, HookHandlerDoneFunction } from 'fast
  */
 const REQUEST_START_TIME = Symbol('requestStartTime');
 
+/** Paths excluded from request logging (health probes, metrics) */
+const SILENT_PATHS = new Set(['/health', '/health/live', '/health/ready', '/metrics']);
+
 /**
  * Augment FastifyRequest with start time
  */
@@ -24,13 +27,15 @@ export function requestStartHook(
 ): void {
   request[REQUEST_START_TIME] = process.hrtime.bigint();
 
-  request.log.info({
-    correlationId: request.correlationId,
-    method: request.method,
-    url: request.url,
-    userAgent: request.headers['user-agent'],
-    ip: request.ip,
-  }, 'Request started');
+  if (!SILENT_PATHS.has(request.url)) {
+    request.log.info({
+      correlationId: request.correlationId,
+      method: request.method,
+      url: request.url,
+      userAgent: request.headers['user-agent'],
+      ip: request.ip,
+    }, 'Request started');
+  }
 
   done();
 }
@@ -60,7 +65,12 @@ export function requestEndHook(
     userId: request.auth?.userId,
   };
 
-  if (reply.statusCode >= 500) {
+  if (SILENT_PATHS.has(request.url)) {
+    // Only log health/metrics requests if they fail
+    if (reply.statusCode >= 500) {
+      request.log.error(logData, 'Health check failed');
+    }
+  } else if (reply.statusCode >= 500) {
     request.log.error(logData, 'Request completed with server error');
   } else if (reply.statusCode >= 400) {
     request.log.warn(logData, 'Request completed with client error');

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -71,6 +71,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
       level: config.logging.level,
       ...(typeof loggerConfig === 'object' ? loggerConfig : {}),
     },
+    disableRequestLogging: true, // Custom request-logger hooks handle this
     ...options.fastifyOptions,
   });
 


### PR DESCRIPTION
## Summary
- Health probes every 30s generated 4 log lines each (2 from Fastify built-in + 2 from custom hooks)
- Added `SILENT_PATHS` set to skip INFO logging for `/health`, `/health/live`, `/health/ready`, `/metrics`
- Health check failures (5xx) are still logged as errors
- Disabled Fastify's default `disableRequestLogging` since custom hooks already provide richer detail

## Test plan
- [ ] Rebuild containers and verify health check requests no longer appear in logs
- [ ] Verify non-health requests still log normally at INFO level
- [ ] Verify 5xx health check failures are still logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)