### PR TITLE
fix: coerce null repos.dev/clone to empty arrays in template config

### DIFF
--- a/packages/config/src/__tests__/template-schema.test.ts
+++ b/packages/config/src/__tests__/template-schema.test.ts
@@ -70,6 +70,20 @@ describe('TemplateConfigSchema', () => {
     ).toThrow();
   });
 
+  it('coerces null dev to empty array', () => {
+    const result = TemplateConfigSchema.parse({
+      repos: { primary: 'generacy', dev: null },
+    });
+    expect(result.repos.dev).toEqual([]);
+  });
+
+  it('coerces null clone to empty array', () => {
+    const result = TemplateConfigSchema.parse({
+      repos: { primary: 'generacy', clone: null },
+    });
+    expect(result.repos.clone).toEqual([]);
+  });
+
   it('rejects repos.dev with empty string', () => {
     expect(() =>
       TemplateConfigSchema.parse({ repos: { primary: 'generacy', dev: [''] } }),

--- a/packages/config/src/template-schema.ts
+++ b/packages/config/src/template-schema.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const TemplateReposSchema = z.object({
   primary: z.string().min(1),
-  dev: z.array(z.string().min(1)).optional().default([]),
-  clone: z.array(z.string().min(1)).optional().default([]),
+  dev: z.array(z.string().min(1)).nullable().transform((v) => v ?? []).optional().default([]),
+  clone: z.array(z.string().min(1)).nullable().transform((v) => v ?? []).optional().default([]),
 });
 
 export const TemplateConfigSchema = z.object({


### PR DESCRIPTION
## Summary
- YAML parses `dev:` and `clone:` with no value as `null`, not `undefined`. The Zod schema used `.optional().default([])` which only handles `undefined`, causing a validation error when loading external project configs with empty dev/clone sections.
- Adds `.nullable().transform(v => v ?? [])` to coerce `null` to `[]` in `TemplateReposSchema`
- Adds tests for the null coercion case

## Context
Follow-up to #334. The schema fix landed in #337 but didn't account for YAML null semantics. External project configs like:

```yaml
repos:
  primary: christrudelpw/markdown-preview-tool
  dev:
  clone:
```

...caused the orchestrator to crash with: `Expected array, received null` at `repos.dev` and `repos.clone`.

## Test plan
- [x] Existing template schema tests pass (12/12)
- [x] All config package tests pass (123/123)
- [x] TypeScript compilation clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)