### PR TITLE
fix: integrate GitHub answers before clarification gate check

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
@@ -5,6 +5,7 @@ import {
   postClarifications,
   hasPendingClarifications,
   clarificationMarker,
+  integrateClarificationAnswers,
 } from '../clarification-poster.js';
 import type { WorkerContext, Logger } from '../types.js';
 
@@ -13,10 +14,12 @@ import type { WorkerContext, Logger } from '../types.js';
 // ---------------------------------------------------------------------------
 const mockReaddirSync = vi.fn<(path: string) => string[]>();
 const mockReadFileSync = vi.fn<(path: string, encoding: string) => string>();
+const mockWriteFileSync = vi.fn<(path: string, content: string) => void>();
 
 vi.mock('node:fs', () => ({
   readdirSync: (path: string) => mockReaddirSync(path),
   readFileSync: (path: string, encoding: string) => mockReadFileSync(path, encoding),
+  writeFileSync: (path: string, content: string) => mockWriteFileSync(path, content),
 }));
 
 // ---------------------------------------------------------------------------
@@ -393,6 +396,162 @@ describe('hasPendingClarifications', () => {
     mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
 
     expect(hasPendingClarifications('/tmp/checkout', 8)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T005: integrateClarificationAnswers tests
+// ---------------------------------------------------------------------------
+describe('integrateClarificationAnswers', () => {
+  let context: WorkerContext;
+  let logger: Logger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    context = createWorkerContext();
+    logger = createMockLogger();
+  });
+
+  it('integrates answers from GitHub comments into clarifications.md', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 1, body: 'Q1: A\nQ2: Use PostgreSQL', author: 'user', created_at: '', updated_at: '' },
+    ]);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(2);
+    expect(result.reason).toBeUndefined();
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+
+    const writtenContent = mockWriteFileSync.mock.calls[0]![1] as string;
+    expect(writtenContent).toContain('**Answer**: A');
+    expect(writtenContent).toContain('**Answer**: Use PostgreSQL');
+    // Already-answered Q3 should remain unchanged
+    expect(writtenContent).toContain('**Answer**: Use the existing brand colors');
+  });
+
+  it('returns no-spec-dir when spec directory not found', async () => {
+    mockReaddirSync.mockReturnValue(['99-other-issue']);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(0);
+    expect(result.reason).toBe('no-spec-dir');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns no-file when clarifications.md does not exist', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(0);
+    expect(result.reason).toBe('no-file');
+  });
+
+  it('returns no-pending when all questions already answered', async () => {
+    const allAnswered = `### Q1: Done
+**Context**: Answered.
+**Question**: Already answered?
+
+**Answer**: Yes, done.
+`;
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(allAnswered);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(0);
+    expect(result.reason).toBe('no-pending');
+  });
+
+  it('returns no-answers when no matching answers found in comments', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 1, body: 'Some unrelated comment', author: 'user', created_at: '', updated_at: '' },
+    ]);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(0);
+    expect(result.reason).toBe('no-answers');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('handles partial answers (only some questions answered)', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 1, body: 'Q1: OAuth 2.0', author: 'user', created_at: '', updated_at: '' },
+    ]);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(1);
+    const writtenContent = mockWriteFileSync.mock.calls[0]![1] as string;
+    expect(writtenContent).toContain('**Answer**: OAuth 2.0');
+    // Q2 should still be pending
+    expect(writtenContent).toContain('*Pending*');
+  });
+
+  it('uses last answer when multiple comments answer the same question', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 1, body: 'Q1: First answer', author: 'user', created_at: '', updated_at: '' },
+      { id: 2, body: 'Q1: Updated answer', author: 'user', created_at: '', updated_at: '' },
+    ]);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(1);
+    const writtenContent = mockWriteFileSync.mock.calls[0]![1] as string;
+    expect(writtenContent).toContain('**Answer**: Updated answer');
+    expect(writtenContent).not.toContain('First answer');
+  });
+
+  it('works with zero-padded spec directories', async () => {
+    mockReaddirSync.mockReturnValue(['008-fix-something']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+
+    const ctx = createWorkerContext({
+      item: {
+        owner: 'test-owner',
+        repo: 'test-repo',
+        issueNumber: 8,
+        workflowName: 'speckit-bugfix',
+        command: 'continue',
+        priority: Date.now(),
+        enqueuedAt: new Date().toISOString(),
+      },
+    });
+    (ctx.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 1, body: 'Q1: A\nQ2: B', author: 'user', created_at: '', updated_at: '' },
+    ]);
+
+    const result = await integrateClarificationAnswers(ctx, logger);
+
+    expect(result.integrated).toBe(2);
+  });
+
+  it('handles GitHub API failure gracefully', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('API rate limit'),
+    );
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(0);
+    expect(result.reason).toBe('no-answers');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/orchestrator/src/worker/clarification-poster.ts
+++ b/packages/orchestrator/src/worker/clarification-poster.ts
@@ -6,7 +6,7 @@
  * but can fail silently. This module reads `clarifications.md`, extracts
  * pending questions, and posts them as a comment with a dedup marker.
  */
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { WorkerContext, Logger } from './types.js';
 
