### PR TITLE
fix: resolve speckit commands from agency source packages dir

### DIFF
--- a/packages/generacy/src/__tests__/setup/build.test.ts
+++ b/packages/generacy/src/__tests__/setup/build.test.ts
@@ -581,7 +581,31 @@ describe('setup build command', () => {
   });
 
   describe('Phase 4: speckit command resolution and copy', () => {
-    it('resolves commands from local generacy workspace node_modules (Tier 1)', async () => {
+    it('resolves commands from agency source packages directory (Tier 1 first)', async () => {
+      mockExecBehavior();
+      mockFileSystem([
+        '/workspaces/agency',
+        '/workspaces/latency',
+        '/workspaces/agency/packages/agency/dist/cli.js',
+        '/workspaces/agency/packages/agency-plugin-spec-kit/dist/index.js',
+        '/workspaces/agency/packages/agency-plugin-spec-kit/commands',
+      ]);
+      mockReaddirSync.mockReturnValue(['specify.md', 'clarify.md', 'plan.md']);
+
+      await runBuildCommand(['--skip-cleanup', '--skip-generacy']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { path: '/workspaces/agency/packages/agency-plugin-spec-kit/commands' },
+        'Resolved speckit commands from local workspace',
+      );
+      expect(mockCopyFileSync).toHaveBeenCalledTimes(3);
+      expect(mockCopyFileSync).toHaveBeenCalledWith(
+        '/workspaces/agency/packages/agency-plugin-spec-kit/commands/specify.md',
+        '/home/testuser/.claude/commands/specify.md',
+      );
+    });
+
+    it('resolves commands from local generacy workspace node_modules (Tier 1 fallback)', async () => {
       mockExecBehavior();
       mockFileSystem([
         '/workspaces/agency',

--- a/packages/generacy/src/cli/commands/setup/build.ts
+++ b/packages/generacy/src/cli/commands/setup/build.ts
@@ -271,8 +271,11 @@ function resolveSpeckitCommandsDir(config: BuildConfig): string | null {
   const logger = getLogger();
   const pkgSubpath = join('@generacy-ai', 'agency-plugin-spec-kit', 'commands');
 
-  // Tier 1: Local workspace node_modules
+  // Tier 1: Local workspace — source package directory, then node_modules
+  // The source path handles pnpm workspaces where the package won't appear
+  // in a hoisted node_modules/@scope/pkg location.
   const localPaths = [
+    join(config.agencyDir, 'packages', 'agency-plugin-spec-kit', 'commands'),
     join(config.generacyDir, 'node_modules', pkgSubpath),
     join(config.agencyDir, 'node_modules', pkgSubpath),
   ];
@@ -326,6 +329,7 @@ function installClaudeCodeIntegration(config: BuildConfig): void {
     logger.error(
       {
         checkedPaths: [
+          join(config.agencyDir, 'packages', 'agency-plugin-spec-kit', 'commands'),
           join(config.generacyDir, 'node_modules', '@generacy-ai', 'agency-plugin-spec-kit', 'commands'),
           join(config.agencyDir, 'node_modules', '@generacy-ai', 'agency-plugin-spec-kit', 'commands'),
           '{npm root -g}/@generacy-ai/agency-plugin-spec-kit/commands',


### PR DESCRIPTION
## Summary
- Speckit command installation was failing because `resolveSpeckitCommandsDir` only checked `node_modules` paths, but in pnpm workspaces the package isn't hoisted there
- Added the direct source path (`agencyDir/packages/agency-plugin-spec-kit/commands`) as the first resolution path in Tier 1
- Works for anyone with the agency repo cloned locally (dev containers, forks added to workspaces)

## Test plan
- [x] Added test for new source package directory resolution
- [x] All 44 existing tests pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)