### PR TITLE
fix: detect phase-committed changes in implement phase validation (#323)

### DIFF
--- a/packages/orchestrator/src/worker/pr-manager.test.ts
+++ b/packages/orchestrator/src/worker/pr-manager.test.ts
@@ -33,6 +33,7 @@ function createMockGitHubClient(
     getDefaultBranch: vi.fn().mockResolvedValue('main'),
     createPullRequest: vi.fn().mockResolvedValue({ number: 42, url: 'https://github.com/test/repo/pull/42' }),
     markPRReady: vi.fn().mockResolvedValue(undefined),
+    getCommitsBetween: vi.fn().mockResolvedValue([]),
 
     // Other GitHubClient methods (not used by PrManager but required by interface)
     clone: vi.fn().mockResolvedValue(undefined),
@@ -398,6 +399,61 @@ describe('PrManager', () => {
       expect(urlBeforeReady).toBe(expectedUrl);
       expect(urlAfterReady).toBe(expectedUrl);
       expect(urlBeforeReady).toBe(urlAfterReady);
+    });
+  });
+
+  describe('commitPushAndEnsurePr() - change detection', () => {
+    it('should detect changes when phase committed directly (no uncommitted changes)', async () => {
+      // No uncommitted changes, but phase made its own commit
+      github.getStatus = vi.fn().mockResolvedValue({ has_changes: false });
+      github.getCommitsBetween = vi.fn().mockResolvedValue([
+        { sha: 'abc123', message: 'feat: implement feature' },
+      ]);
+
+      const result = await prManager.commitPushAndEnsurePr('implement');
+
+      expect(result.hasChanges).toBe(true);
+      expect(github.stageAll).not.toHaveBeenCalled();
+      expect(github.commit).not.toHaveBeenCalled();
+      expect(github.push).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: 'implement', unpushedCount: 1 }),
+        'Phase committed its own changes — pushing to remote',
+      );
+    });
+
+    it('should return false when no uncommitted changes and no unpushed commits', async () => {
+      github.getStatus = vi.fn().mockResolvedValue({ has_changes: false });
+      github.getCommitsBetween = vi.fn().mockResolvedValue([]);
+
+      const result = await prManager.commitPushAndEnsurePr('implement');
+
+      expect(result.hasChanges).toBe(false);
+      expect(github.push).not.toHaveBeenCalled();
+    });
+
+    it('should commit and push when there are uncommitted changes', async () => {
+      github.getStatus = vi.fn().mockResolvedValue({ has_changes: true });
+      github.getCommitsBetween = vi.fn().mockResolvedValue([
+        { sha: 'new123', message: 'chore(speckit): complete implement phase' },
+      ]);
+
+      const result = await prManager.commitPushAndEnsurePr('implement');
+
+      expect(result.hasChanges).toBe(true);
+      expect(github.stageAll).toHaveBeenCalled();
+      expect(github.commit).toHaveBeenCalled();
+      expect(github.push).toHaveBeenCalled();
+    });
+
+    it('should handle getCommitsBetween failure gracefully (treat as no unpushed)', async () => {
+      github.getStatus = vi.fn().mockResolvedValue({ has_changes: false });
+      github.getCommitsBetween = vi.fn().mockRejectedValue(new Error('no upstream'));
+
+      const result = await prManager.commitPushAndEnsurePr('implement');
+
+      // getCommitsBetween failure caught, treated as no unpushed commits
+      expect(result.hasChanges).toBe(false);
     });
   });
 