@@ -237,6 +237,135 @@ export function hasPendingClarifications(
 
   const questions = parseClarifications(content);
   return questions.some((q) => !q.answered);
+}
+
+// ---------------------------------------------------------------------------
+// integrateClarificationAnswers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse answers from GitHub issue comments.
+ *
+ * Scans comment bodies for patterns like `Q1: answer text` and extracts
+ * answers keyed by question number. Later answers for the same question
+ * override earlier ones (last wins).
+ */
+function parseAnswersFromComments(
+  comments: Array<{ body: string }>,
+  questionNumbers: number[],
+): Map<number, string> {
+  const answers = new Map<number, string>();
+
+  for (const comment of comments) {
+    const regex =
+      /(?:\*\*)?Q(\d+)(?:\*\*)?:\s*(.*?)(?=(?:\n(?:\*\*)?Q\d+(?:\*\*)?:)|$)/gs;
+
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(comment.body)) !== null) {
+      const numStr = match[1];
+      const answerStr = match[2];
+      if (!numStr || answerStr === undefined) continue;
+      const questionNumber = parseInt(numStr, 10);
+      const answer = answerStr.trim();
+
+      if (answer && questionNumbers.includes(questionNumber)) {
+        answers.set(questionNumber, answer);
+      }
+    }
+  }
+
+  return answers;
+}
+
+export interface IntegrationResult {
+  /** Number of answers integrated into the file */
+  integrated: number;
+  /** Reason if nothing was integrated */
+  reason?: 'no-spec-dir' | 'no-file' | 'no-pending' | 'no-answers' | 'no-changes';
+}
+
+/**
+ * Integrate clarification answers from GitHub issue comments into the local
+ * clarifications.md file.
+ *
+ * This is a defensive measure: the Claude CLI clarify command is supposed to
+ * call `manage_clarifications update_answer` to persist answers, but if it
+ * fails to do so, this function ensures the answers are integrated before
+ * the gate checker evaluates `hasPendingClarifications`.
+ */
+export async function integrateClarificationAnswers(
+  context: WorkerContext,
+  logger: Logger,
+): Promise<IntegrationResult> {
+  const { github, item, checkoutPath } = context;
+  const { owner, repo, issueNumber } = item;
+
+  // 1. Find clarifications.md
+  const specsDir = join(checkoutPath, 'specs');
+  const specDir = findSpecDir(specsDir, issueNumber);
+  if (!specDir) {
+    return { integrated: 0, reason: 'no-spec-dir' };
+  }
+
+  const clarificationsPath = join(specsDir, specDir, 'clarifications.md');
+
+  let content: string;
+  try {
+    content = readFileSync(clarificationsPath, 'utf-8');
+  } catch {
+    return { integrated: 0, reason: 'no-file' };
+  }
+
+  // 2. Parse questions to find pending ones
+  const questions = parseClarifications(content);
+  const pendingQuestions = questions.filter((q) => !q.answered);
+  if (pendingQuestions.length === 0) {
+    return { integrated: 0, reason: 'no-pending' };
+  }
+
+  const pendingNumbers = pendingQuestions.map((q) => q.number);
+
+  // 3. Fetch GitHub issue comments and parse answers
+  let comments: Array<{ body: string }>;
+  try {
+    comments = await github.getIssueComments(owner, repo, issueNumber);
+  } catch (error) {
+    logger.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      'Failed to fetch issue comments for answer integration',
+    );
+    return { integrated: 0, reason: 'no-answers' };
+  }
+
+  const answers = parseAnswersFromComments(comments, pendingNumbers);
+  if (answers.size === 0) {
+    return { integrated: 0, reason: 'no-answers' };
+  }
+
+  // 4. Update the file content — replace *Pending* with actual answers
+  //    for each matched question
+  let updatedContent = content;
+  for (const [questionNum, answer] of answers) {
+    // Match the answer line within the correct question section.
+    // The pattern finds ### Q{N}: ... **Answer**: *Pending* and replaces
+    // the *Pending* part with the actual answer text.
+    const pattern = new RegExp(
+      `(### Q${questionNum}:[\\s\\S]*?\\*\\*Answer\\*\\*:\\s*)\\*Pending\\*`,
+    );
+    updatedContent = updatedContent.replace(pattern, `$1${answer}`);
+  }
+
+  if (updatedContent === content) {
+    return { integrated: 0, reason: 'no-changes' };
+  }
+
+  writeFileSync(clarificationsPath, updatedContent);
+  logger.info(
+    { count: answers.size, issueNumber },
+    'Integrated GitHub answers into clarifications.md',
+  );
+
+  return { integrated: answers.size };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -7,7 +7,7 @@ import type { GateChecker } from './gate-checker.js';
 import type { CliSpawner } from './cli-spawner.js';
 import type { OutputCapture } from './output-capture.js';
 import type { PrManager } from './pr-manager.js';
