### PR TITLE
fix: worker should reuse bootstrapped repos instead of cloning into /tmp

### DIFF
--- a/packages/orchestrator/src/config/loader.ts
+++ b/packages/orchestrator/src/config/loader.ts
@@ -192,6 +192,15 @@ function loadFromEnv(): Record<string, unknown> {
     );
   }
 
+  // Worker config
+  const workerWorkspaceDir = process.env['WORKER_WORKSPACE_DIR'] ?? process.env[`${ENV_PREFIX}WORKER_WORKSPACE_DIR`];
+  if (workerWorkspaceDir) {
+    if (!config.worker) {
+      config.worker = {};
+    }
+    (config.worker as Record<string, unknown>).workspaceDir = workerWorkspaceDir;
+  }
+
   // Smee config (SMEE_CHANNEL_URL takes precedence, falls back to ORCHESTRATOR_SMEE_CHANNEL_URL)
   const smeeChannelUrl = process.env['SMEE_CHANNEL_URL'] ?? process.env[`${ENV_PREFIX}SMEE_CHANNEL_URL`];
   if (smeeChannelUrl) {

--- a/packages/orchestrator/src/worker/__tests__/repo-checkout.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/repo-checkout.test.ts
@@ -115,9 +115,16 @@ describe('RepoCheckout', () => {
   // getCheckoutPath
   // -------------------------------------------------------------------------
   describe('getCheckoutPath()', () => {
-    it('returns the correct path for worker/owner/repo', () => {
-      const path = checkout.getCheckoutPath('worker-1', 'octocat', 'hello-world');
+    it('returns isolated path when no bootstrapped repo exists', async () => {
+      mockStat.mockRejectedValue(enoentError());
+      const path = await checkout.getCheckoutPath('worker-1', 'octocat', 'hello-world');
       expect(path).toBe('/workspace/worker-1/octocat/hello-world');
+    });
+
+    it('returns bootstrapped path when repo .git exists at {workspaceDir}/{repo}', async () => {
+      mockStat.mockResolvedValue({ isDirectory: () => true });
+      const path = await checkout.getCheckoutPath('worker-1', 'octocat', 'hello-world');
+      expect(path).toBe('/workspace/hello-world');
     });
   });
 
@@ -126,8 +133,11 @@ describe('RepoCheckout', () => {
   // -------------------------------------------------------------------------
   describe('ensureCheckout() with existing directory', () => {
     beforeEach(() => {
-      // Directory exists
-      mockStat.mockResolvedValue({ isDirectory: () => true });
+      // First stat: bootstrapped .git check → not found (fall back to isolated path)
+      // Second stat: isolated checkout path → exists
+      mockStat
+        .mockRejectedValueOnce(enoentError())   // getCheckoutPath: no bootstrapped repo
+        .mockResolvedValue({ isDirectory: () => true }); // ensureCheckout: dir exists
     });
 
     it('calls fetch origin', async () => {
@@ -205,7 +215,7 @@ describe('RepoCheckout', () => {
   // -------------------------------------------------------------------------
   describe('ensureCheckout() with non-existing directory', () => {
     beforeEach(() => {
-      // Directory does not exist
+      // Both stat calls fail: no bootstrapped repo, no isolated checkout
       mockStat.mockRejectedValue(enoentError());
     });
 
@@ -260,13 +270,51 @@ describe('RepoCheckout', () => {
   });
 
   // -------------------------------------------------------------------------
+  // ensureCheckout — bootstrapped repo (container-per-worker mode)
+  // -------------------------------------------------------------------------
+  describe('ensureCheckout() with bootstrapped repo', () => {
+    beforeEach(() => {
+      // Bootstrapped .git exists → use /workspace/repo directly
+      mockStat.mockResolvedValue({ isDirectory: () => true });
+    });
+
+    it('uses bootstrapped path instead of isolated path', async () => {
+      const path = await checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop');
+      expect(path).toBe('/workspace/repo');
+    });
+
+    it('fetches and resets in bootstrapped checkout', async () => {
+      await checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop');
+
+      const fetchCall = findCall('git', ['fetch', 'origin']);
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall![2]).toEqual({ cwd: '/workspace/repo' });
+
+      const resetCall = findCall('git', ['reset', '--hard', 'origin/develop']);
+      expect(resetCall).toBeDefined();
+      expect(resetCall![2]).toEqual({ cwd: '/workspace/repo' });
+    });
+
+    it('does not clone when bootstrapped repo exists', async () => {
+      await checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop');
+
+      const cloneCall = findCall('git', ['clone']);
+      expect(cloneCall).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // ensureCheckout — stat error other than ENOENT
   // -------------------------------------------------------------------------
   describe('ensureCheckout() with unexpected stat error', () => {
     it('re-throws non-ENOENT errors from stat', async () => {
       const permError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
       permError.code = 'EACCES';
-      mockStat.mockRejectedValue(permError);
+      // First stat (bootstrapped .git) → not found (normal)
+      // Second stat (isolated checkout) → permission error
+      mockStat
+        .mockRejectedValueOnce(enoentError())
+        .mockRejectedValue(permError);
 
       await expect(
         checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop'),

--- a/packages/orchestrator/src/worker/repo-checkout.ts
+++ b/packages/orchestrator/src/worker/repo-checkout.ts
@@ -7,10 +7,16 @@ import type { Logger } from './types.js';
 const execFileAsync = promisify(execFile);
 
 /**
- * Manages per-worker isolated git repository checkouts.
+ * Manages git repository checkouts for workers.
  *
- * Each worker gets its own checkout at `{workspaceDir}/{workerId}/{owner}/{repo}`
- * to avoid race conditions between concurrent workers.
+ * Supports two modes:
+ * - **Container-per-worker** (preferred): If a bootstrapped repo already exists
+ *   at `{workspaceDir}/{repo}`, it is reused directly. This avoids redundant
+ *   clones and ensures the checkout shares the same environment (MCP server
+ *   paths, node_modules, build artifacts) set up by the bootstrap entrypoint.
+ * - **Isolated checkout** (fallback): If no bootstrapped repo is found, a fresh
+ *   clone is created at `{workspaceDir}/{workerId}/{owner}/{repo}` to isolate
+ *   concurrent workers sharing a single process.
  */
 export class RepoCheckout {
   constructor(
@@ -20,14 +26,19 @@ export class RepoCheckout {
 
   /**
    * Compute the checkout path for a given worker and repository.
-   * Does not perform any filesystem or git operations.
    *
-   * @param workerId - Unique worker identifier
-   * @param owner - Repository owner (GitHub user or org)
-   * @param repo - Repository name
-   * @returns The absolute path where the checkout would reside
+   * Prefers a bootstrapped repo at `{workspaceDir}/{repo}` when it exists.
+   * Falls back to the isolated path `{workspaceDir}/{workerId}/{owner}/{repo}`.
    */
-  getCheckoutPath(workerId: string, owner: string, repo: string): string {
+  async getCheckoutPath(workerId: string, owner: string, repo: string): Promise<string> {
+    const bootstrappedPath = join(this.workspaceDir, repo);
+    if (await this.directoryExists(join(bootstrappedPath, '.git'))) {
+      this.logger.debug(
+        { bootstrappedPath, repo },
+        'Using bootstrapped repo checkout',
+      );
+      return bootstrappedPath;
+    }
     return join(this.workspaceDir, workerId, owner, repo);
   }
 
@@ -49,7 +60,7 @@ export class RepoCheckout {
     repo: string,
     branch: string,
   ): Promise<string> {
-    const checkoutPath = this.getCheckoutPath(workerId, owner, repo);
+    const checkoutPath = await this.getCheckoutPath(workerId, owner, repo);
 
     const exists = await this.directoryExists(checkoutPath);
 


### PR DESCRIPTION
## Summary

- Workers in container-per-worker mode were creating fresh clones in `/tmp/orchestrator-workspaces/` instead of using the repos already bootstrapped at `/workspaces/{repo}` by the entrypoint
- This caused Claude CLI to run in a bare checkout disconnected from the MCP server's `cwd` (`/workspaces/agency`), so speckit MCP tools (`get_paths`, `check_prereqs`) searched the wrong directory
- Result: all phases after specify exited in ~4.4s with no meaningful output, and implement failed with "no file changes"

## Changes

- `RepoCheckout.getCheckoutPath` now checks for a bootstrapped repo at `{workspaceDir}/{repo}/.git` and reuses it when found
- Falls back to isolated `{workerId}/{owner}/{repo}` path for multi-worker-per-process deployments (backward compatible)
- Added `WORKER_WORKSPACE_DIR` env var mapping in config loader
- Updated tests with bootstrapped repo scenarios

## Test plan

- [x] All 32 repo-checkout tests pass (including 3 new bootstrapped-mode tests)
- [x] Full orchestrator test suite passes (12 pre-existing failures unrelated to this change)
- [x] TypeScript compiles cleanly
- [ ] Pair with generacy-ai/tetrad-development PR that sets `WORKER_WORKSPACE_DIR=/workspaces` in docker-compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)