### PR TITLE
fix: add clarification gate to bugfix workflow and fix integration test parser

### DIFF
--- a/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
+++ b/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
@@ -186,8 +186,22 @@ describe('PR Feedback Integration Test: Webhook → Enqueue', () => {
       [{ owner: 'test-org', repo: 'test-repo' }],
     );
 
-    // Setup Fastify server with webhook routes
+    // Setup Fastify server with custom content type parser (preserves raw body
+    // for HMAC signature verification, matching production server.ts setup)
     server = Fastify({ logger: false });
+    server.removeContentTypeParser('application/json');
+    server.addContentTypeParser(
+      'application/json',
+      { parseAs: 'string' },
+      (_req, body, done) => {
+        try {
+          const json = JSON.parse(body as string);
+          done(null, { parsed: json, raw: body });
+        } catch (err) {
+          done(err as Error, undefined);
+        }
+      },
+    );
     await setupPrWebhookRoutes(server, {
       monitorService,
       webhookSecret: WEBHOOK_SECRET,
@@ -1172,8 +1186,22 @@ describe('PR Feedback Integration Test: Deduplication', () => {
       [{ owner: 'test-org', repo: 'test-repo' }],
     );
 
-    // Setup Fastify server with webhook routes
+    // Setup Fastify server with custom content type parser (preserves raw body
+    // for HMAC signature verification, matching production server.ts setup)
     server = Fastify({ logger: false });
+    server.removeContentTypeParser('application/json');
+    server.addContentTypeParser(
+      'application/json',
+      { parseAs: 'string' },
+      (_req, body, done) => {
+        try {
+          const json = JSON.parse(body as string);
+          done(null, { parsed: json, raw: body });
+        } catch (err) {
+          done(err as Error, undefined);
+        }
+      },
+    );
     await setupPrWebhookRoutes(server, {
       monitorService,
       webhookSecret: WEBHOOK_SECRET,

--- a/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
@@ -131,7 +131,13 @@ function createConfig(overrides: Partial<WorkerConfig> = {}): WorkerConfig {
           condition: 'always',
         },
       ],
-      'speckit-bugfix': [],
+      'speckit-bugfix': [
+        {
+          phase: 'clarify',
+          gateLabel: 'waiting-for:clarification',
+          condition: 'always',
+        },
+      ],
     },
     ...overrides,
   };
@@ -246,8 +252,8 @@ describe('ClaudeCliWorker (integration)', () => {
     });
   });
 
-  describe('speckit-bugfix workflow: no gates', () => {
-    it('runs all phases to completion including validate', async () => {
+  describe('speckit-bugfix workflow: gates at clarify', () => {
+    it('runs specify and clarify then hits clarification gate', async () => {
       mockGithub.getIssue.mockResolvedValue({ labels: [] });
       spawnFn.mockImplementation(() => createMockProcess(0, 5).handle);
 
@@ -259,25 +265,14 @@ describe('ClaudeCliWorker (integration)', () => {
 
       await worker.handle(createQueueItem({ workflowName: 'speckit-bugfix' }));
 
-      // Should have spawned CLI for specify, clarify, plan, tasks, implement
-      // and sh for validate = 6 total spawns
-      expect(spawnFn).toHaveBeenCalledTimes(6);
+      // Should have spawned CLI for specify and clarify only (gate hit after clarify)
+      expect(spawnFn).toHaveBeenCalledTimes(2);
 
-      // Validate phase spawns 'sh -c' instead of 'claude'
-      const lastSpawnCall = spawnFn.mock.calls[5] as [string, string[], unknown];
-      expect(lastSpawnCall[0]).toBe('sh');
-      expect(lastSpawnCall[1]).toEqual(['-c', 'pnpm test && pnpm build']);
-
-      // Workflow should be complete — agent:in-progress removed
-      expect(mockGithub.removeLabels).toHaveBeenCalledWith(
-        'test-owner', 'test-repo', 42, ['agent:in-progress'],
+      // waiting-for:clarification label should be added
+      expect(mockGithub.addLabels).toHaveBeenCalledWith(
+        'test-owner', 'test-repo', 42,
+        expect.arrayContaining(['waiting-for:clarification']),
       );
-
-      // SSE events should include workflow:completed
-      const completedEvent = sseEvents.find(
-        (e: unknown) => (e as { type: string }).type === 'workflow:completed',
-      );
-      expect(completedEvent).toBeDefined();
     });
   });
 

--- a/packages/orchestrator/src/worker/__tests__/gate-checker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/gate-checker.test.ts
@@ -28,7 +28,9 @@ describe('GateChecker', () => {
     'speckit-feature': [
       { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },
     ],
-    'speckit-bugfix': [],
+    'speckit-bugfix': [
+      { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },
+    ],
   };
 
   it('returns gate definition for speckit-feature workflow, clarify phase (condition: always)', () => {
@@ -49,11 +51,15 @@ describe('GateChecker', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null for speckit-bugfix workflow, clarify phase (empty gates)', () => {
+  it('returns gate definition for speckit-bugfix workflow, clarify phase (condition: always)', () => {
     const config = makeConfig(defaultGates);
     const result = checker.checkGate('clarify', 'speckit-bugfix', config);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      phase: 'clarify',
+      gateLabel: 'waiting-for:clarification',
+      condition: 'always',
+    });
   });
 
   it('returns null for unknown workflow name', () => {

--- a/packages/orchestrator/src/worker/config.ts
+++ b/packages/orchestrator/src/worker/config.ts
@@ -30,7 +30,9 @@ export const WorkerConfigSchema = z.object({
     'speckit-feature': [
       { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },
     ],
-    'speckit-bugfix': [],
+    'speckit-bugfix': [
+      { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },
+    ],
     'speckit-epic': [
       { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },
       { phase: 'tasks', gateLabel: 'waiting-for:tasks-review', condition: 'always' },


### PR DESCRIPTION
## Summary

- **Bugfix workflow missing clarification gate**: The `speckit-bugfix` workflow had an empty gates array in `config.ts`, so the orchestrator never paused at the clarification phase. This caused #316 to proceed through plan → tasks → implement without waiting for answers to the clarification questions. Added the same `waiting-for:clarification` gate that `speckit-feature` and `speckit-epic` already have.

- **Pre-existing integration test failures**: Fixed 14 failing tests in `pr-feedback-integration.test.ts` caused by a missing custom `application/json` content type parser. The webhook route expects `{ parsed, raw }` body format for HMAC signature verification, but the integration test wasn't registering the parser (unlike `pr-webhooks.test.ts` and `server.ts` which both had it).

## Test plan

- [x] All 1030 orchestrator tests pass (0 failures, up from 14 pre-existing failures)
- [x] `gate-checker.test.ts` — bugfix now returns gate definition instead of null
- [x] `claude-cli-worker.test.ts` — bugfix workflow gates after clarify (2 spawns, not 6)
- [x] `pr-feedback-integration.test.ts` — all 35 tests pass with content type parser fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)