-import { postClarifications, hasPendingClarifications } from './clarification-poster.js';
+import { postClarifications, hasPendingClarifications, integrateClarificationAnswers } from './clarification-poster.js';
 
 /** Phases that MUST produce file changes to be considered successful. */
 const PHASES_REQUIRING_CHANGES: ReadonlySet<WorkflowPhase> = new Set(['implement']);
@@ -251,6 +251,11 @@ export class PhaseLoop {
         if (gate.condition === 'always') {
           gateActive = true;
         } else if (gate.condition === 'on-questions') {
+          // Defensive: integrate any GitHub answers into local clarifications.md
+          // before checking for pending questions. The Claude CLI clarify command
+          // should do this via manage_clarifications update_answer, but if it
+          // doesn't, this ensures answers aren't lost and the gate passes.
+          await integrateClarificationAnswers(context, this.logger);
           gateActive = hasPendingClarifications(context.checkoutPath, context.item.issueNumber);
           if (!gateActive) {
             this.logger.info(


### PR DESCRIPTION
## Summary

- Adds `integrateClarificationAnswers()` to the orchestrator that fetches GitHub issue comments, parses `Q{N}: answer` patterns, and writes answers into the local `clarifications.md` before the `on-questions` gate evaluates
- Prevents the clarification gate from re-activating when the Claude CLI clarify command fails to persist answers via `manage_clarifications update_answer`
- Includes 8 new tests covering answer integration, partial answers, zero-padded dirs, API failures, and dedup

## Problem

When resuming after clarification answers are posted, the clarify phase re-runs but sometimes only updates `spec.md` without calling `manage_clarifications update_answer` to persist answers into `clarifications.md`. The `hasPendingClarifications()` gate check reads the local file, finds `*Pending*` entries, and re-activates the `waiting-for:clarification` gate — causing an infinite loop.

## Test plan

- [x] All 37 clarification-poster tests pass (8 new)
- [x] Phase-loop tests pass
- [x] Pre-existing claude-cli-worker test failures confirmed unrelated
- [ ] Rebuild dev containers and requeue cluster-templates#8 to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)