### PR TITLE
fix: enable iterative clarification gate cycle in orchestrator

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
@@ -289,7 +289,7 @@ describe('ClaudeCliWorker (integration)', () => {
   });
 
   describe('continue command: resume after gate', () => {
-    it('starts from plan when continue command with completed:clarification label', async () => {
+    it('starts from clarify when continue command with completed:clarification label (re-runs clarify for answer integration)', async () => {
       mockGithub.getIssue.mockResolvedValue({
         labels: [
           { name: 'completed:specify' },
@@ -312,10 +312,10 @@ describe('ClaudeCliWorker (integration)', () => {
         workflowName: 'speckit-bugfix',
       }));
 
-      // First CLI spawn should be for 'plan' (GATE_MAPPING: clarification → resumeFrom: plan)
+      // First CLI spawn should be for 'clarify' (GATE_MAPPING: clarification → resumeFrom: clarify)
       const firstSpawnArgs = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
       const promptArg = firstSpawnArgs[firstSpawnArgs.length - 1]!;
-      expect(promptArg).toContain('/agency-spec-kit:plan');
+      expect(promptArg).toContain('/agency-spec-kit:clarify');
     });
   });
 

--- a/packages/orchestrator/src/worker/__tests__/label-manager.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/label-manager.test.ts
@@ -146,11 +146,12 @@ describe('LabelManager', () => {
   });
 
   describe('onResumeStart', () => {
-    it('removes waiting-for:* and agent:paused labels when present', async () => {
+    it('removes waiting-for:*, corresponding completed:*, and agent:paused labels when present', async () => {
       const lm = createLabelManager();
       mockGithub.getIssue.mockResolvedValue({
         labels: [
           { name: 'waiting-for:clarification' },
+          { name: 'completed:clarification' },
           { name: 'agent:paused' },
           { name: 'workflow:speckit-feature' },
           { name: 'completed:specify' },
@@ -163,8 +164,28 @@ describe('LabelManager', () => {
       expect(mockGithub.removeLabels).toHaveBeenCalledWith('owner', 'repo', 42, [
         'waiting-for:clarification',
         'agent:paused',
+        'completed:clarification',
       ]);
       expect(mockGithub.addLabels).toHaveBeenCalledWith('owner', 'repo', 42, ['agent:in-progress']);
+    });
+
+    it('does not remove completed:* labels that have no corresponding waiting-for:* label', async () => {
+      const lm = createLabelManager();
+      mockGithub.getIssue.mockResolvedValue({
+        labels: [
+          { name: 'waiting-for:clarification' },
+          { name: 'agent:paused' },
+          { name: 'completed:specify' },
+        ],
+      });
+
+      await lm.onResumeStart();
+
+      // completed:specify should NOT be removed (no waiting-for:specify present)
+      expect(mockGithub.removeLabels).toHaveBeenCalledWith('owner', 'repo', 42, [
+        'waiting-for:clarification',
+        'agent:paused',
+      ]);
     });
 
     it('does not call removeLabels when no stale labels exist', async () => {

--- a/packages/orchestrator/src/worker/__tests__/phase-resolver.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-resolver.test.ts
@@ -56,13 +56,13 @@ describe('PhaseResolver', () => {
   });
 
   describe('continue command', () => {
-    it('returns "plan" when completed:clarification is present (resumes after clarify gate)', () => {
+    it('returns "clarify" when completed:clarification is present (resumes to re-run clarify for answer integration)', () => {
       expect(
         resolver.resolveStartPhase(
           ['waiting-for:clarification', 'completed:clarification'],
           'continue',
         ),
-      ).toBe('plan');
+      ).toBe('clarify');
     });
 
     it('returns "clarify" when completed:spec-review is present (resumes after spec-review gate)', () => {
@@ -118,9 +118,9 @@ describe('PhaseResolver', () => {
 
   describe('GATE_MAPPING integration', () => {
     it.each([
-      ['clarification', 'plan'],
+      ['clarification', 'clarify'],
       ['spec-review', 'clarify'],
-      ['clarification-review', 'plan'],
+      ['clarification-review', 'clarify'],
       ['plan-review', 'tasks'],
       ['tasks-review', 'implement'],
       ['implementation-review', 'validate'],
@@ -137,7 +137,7 @@ describe('PhaseResolver', () => {
           ['completed:specify', 'completed:clarification'],
           'continue',
         ),
-      ).toBe('plan');
+      ).toBe('clarify');
     });
 
     it('resolveFromProcess normalizes gate names via GATE_MAPPING', () => {
@@ -276,7 +276,7 @@ describe('PhaseResolver', () => {
             'continue',
             'speckit-epic',
           ),
-        ).toBe('plan');
+        ).toBe('clarify');
       });
     });
 

--- a/packages/orchestrator/src/worker/label-manager.ts
+++ b/packages/orchestrator/src/worker/label-manager.ts
@@ -154,10 +154,23 @@ export class LabelManager {
         (l) => l.startsWith('waiting-for:') || l === 'agent:paused',
       );
 
+      // Also remove completed: labels for gates being resumed, so re-entering
+      // the phase can re-activate the gate if needed (e.g., follow-up
+      // clarification questions require another pause cycle).
+      const gateSuffixes = currentLabels
+        .filter((l) => l.startsWith('waiting-for:'))
+        .map((l) => l.slice('waiting-for:'.length));
+      for (const suffix of gateSuffixes) {
+        const completedLabel = `completed:${suffix}`;
+        if (currentLabels.includes(completedLabel) && !labelsToRemove.includes(completedLabel)) {
+          labelsToRemove.push(completedLabel);
+        }
+      }
+
       if (labelsToRemove.length > 0) {
         this.logger.info(
           { labels: labelsToRemove, issue: this.issueNumber },
-          'Resume: removing waiting-for and agent:paused labels',
+          'Resume: removing waiting-for, completed gate, and agent:paused labels',
         );
         await this.github.removeLabels(this.owner, this.repo, this.issueNumber, labelsToRemove);
       }

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -160,7 +160,7 @@ export class PhaseLoop {
             {
               prompt: context.issueUrl,
               cwd: context.checkoutPath,
-              env: {},
+              env: { CLAUDE_HEADLESS: 'true' },
               timeoutMs: config.phaseTimeoutMs,
               signal: context.signal,
               resumeSessionId: currentSessionId,

--- a/packages/orchestrator/src/worker/phase-resolver.ts
+++ b/packages/orchestrator/src/worker/phase-resolver.ts
@@ -7,9 +7,9 @@ import { PHASE_SEQUENCE, getPhaseSequence, type WorkflowPhase } from './types.js
  * - `resumeFrom`: the phase to start from when the gate is satisfied (used in resolveFromContinue)
  */
 export const GATE_MAPPING: Record<string, { phase: WorkflowPhase; resumeFrom: WorkflowPhase }> = {
-  'clarification':          { phase: 'clarify',    resumeFrom: 'plan' },
+  'clarification':          { phase: 'clarify',    resumeFrom: 'clarify' },
   'spec-review':            { phase: 'specify',    resumeFrom: 'clarify' },
-  'clarification-review':   { phase: 'clarify',    resumeFrom: 'plan' },
+  'clarification-review':   { phase: 'clarify',    resumeFrom: 'clarify' },
   'plan-review':            { phase: 'plan',       resumeFrom: 'tasks' },
   'tasks-review':           { phase: 'tasks',      resumeFrom: 'implement' },
   'implementation-review':  { phase: 'implement',  resumeFrom: 'validate' },


### PR DESCRIPTION
## Summary

Fixes three issues that prevented the clarification gate from working correctly in the orchestrator:

- **`GATE_MAPPING` resumed to `plan` instead of `clarify`** — after developer answers, the workflow skipped straight to planning instead of re-running clarify to integrate answers and check for follow-ups
- **CLI spawner missing `CLAUDE_HEADLESS=true`** — the clarify command couldn't detect headless mode, causing unpredictable behavior in automated workflows
- **`onResumeStart` didn't remove `completed:clarification` labels** — on re-entry to the clarify phase, the gate appeared "already satisfied" and was skipped

### Expected flow after fix

1. Clarify runs → questions generated → posted to issue → workflow pauses
2. Developer answers → adds `completed:clarification` → orchestrator resumes
3. Clarify re-runs → integrates answers → checks for follow-ups
4. If follow-ups needed → cycle repeats from step 1
5. If no questions remain → proceeds to planning

**Companion PR:** generacy-ai/tetrad-development#35 — adds clarify phase to speckit-bugfix.yaml

## Test plan

- [ ] All 57 phase-resolver and label-manager tests pass (verified)
- [ ] Rebuild dev containers and test end-to-end with a queued issue
- [ ] Verify iterative clarification cycle works (question → answer → follow-up → answer → proceed)
- [ ] Verify no-questions scenario proceeds directly to planning

🤖 Generated with [Claude Code](https://claude.com/claude-code)