### PR TITLE
fix: handle zero-padded spec directory names in clarification poster

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
@@ -286,6 +286,28 @@ describe('postClarifications', () => {
     expect(result.reason).toBe('file-not-found');
   });
 
+  it('posts clarification comment with zero-padded spec directory', async () => {
+    mockReaddirSync.mockReturnValue(['008-fix-something']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+
+    const ctx = createWorkerContext({
+      item: {
+        owner: 'test-owner',
+        repo: 'test-repo',
+        issueNumber: 8,
+        workflowName: 'speckit-bugfix',
+        command: 'process',
+        priority: Date.now(),
+        enqueuedAt: new Date().toISOString(),
+      },
+    });
+
+    const result = await postClarifications(ctx, logger);
+
+    expect(result.posted).toBe(true);
+    expect(result.pendingCount).toBe(2);
+  });
+
   it('returns post-failed when GitHub API errors', async () => {
     mockReaddirSync.mockReturnValue(['42-feature-branch']);
     mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
@@ -357,6 +379,20 @@ describe('hasPendingClarifications', () => {
     mockReadFileSync.mockReturnValue('');
 
     expect(hasPendingClarifications('/tmp/checkout', 42)).toBe(false);
+  });
+
+  it('matches zero-padded spec directory names', () => {
+    mockReaddirSync.mockReturnValue(['042-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+
+    expect(hasPendingClarifications('/tmp/checkout', 42)).toBe(true);
+  });
+
+  it('matches triple-zero-padded spec directory for single-digit issue', () => {
+    mockReaddirSync.mockReturnValue(['008-fix-something']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+
+    expect(hasPendingClarifications('/tmp/checkout', 8)).toBe(true);
   });
 });
 

--- a/packages/orchestrator/src/worker/clarification-poster.ts
+++ b/packages/orchestrator/src/worker/clarification-poster.ts
@@ -11,6 +11,31 @@ import { join } from 'node:path';
 import type { WorkerContext, Logger } from './types.js';
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the spec directory for a given issue number.
+ *
+ * Spec directories are named `{number}-{slug}` where the number may be
+ * zero-padded (e.g., `008-fix-something`). This function parses the numeric
+ * prefix from each directory and compares as integers to handle both padded
+ * and unpadded naming conventions.
+ */
+function findSpecDir(specsDir: string, issueNumber: number): string | undefined {
+  let dirs: string[];
+  try {
+    dirs = readdirSync(specsDir);
+  } catch {
+    return undefined;
+  }
+  return dirs.find((d) => {
+    const match = d.match(/^(\d+)-/);
+    return match !== null && parseInt(match[1]!, 10) === issueNumber;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -198,19 +223,10 @@ export function hasPendingClarifications(
   issueNumber: number,
 ): boolean {
   const specsDir = join(checkoutPath, 'specs');
+  const specDir = findSpecDir(specsDir, issueNumber);
+  if (!specDir) return false;
 
-  let clarificationsPath: string | undefined;
-  try {
-    const dirs = readdirSync(specsDir);
-    const match = dirs.find((d) => d.startsWith(`${issueNumber}-`));
-    if (match) {
-      clarificationsPath = join(specsDir, match, 'clarifications.md');
-    }
-  } catch {
-    return false;
-  }
-
-  if (!clarificationsPath) return false;
+  const clarificationsPath = join(specsDir, specDir, 'clarifications.md');
 
   let content: string;
   try {
@@ -239,17 +255,11 @@ export async function postClarifications(
 
   // 1. Find clarifications.md in the specs directory
   const specsDir = join(checkoutPath, 'specs');
-  let clarificationsPath: string | undefined;
+  const specDir = findSpecDir(specsDir, issueNumber);
 
-  try {
-    const dirs = readdirSync(specsDir);
-    const match = dirs.find((d) => d.startsWith(`${issueNumber}-`));
-    if (match) {
-      clarificationsPath = join(specsDir, match, 'clarifications.md');
-    }
-  } catch {
-    // specs/ dir doesn't exist
-  }
+  const clarificationsPath = specDir
+    ? join(specsDir, specDir, 'clarifications.md')
+    : undefined;
 
   if (!clarificationsPath) {
     logger.warn({ issueNumber }, 'No spec directory found for issue — skipping clarification posting');


### PR DESCRIPTION
## Summary

- `createFeature` creates spec directories with zero-padded numbers (e.g., `008-fix-something`), but `hasPendingClarifications` and `postClarifications` used `d.startsWith('8-')` which never matched padded names
- Extracts a `findSpecDir` helper that parses the numeric prefix via regex and compares as integers, handling both padded (`008-`) and unpadded (`8-`) directory names
- Adds tests for zero-padded directory matching in both `hasPendingClarifications` and `postClarifications`

This was the root cause of clarification questions not being posted to GitHub issues — the `on-questions` gate condition always evaluated to false because the spec directory couldn't be found.

## Test plan

- [x] All 28 clarification-poster tests pass (including 3 new zero-padding tests)
- [ ] Rebuild dev containers and requeue issue to verify clarifications are posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)