### PR TITLE
fix: use namespaced speckit slash commands in PHASE_TO_COMMAND

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
@@ -315,7 +315,7 @@ describe('ClaudeCliWorker (integration)', () => {
       // First CLI spawn should be for 'plan' (GATE_MAPPING: clarification → resumeFrom: plan)
       const firstSpawnArgs = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
       const promptArg = firstSpawnArgs[firstSpawnArgs.length - 1]!;
-      expect(promptArg).toContain('/plan');
+      expect(promptArg).toContain('/agency-spec-kit:plan');
     });
   });
 
@@ -989,10 +989,10 @@ describe('ClaudeCliWorker (integration)', () => {
         const args = call[1] as string[];
         return args[args.length - 1] ?? null;
       });
-      expect(prompts[0]).toContain('/specify');
-      expect(prompts[1]).toContain('/clarify');
-      expect(prompts[2]).toContain('/plan');
-      expect(prompts[3]).toContain('/tasks');
+      expect(prompts[0]).toContain('/agency-spec-kit:specify');
+      expect(prompts[1]).toContain('/agency-spec-kit:clarify');
+      expect(prompts[2]).toContain('/agency-spec-kit:plan');
+      expect(prompts[3]).toContain('/agency-spec-kit:tasks');
 
       // Verify workflow completed (not failed)
       const completedEvent = sseEvents.find(
@@ -1081,7 +1081,7 @@ describe('ClaudeCliWorker (integration)', () => {
       expect(spawnFn).toHaveBeenCalledTimes(2);
 
       const firstPrompt = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
-      expect(firstPrompt[firstPrompt.length - 1]).toContain('/plan');
+      expect(firstPrompt[firstPrompt.length - 1]).toContain('/agency-spec-kit:plan');
     });
   });
 

--- a/packages/orchestrator/src/worker/types.ts
+++ b/packages/orchestrator/src/worker/types.ts
@@ -35,11 +35,11 @@ export function getPhaseSequence(workflowName: string): WorkflowPhase[] {
  * Map each phase to its Claude CLI slash command (null = no CLI command)
  */
 export const PHASE_TO_COMMAND: Record<WorkflowPhase, string | null> = {
-  specify: '/specify',
-  clarify: '/clarify',
-  plan: '/plan',
-  tasks: '/tasks',
-  implement: '/implement',
+  specify: '/agency-spec-kit:specify',
+  clarify: '/agency-spec-kit:clarify',
+  plan: '/agency-spec-kit:plan',
+  tasks: '/agency-spec-kit:tasks',
+  implement: '/agency-spec-kit:implement',
   validate: null,
 };
 


### PR DESCRIPTION
## Summary
- Updates `PHASE_TO_COMMAND` to use `agency-spec-kit:` prefixed slash commands matching the marketplace plugin namespace
- The marketplace plugin installs commands as `agency-spec-kit:specify`, `agency-spec-kit:clarify`, etc.
- `PHASE_TO_COMMAND` was sending `/specify`, `/clarify` — which Claude CLI rejected as `"Unknown skill: specify"`
- This caused all phases to complete in ~5-7 seconds with exit code 0 but no actual work done

**Root cause**: When the marketplace plugin is successfully installed, Phase 4 of `generacy setup build` cleans up old file-copy commands from `~/.claude/commands/`. The file-copy path used unprefixed names (`specify.md`), but the marketplace plugin namespaces them as `agency-spec-kit:specify`. After cleanup, only the namespaced variants exist.

## Test plan
- [x] cli-spawner tests pass (17/17)
- [x] repo-checkout tests pass (32/32)
- [ ] Rebuild containers, requeue issue #342, verify phases run with correct slash commands and take meaningful time

🤖 Generated with [Claude Code](https://claude.com/claude-code)