### PR TITLE
fix: allow implement phase to pass when prior implementation exists

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/phase-loop.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.test.ts
@@ -160,3 +160,56 @@ describe('PhaseLoop - pre-validate install', () => {
     expect(deps.labelManager.onError).toHaveBeenCalledWith('validate');
   });
 });
+
+describe('PhaseLoop - implement phase requires changes', () => {
+  let phaseLoop: PhaseLoop;
+  let deps: PhaseLoopDeps;
+
+  beforeEach(() => {
+    phaseLoop = new PhaseLoop(mockLogger);
+    deps = createMockDeps();
+  });
+
+  it('fails implement phase when no changes and no prior implementation', async () => {
+    const context = createMockContext('implement');
+    context.github = {
+      getDefaultBranch: vi.fn().mockResolvedValue('develop'),
+      getCurrentBranch: vi.fn().mockResolvedValue('008-feature'),
+      getCommitsBetween: vi.fn().mockResolvedValue([
+        { sha: 'abc', message: 'chore(speckit): complete specify phase for #8' },
+      ]),
+    } as any;
+    const config = createConfig();
+
+    (deps.cliSpawner.spawnPhase as any).mockResolvedValue(makeSuccessResult('implement'));
+    (deps.prManager.commitPushAndEnsurePr as any).mockResolvedValue({ prUrl: null, hasChanges: false });
+
+    const result = await phaseLoop.executeLoop(context, config, deps, ['implement']);
+
+    expect(result.completed).toBe(false);
+    expect(result.lastPhase).toBe('implement');
+    expect(deps.labelManager.onError).toHaveBeenCalledWith('implement');
+  });
+
+  it('continues when no new changes but prior implementation commit exists on branch', async () => {
+    const context = createMockContext('implement');
+    context.github = {
+      getDefaultBranch: vi.fn().mockResolvedValue('develop'),
+      getCurrentBranch: vi.fn().mockResolvedValue('008-feature'),
+      getCommitsBetween: vi.fn().mockResolvedValue([
+        { sha: 'abc', message: 'chore(speckit): complete specify phase for #8' },
+        { sha: 'def', message: 'chore(speckit): complete implement phase for #8' },
+      ]),
+    } as any;
+    const config = createConfig();
+
+    (deps.cliSpawner.spawnPhase as any).mockResolvedValue(makeSuccessResult('implement'));
+    (deps.prManager.commitPushAndEnsurePr as any).mockResolvedValue({ prUrl: null, hasChanges: false });
+
+    const result = await phaseLoop.executeLoop(context, config, deps, ['implement']);
+
+    expect(result.completed).toBe(true);
+    expect(deps.labelManager.onError).not.toHaveBeenCalled();
+    expect(deps.labelManager.onPhaseComplete).toHaveBeenCalledWith('implement');
+  });
+});

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -218,25 +218,47 @@ export class PhaseLoop {
 
       // 5b. Fail phases that require file changes but produced none
       if (PHASES_REQUIRING_CHANGES.has(phase) && !hasChanges) {
-        this.logger.error(
-          { phase },
-          'Phase completed with exit code 0 but produced no file changes',
-        );
-        await labelManager.onError(phase);
-        await stageCommentManager.updateStageComment({
-          stage,
-          status: 'error',
-          phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'error'),
-          startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
-          prUrl: context.prUrl,
-        });
-        result.success = false;
-        result.error = {
-          message: `Phase "${phase}" succeeded but produced no file changes — expected code to be written`,
-          stderr: '',
-          phase,
-        };
-        return { results, completed: false, lastPhase: phase, gateHit: false };
+        // Check if a previous run already produced implementation changes on this
+        // branch (e.g., issue was requeued). If the branch has prior commits for
+        // this phase, treat it as a soft pass rather than an error.
+        let hasPriorImplementation = false;
+        try {
+          const defaultBranch = await context.github.getDefaultBranch();
+          const branch = await context.github.getCurrentBranch();
+          const commits = await context.github.getCommitsBetween(`origin/${defaultBranch}`, branch);
+          hasPriorImplementation = commits.some(
+            (c) => c.message.includes(`complete ${phase} phase`),
+          );
+        } catch {
+          // If we can't check, fall through to the error path
+        }
+
+        if (hasPriorImplementation) {
+          this.logger.warn(
+            { phase },
+            'Phase produced no new changes but branch has prior implementation commits — continuing',
+          );
+        } else {
+          this.logger.error(
+            { phase },
+            'Phase completed with exit code 0 but produced no file changes',
+          );
+          await labelManager.onError(phase);
+          await stageCommentManager.updateStageComment({
+            stage,
+            status: 'error',
+            phases: this.buildPhaseProgress(sequence, startIndex, i, phaseTimestamps, 'error'),
+            startedAt: phaseTimestamps.get(sequence[startIndex]!)?.startedAt ?? new Date().toISOString(),
+            prUrl: context.prUrl,
+          });
+          result.success = false;
+          result.error = {
+            message: `Phase "${phase}" succeeded but produced no file changes — expected code to be written`,
+            stderr: '',
+            phase,
+          };
+          return { results, completed: false, lastPhase: phase, gateHit: false };
+        }
       }
 
       // 5c. Mark phase as completed in labels


### PR DESCRIPTION
## Summary

- When an issue is requeued from scratch, the feature branch retains implementation files from the previous run
- The implement phase finds nothing new to write, exits with code 0 but no file changes, and the `PHASES_REQUIRING_CHANGES` guard treats this as an error
- Now checks for prior implementation commits on the branch before failing — if a previous run's commit exists for the same phase, treats the no-changes result as a warning rather than an error

## Problem

Requeued issues fail at the implement phase with: `Phase "implement" succeeded but produced no file changes — expected code to be written`. The branch already has the implementation from a previous run, so the Claude CLI correctly finds nothing to do, but the orchestrator interprets this as a failure.

## Test plan

- [x] New test: fails implement when no changes and no prior implementation commit
- [x] New test: continues when prior implementation commit exists on branch
- [x] All 5 phase-loop tests pass
- [x] All 42 clarification-poster + phase-loop tests pass
- [ ] Rebuild dev containers and requeue cluster-templates#8 to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)