### PR TITLE
fix: validate implement phase produces file changes before marking complete

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
@@ -130,11 +130,21 @@ function createConfig(overrides: Partial<WorkerConfig> = {}): WorkerConfig {
           gateLabel: 'waiting-for:clarification',
           condition: 'always',
         },
+        {
+          phase: 'implement',
+          gateLabel: 'waiting-for:implementation-review',
+          condition: 'always',
+        },
       ],
       'speckit-bugfix': [
         {
           phase: 'clarify',
           gateLabel: 'waiting-for:clarification',
+          condition: 'always',
+        },
+        {
+          phase: 'implement',
+          gateLabel: 'waiting-for:implementation-review',
           condition: 'always',
         },
       ],
@@ -174,8 +184,10 @@ describe('ClaudeCliWorker (integration)', () => {
     mockGithub.getIssueComments.mockResolvedValue([]);
     mockGithub.addIssueComment.mockResolvedValue({ id: 1, body: '' });
     mockGithub.updateComment.mockResolvedValue(undefined);
-    // PrManager git mocks
-    mockGithub.getStatus.mockResolvedValue({ branch: 'feature/42', has_changes: false, staged: [], unstaged: [], untracked: [] });
+    // PrManager git mocks — default to has_changes: true so implement phase
+    // passes the "must produce changes" check. Tests that need has_changes: false
+    // should override this mock.
+    mockGithub.getStatus.mockResolvedValue({ branch: 'feature/42', has_changes: true, staged: [], unstaged: [], untracked: [] });
     mockGithub.stageAll.mockResolvedValue(undefined);
     mockGithub.commit.mockResolvedValue({ sha: 'abc123', files_committed: [] });
     mockGithub.push.mockResolvedValue({ success: true, ref: 'refs/heads/feature/42', remote: 'origin' });

--- a/packages/orchestrator/src/worker/config.ts
+++ b/packages/orchestrator/src/worker/config.ts
@@ -29,9 +29,11 @@ export const WorkerConfigSchema = z.object({
   gates: z.record(z.string(), z.array(GateDefinitionSchema)).default({
     'speckit-feature': [
       { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },
+      { phase: 'implement', gateLabel: 'waiting-for:implementation-review', condition: 'always' },
     ],
     'speckit-bugfix': [
       { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },
+      { phase: 'implement', gateLabel: 'waiting-for:implementation-review', condition: 'always' },
     ],
     'speckit-epic': [
       { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'always' },

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -8,6 +8,9 @@ import type { CliSpawner } from './cli-spawner.js';
 import type { OutputCapture } from './output-capture.js';
 import type { PrManager } from './pr-manager.js';
 
+/** Phases that MUST produce file changes to be considered successful. */
+const PHASES_REQUIRING_CHANGES: ReadonlySet<WorkflowPhase> = new Set(['implement']);
+
 /**
  * Dependencies injected into the PhaseLoop.
  */
@@ -86,6 +89,9 @@ export class PhaseLoop {
       'Starting phase loop',
     );
 
+    // Track actual timestamps per phase
+    const phaseTimestamps = new Map<WorkflowPhase, { startedAt: string; completedAt?: string }>();
+
     for (let i = startIndex; i < sequence.length; i++) {
       const phase = sequence[i]!;
 
@@ -97,6 +103,9 @@ export class PhaseLoop {
 
       this.logger.info({ phase, index: i }, 'Starting phase');
 
+      // Record phase start time
+      phaseTimestamps.set(phase, { startedAt: new Date().toISOString() });
+
       // 1. Update labels: mark this phase as active
       await labelManager.onPhaseStart(phase);
 
@@ -105,8 +114,8 @@ export class PhaseLoop {
       await stageCommentManager.updateStageComment({
         stage,
         status: 'in_progress',
-        phases: this.buildPhaseProgress(sequence, startIndex, i),
-        startedAt: new Date().toISOString(),
+        phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps),
+        startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
       });
 
       // 3. Execute the phase
@@ -144,8 +153,8 @@ export class PhaseLoop {
         await stageCommentManager.updateStageComment({
           stage,
           status: 'error',
-          phases: this.buildPhaseProgress(sequence, startIndex, i, 'error'),
-          startedAt: new Date().toISOString(),
+          phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'error'),
+          startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
         });
         throw error;
       }
@@ -170,20 +179,43 @@ export class PhaseLoop {
         await stageCommentManager.updateStageComment({
           stage,
           status: 'error',
-          phases: this.buildPhaseProgress(sequence, startIndex, i, 'error'),
-          startedAt: new Date().toISOString(),
+          phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'error'),
+          startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
         });
         return { results, completed: false, lastPhase: phase, gateHit: false };
       }
 
-      // 5. Mark phase as completed in labels
-      await labelManager.onPhaseComplete(phase);
-
-      // 5b. Commit, push, and ensure draft PR exists
-      const prUrl = await prManager.commitPushAndEnsurePr(phase);
+      // 5. Commit, push, and ensure draft PR exists (before marking complete)
+      const { prUrl, hasChanges } = await prManager.commitPushAndEnsurePr(phase);
       if (prUrl) {
         context.prUrl = prUrl;
       }
+
+      // 5b. Fail phases that require file changes but produced none
+      if (PHASES_REQUIRING_CHANGES.has(phase) && !hasChanges) {
+        this.logger.error(
+          { phase },
+          'Phase completed with exit code 0 but produced no file changes',
+        );
+        await labelManager.onError(phase);
+        await stageCommentManager.updateStageComment({
+          stage,
+          status: 'error',
+          phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'error'),
+          startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
+          prUrl: context.prUrl,
+        });
+        result.success = false;
+        result.error = {
+          message: `Phase "${phase}" succeeded but produced no file changes — expected code to be written`,
+          stderr: '',
+          phase,
+        };
+        return { results, completed: false, lastPhase: phase, gateHit: false };
+      }
+
+      // 5c. Mark phase as completed in labels
+      await labelManager.onPhaseComplete(phase);
 
       // 6. Check for review gates
       const gate = gateChecker.checkGate(phase, context.item.workflowName, config);
@@ -200,27 +232,35 @@ export class PhaseLoop {
           reason: `Review gate "${gate.gateLabel}" activated after phase "${phase}"`,
         };
 
+        // Record completion time before gate pause
+        const ts = phaseTimestamps.get(phase);
+        if (ts) ts.completedAt = new Date().toISOString();
+
         // Update stage comment showing gate hit
         await stageCommentManager.updateStageComment({
           stage,
           status: 'in_progress',
-          phases: this.buildPhaseProgress(sequence, startIndex, i, 'complete'),
-          startedAt: new Date().toISOString(),
+          phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'complete'),
+          startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
           prUrl: context.prUrl,
         });
 
         return { results, completed: false, lastPhase: phase, gateHit: true };
       }
 
-      // 7. Update stage comment showing phase complete
+      // 7. Record phase completion time
+      const phaseTs = phaseTimestamps.get(phase);
+      if (phaseTs) phaseTs.completedAt = new Date().toISOString();
+
+      // 8. Update stage comment showing phase complete
       const isLastPhaseInStage =
         i + 1 >= sequence.length || PHASE_TO_STAGE[sequence[i + 1]!] !== stage;
 
       await stageCommentManager.updateStageComment({
         stage,
         status: isLastPhaseInStage ? 'complete' : 'in_progress',
-        phases: this.buildPhaseProgress(sequence, startIndex, i, 'complete'),
-        startedAt: new Date().toISOString(),
+        phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'complete'),
+        startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
         ...(isLastPhaseInStage ? { completedAt: new Date().toISOString() } : {}),
         prUrl: context.prUrl,
       });
@@ -240,26 +280,30 @@ export class PhaseLoop {
 
   /**
    * Build a phase progress array for stage comment updates.
+   *
+   * Uses actual tracked timestamps per phase rather than a single synthetic timestamp.
    */
   private buildPhaseProgress(
     sequence: WorkflowPhase[],
     startIndex: number,
     currentIndex: number,
+    phaseTimestamps: Map<WorkflowPhase, { startedAt: string; completedAt?: string }>,
     currentStatus: 'in_progress' | 'complete' | 'error' = 'in_progress',
   ): { phase: WorkflowPhase; status: 'pending' | 'in_progress' | 'complete' | 'error'; startedAt?: string; completedAt?: string }[] {
-    const now = new Date().toISOString();
     return sequence.map((phase, idx) => {
+      const ts = phaseTimestamps.get(phase);
+
       if (idx < startIndex) {
-        // Before the start — already complete from a prior run
-        return { phase, status: 'complete' as const, completedAt: now };
+        // Before the start — already complete from a prior run (no tracked timestamp)
+        return { phase, status: 'complete' as const };
       }
       if (idx < currentIndex) {
         // Earlier in this run — completed
-        return { phase, status: 'complete' as const, startedAt: now, completedAt: now };
+        return { phase, status: 'complete' as const, startedAt: ts?.startedAt, completedAt: ts?.completedAt };
       }
       if (idx === currentIndex) {
         // Current phase
-        return { phase, status: currentStatus, startedAt: now };
+        return { phase, status: currentStatus, startedAt: ts?.startedAt, ...(currentStatus === 'complete' || currentStatus === 'error' ? { completedAt: ts?.completedAt } : {}) };
       }
       // Future phase
       return { phase, status: 'pending' as const };

--- a/packages/orchestrator/src/worker/pr-manager.ts
+++ b/packages/orchestrator/src/worker/pr-manager.ts
@@ -36,25 +36,28 @@ export class PrManager {
    * Safe to call after every phase — handles "nothing to commit" and
    * "PR already exists" gracefully.
    *
-   * @returns The PR URL if one exists/was created, undefined otherwise.
+   * @returns An object with the PR URL (if available) and whether changes were committed.
    */
-  async commitPushAndEnsurePr(phase: WorkflowPhase): Promise<string | undefined> {
-    await this.commitAndPush(phase);
-    return this.ensureDraftPr();
+  async commitPushAndEnsurePr(phase: WorkflowPhase): Promise<{ prUrl?: string; hasChanges: boolean }> {
+    const hasChanges = await this.commitAndPush(phase);
+    const prUrl = await this.ensureDraftPr();
+    return { prUrl, hasChanges };
   }
 
   /**
    * Commit all changed files and push to the remote.
    *
    * Handles "nothing to commit" gracefully by checking git status first.
+   *
+   * @returns true if changes were committed and pushed, false otherwise.
    */
-  private async commitAndPush(phase: WorkflowPhase): Promise<void> {
+  private async commitAndPush(phase: WorkflowPhase): Promise<boolean> {
     try {
       // Check if there are any changes to commit
       const status = await this.github.getStatus();
       if (!status.has_changes) {
         this.logger.debug({ phase }, 'No changes to commit after phase');
-        return;
+        return false;
       }
 
       // Stage all changes
@@ -75,12 +78,15 @@ export class PrManager {
         { phase, ref: pushResult.ref, remote: pushResult.remote },
         'Pushed phase changes to remote',
       );
+
+      return true;
     } catch (error) {
       // Log but don't fail the workflow — commit/push is best-effort between phases
       this.logger.warn(
         { phase, error: String(error) },
         'Failed to commit/push after phase (non-fatal)',
       );
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a bug where the orchestrator's implement phase could complete successfully without producing any code changes. This was observed in #316 where all workflow phases were marked complete with identical timestamps but zero source code was committed.

**Root causes addressed:**
- **Phase success was decoupled from semantic validation** — only exit code was checked, not whether actual work was produced
- **Phase marked complete before commit** — `labelManager.onPhaseComplete()` ran before `prManager.commitPushAndEnsurePr()`, so even if no commit happened, the phase was already labeled complete
- **Fake timestamps** — `buildPhaseProgress` generated a single `new Date()` for all phases, making instant completion look legitimate
- **No gates protecting implement** — nothing stopped the workflow from blowing through implement and validate instantly

**Changes:**
- Implement phase now **fails if it produces no file changes** (controlled via `PHASES_REQUIRING_CHANGES` set)
- **Commit happens before marking complete** — reordered so labels reflect actual state
- **Per-phase timestamp tracking** — `buildPhaseProgress` uses a `Map<WorkflowPhase, { startedAt, completedAt }>` instead of a single synthetic timestamp
- **`waiting-for:implementation-review` gate** added to `speckit-feature` and `speckit-bugfix` workflows
- `PrManager.commitPushAndEnsurePr` returns `{ prUrl, hasChanges }` so callers can check if changes were committed

## Test plan

- [x] All 1030 existing tests pass
- [x] TypeScript build passes
- [ ] Deploy to staging and trigger a speckit-feature workflow — verify implement phase fails if Claude CLI produces no changes
- [ ] Verify implement gate pauses workflow with `waiting-for:implementation-review` label
- [ ] Verify stage comment timestamps show distinct per-phase times

🤖 Generated with [Claude Code](https://claude.com/claude-code)