--- a/packages/orchestrator/src/worker/pr-manager.ts
+++ b/packages/orchestrator/src/worker/pr-manager.ts
@@ -36,7 +36,8 @@ export class PrManager {
    * Safe to call after every phase — handles "nothing to commit" and
    * "PR already exists" gracefully.
    *
-   * @returns An object with the PR URL (if available) and whether changes were committed.
+   * @returns An object with the PR URL (if available) and whether changes were produced
+   * (either uncommitted changes we commit, or commits the phase made directly).
    */
   async commitPushAndEnsurePr(phase: WorkflowPhase): Promise<{ prUrl?: string; hasChanges: boolean }> {
     const hasChanges = await this.commitAndPush(phase);
@@ -45,39 +46,57 @@ export class PrManager {
   }
 
   /**
-   * Commit all changed files and push to the remote.
+   * Commit any uncommitted changes and push to the remote.
    *
-   * Handles "nothing to commit" gracefully by checking git status first.
+   * Handles both cases: uncommitted changes (we commit them) and changes the
+   * phase already committed directly (detected via unpushed commits).
    *
-   * @returns true if changes were committed and pushed, false otherwise.
+   * @returns true if changes were produced (committed or already committed), false otherwise.
    */
   private async commitAndPush(phase: WorkflowPhase): Promise<boolean> {
     try {
-      // Check if there are any changes to commit
+      let committed = false;
+
+      // Check if there are any uncommitted changes to commit
       const status = await this.github.getStatus();
-      if (!status.has_changes) {
-        this.logger.debug({ phase }, 'No changes to commit after phase');
+      if (status.has_changes) {
+        // Stage all changes
+        await this.github.stageAll();
+
+        // Commit with a phase-specific message
+        const message = `chore(speckit): complete ${phase} phase for #${this.issueNumber}`;
+        const commitResult = await this.github.commit(message);
+        this.logger.info(
+          { phase, sha: commitResult.sha, files: commitResult.files_committed.length },
+          'Committed phase changes',
+        );
+        committed = true;
+      }
+
+      // Check for unpushed commits (the phase may have committed directly)
+      const branch = await this.github.getCurrentBranch();
+      const unpushed = await this.github.getCommitsBetween(`origin/${branch}`, branch).catch(() => []);
+      const hasUnpushed = unpushed.length > 0;
+
+      if (!committed && !hasUnpushed) {
+        this.logger.debug({ phase }, 'No changes to commit or push after phase');
         return false;
       }
 
-      // Stage all changes
-      await this.github.stageAll();
-
-      // Commit with a phase-specific message
-      const message = `chore(speckit): complete ${phase} phase for #${this.issueNumber}`;
-      const commitResult = await this.github.commit(message);
-      this.logger.info(
-        { phase, sha: commitResult.sha, files: commitResult.files_committed.length },
-        'Committed phase changes',
-      );
-
-      // Push to remote (set upstream on first push)
-      const branch = await this.github.getCurrentBranch();
-      const pushResult = await this.github.push('origin', branch, true);
-      this.logger.info(
-        { phase, ref: pushResult.ref, remote: pushResult.remote },
-        'Pushed phase changes to remote',
-      );
+      if (hasUnpushed) {
+        if (!committed) {
+          this.logger.info(
+            { phase, unpushedCount: unpushed.length },
+            'Phase committed its own changes — pushing to remote',
+          );
+        }
+        // Push to remote (set upstream on first push)
+        const pushResult = await this.github.push('origin', branch, true);
+        this.logger.info(
+          { phase, ref: pushResult.ref, remote: pushResult.remote },
+          'Pushed phase changes to remote',
+        );
+      }
 
       return true;
     } catch (error) {


### PR DESCRIPTION
## Summary

- The `/implement` skill commits its own changes directly via `git commit`, so when the orchestrator checks `git status` afterward, it sees a clean working tree and falsely reports "no file changes produced"
- Now `PrManager.commitAndPush()` also checks for unpushed commits via `getCommitsBetween(origin/branch, branch)` to detect changes the phase committed directly
- Added 4 test cases covering: phase-committed detection, no-changes, both uncommitted+committed, and `getCommitsBetween` failure fallback

Closes #323

## Test plan

- [x] All 23 PrManager tests pass (including 4 new ones)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Re-run #316 processing after rebuild to verify implement phase succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)