### PR TITLE
fix: skip review gates when already satisfied by completed label

### DIFF
--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -220,32 +220,47 @@ export class PhaseLoop {
       // 6. Check for review gates
       const gate = gateChecker.checkGate(phase, context.item.workflowName, config);
       if (gate && gate.condition === 'always') {
-        this.logger.info(
-          { phase, gateLabel: gate.gateLabel },
-          'Gate hit, pausing workflow',
-        );
-        await labelManager.onGateHit(phase, gate.gateLabel);
+        // Check if this gate is already satisfied (e.g., completed:clarification
+        // was added before the workflow reached this point). The completed label
+        // corresponds to the gate label suffix: waiting-for:X → completed:X.
+        const gateSuffix = gate.gateLabel.replace(/^waiting-for:/, '');
+        const completedLabel = `completed:${gateSuffix}`;
+        const currentIssue = await context.github.getIssue(context.item.owner, context.item.repo, context.item.issueNumber);
+        const currentLabels = currentIssue.labels.map((l) => typeof l === 'string' ? l : l.name);
 
-        // Update the result with gate info
-        result.gateHit = {
-          gateLabel: gate.gateLabel,
-          reason: `Review gate "${gate.gateLabel}" activated after phase "${phase}"`,
-        };
+        if (currentLabels.includes(completedLabel)) {
+          this.logger.info(
+            { phase, gateLabel: gate.gateLabel, completedLabel },
+            'Gate already satisfied — skipping pause',
+          );
+        } else {
+          this.logger.info(
+            { phase, gateLabel: gate.gateLabel },
+            'Gate hit, pausing workflow',
+          );
+          await labelManager.onGateHit(phase, gate.gateLabel);
 
-        // Record completion time before gate pause
-        const ts = phaseTimestamps.get(phase);
-        if (ts) ts.completedAt = new Date().toISOString();
+          // Update the result with gate info
+          result.gateHit = {
+            gateLabel: gate.gateLabel,
+            reason: `Review gate "${gate.gateLabel}" activated after phase "${phase}"`,
+          };
 
-        // Update stage comment showing gate hit
-        await stageCommentManager.updateStageComment({
-          stage,
-          status: 'in_progress',
-          phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'complete'),
-          startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
-          prUrl: context.prUrl,
-        });
+          // Record completion time before gate pause
+          const ts = phaseTimestamps.get(phase);
+          if (ts) ts.completedAt = new Date().toISOString();
 
-        return { results, completed: false, lastPhase: phase, gateHit: true };
+          // Update stage comment showing gate hit
+          await stageCommentManager.updateStageComment({
+            stage,
+            status: 'in_progress',
+            phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'complete'),
+            startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
+            prUrl: context.prUrl,
+          });
+
+          return { results, completed: false, lastPhase: phase, gateHit: true };
+        }
       }
 
       // 7. Record phase completion time


### PR DESCRIPTION
## Summary

- Fixes a race condition where the orchestrator pauses at a review gate even when the corresponding `completed:` label is already present on the issue
- Before pausing at a gate, the phase loop now fetches current issue labels and checks for `completed:{gateSuffix}` — if found, the gate is skipped and the workflow continues
- Example: `waiting-for:clarification` gate is skipped if `completed:clarification` already exists

This was discovered while processing #316 — clarification answers were posted and `completed:clarification` was added before the orchestrator reached the clarify gate, causing the workflow to get stuck with both `agent:in-progress` and `agent:paused` labels.

## Test plan

- [x] All 1030 existing tests pass
- [x] TypeScript build passes
- [ ] Requeue #316 after merge — verify the clarify gate is skipped when `completed:clarification` is present
- [ ] Verify normal gate behavior still works (gate pauses when no `completed:` label exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)