### PR TITLE
fix: resolve globally installed agency CLI for MCP config

### DIFF
--- a/packages/generacy/src/cli/commands/setup/build.ts
+++ b/packages/generacy/src/cli/commands/setup/build.ts
@@ -374,10 +374,13 @@ function installClaudeCodeIntegration(config: BuildConfig): void {
     agencyCwd = config.agencyDir;
   } else {
     // Find globally installed @generacy-ai/agency package
-    const globalCli = execSafe('node -e "console.log(require.resolve(\'@generacy-ai/agency/dist/cli.js\'))"');
-    if (globalCli.ok && globalCli.stdout && existsSync(globalCli.stdout)) {
-      agencyCli = globalCli.stdout;
-      logger.info({ path: agencyCli }, 'Using globally installed agency CLI');
+    const globalRoot = execSafe('npm root -g');
+    if (globalRoot.ok && globalRoot.stdout) {
+      const globalCliPath = join(globalRoot.stdout.trim(), '@generacy-ai', 'agency', 'dist', 'cli.js');
+      if (existsSync(globalCliPath)) {
+        agencyCli = globalCliPath;
+        logger.info({ path: agencyCli }, 'Using globally installed agency CLI');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes MCP config setup for external projects where agency is installed globally via npm
- `require.resolve()` doesn't search global `node_modules`, so the fallback always failed silently
- Now uses `npm root -g` to locate the global install path and constructs the CLI path from there

## Context
Follow-up to #340. The MCP config fallback was added but didn't work because `require.resolve` only searches the local `node_modules` tree, not global packages installed with `npm install -g`.

## Test plan
- [ ] External project container: `~/.claude.json` contains agency MCP server entry
- [ ] Agency MCP server path points to global npm install location

🤖 Generated with [Claude Code](https://claude.com/claude-code)