### PR TITLE
fix: drop agency-spec-kit namespace from phase slash commands

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/claude-cli-worker.test.ts
@@ -315,7 +315,7 @@ describe('ClaudeCliWorker (integration)', () => {
       // First CLI spawn should be for 'clarify' (GATE_MAPPING: clarification → resumeFrom: clarify)
       const firstSpawnArgs = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
       const promptArg = firstSpawnArgs[firstSpawnArgs.length - 1]!;
-      expect(promptArg).toContain('/agency-spec-kit:clarify');
+      expect(promptArg).toContain('/clarify');
     });
   });
 
@@ -989,10 +989,10 @@ describe('ClaudeCliWorker (integration)', () => {
         const args = call[1] as string[];
         return args[args.length - 1] ?? null;
       });
-      expect(prompts[0]).toContain('/agency-spec-kit:specify');
-      expect(prompts[1]).toContain('/agency-spec-kit:clarify');
-      expect(prompts[2]).toContain('/agency-spec-kit:plan');
-      expect(prompts[3]).toContain('/agency-spec-kit:tasks');
+      expect(prompts[0]).toContain('/specify');
+      expect(prompts[1]).toContain('/clarify');
+      expect(prompts[2]).toContain('/plan');
+      expect(prompts[3]).toContain('/tasks');
 
       // Verify workflow completed (not failed)
       const completedEvent = sseEvents.find(
@@ -1081,7 +1081,7 @@ describe('ClaudeCliWorker (integration)', () => {
       expect(spawnFn).toHaveBeenCalledTimes(2);
 
       const firstPrompt = (spawnFn.mock.calls[0] as [string, string[], unknown])[1] as string[];
-      expect(firstPrompt[firstPrompt.length - 1]).toContain('/agency-spec-kit:plan');
+      expect(firstPrompt[firstPrompt.length - 1]).toContain('/plan');
     });
   });
 

--- a/packages/orchestrator/src/worker/types.ts
+++ b/packages/orchestrator/src/worker/types.ts
@@ -35,11 +35,11 @@ export function getPhaseSequence(workflowName: string): WorkflowPhase[] {
  * Map each phase to its Claude CLI slash command (null = no CLI command)
  */
 export const PHASE_TO_COMMAND: Record<WorkflowPhase, string | null> = {
-  specify: '/agency-spec-kit:specify',
-  clarify: '/agency-spec-kit:clarify',
-  plan: '/agency-spec-kit:plan',
-  tasks: '/agency-spec-kit:tasks',
-  implement: '/agency-spec-kit:implement',
+  specify: '/specify',
+  clarify: '/clarify',
+  plan: '/plan',
+  tasks: '/tasks',
+  implement: '/implement',
   validate: null,
 };
 


### PR DESCRIPTION
## Summary
- Phase commands were invoked as `/agency-spec-kit:specify`, `/agency-spec-kit:implement`, etc. but the command files are installed as plain `specify.md`, `implement.md` in `~/.claude/commands/`
- Claude Code resolves these as `/specify`, `/implement` — not with the namespace prefix
- This caused every phase to get "Unknown skill" and the implement phase to fail with "no file changes"
- Simplified `PHASE_TO_COMMAND` mapping to use plain `/specify`, `/clarify`, `/plan`, `/tasks`, `/implement`

## Test plan
- [x] Updated test assertions to match new command names
- [x] Pre-existing test failures (12) confirmed unrelated to this change
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)