### PR TITLE
fix: resolve speckit commands and agency CLI from shared packages volume

### DIFF
--- a/packages/generacy/src/__tests__/setup/build.test.ts
+++ b/packages/generacy/src/__tests__/setup/build.test.ts
@@ -650,7 +650,28 @@ describe('setup build command', () => {
       expect(mockCopyFileSync).toHaveBeenCalledTimes(1);
     });
 
-    it('resolves commands from npm global (Tier 2) when local not found', async () => {
+    it('resolves commands from shared packages volume (Tier 2) when local not found', async () => {
+      mockExecBehavior();
+      mockFileSystem([
+        '/workspaces/agency',
+        '/workspaces/latency',
+        '/workspaces/agency/packages/agency/dist/cli.js',
+        '/workspaces/agency/packages/agency-plugin-spec-kit/dist/index.js',
+        // No local node_modules paths, but shared volume has it
+        '/shared-packages/node_modules/@generacy-ai/agency-plugin-spec-kit/commands',
+      ]);
+      mockReaddirSync.mockReturnValue(['specify.md', 'plan.md']);
+
+      await runBuildCommand(['--skip-cleanup', '--skip-generacy']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { path: '/shared-packages/node_modules/@generacy-ai/agency-plugin-spec-kit/commands' },
+        'Resolved speckit commands from shared packages volume',
+      );
+      expect(mockCopyFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('resolves commands from npm global (Tier 3) when local and shared not found', async () => {
       mockExecBehavior({
         'npm root -g': { stdout: '/usr/lib/node_modules' },
       });
@@ -742,6 +763,31 @@ describe('setup build command', () => {
       });
     });
 
+    it('configures Agency MCP server from shared packages volume', async () => {
+      mockExecBehavior();
+      // No source repos — external project with shared packages volume
+      mockFileSystem([
+        '/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js',
+      ]);
+
+      await runBuildCommand(['--skip-cleanup', '--skip-generacy']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { path: '/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js' },
+        'Using agency CLI from shared packages volume',
+      );
+      const claudeJsonCalls = mockWriteFileSync.mock.calls.filter(
+        (c) => (c[0] as string) === '/home/testuser/.claude.json',
+      );
+      expect(claudeJsonCalls.length).toBeGreaterThan(0);
+      const written = JSON.parse(claudeJsonCalls[0][1] as string);
+      expect(written.mcpServers.agency).toEqual({
+        type: 'stdio',
+        command: 'node',
+        args: ['/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js'],
+      });
+    });
+
     it('skips MCP configuration with info log when Agency CLI not found', async () => {
       mockExecBehavior({
         'npm root -g': { throw: true },
@@ -804,6 +850,29 @@ describe('setup build command', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({ count: 2 }),
         'Copied speckit command files',
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it('resolves commands and agency CLI from shared packages volume', async () => {
+      mockExecBehavior();
+      // No source repos — external project with shared packages volume
+      mockFileSystem([
+        '/shared-packages/node_modules/@generacy-ai/agency-plugin-spec-kit/commands',
+        '/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js',
+      ]);
+      mockReaddirSync.mockReturnValue(['specify.md', 'clarify.md', 'plan.md']);
+
+      await runBuildCommand([]);
+
+      expect(mockCopyFileSync).toHaveBeenCalledTimes(3);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { path: '/shared-packages/node_modules/@generacy-ai/agency-plugin-spec-kit/commands' },
+        'Resolved speckit commands from shared packages volume',
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { path: '/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js' },
+        'Using agency CLI from shared packages volume',
       );
       expect(mockExit).not.toHaveBeenCalled();
     });

--- a/packages/generacy/src/cli/commands/setup/build.ts
+++ b/packages/generacy/src/cli/commands/setup/build.ts
@@ -261,10 +261,18 @@ function resolveNpmGlobalRoot(): string | null {
 }
 
 /**
+ * Well-known shared packages directory used by cluster-templates.
+ * The orchestrator installs packages here via `npm install --prefix /shared-packages`;
+ * workers mount this volume read-only.
+ */
+const SHARED_PACKAGES_DIR = '/shared-packages';
+
+/**
  * Resolve the speckit commands directory from the @generacy-ai/agency-plugin-spec-kit package.
- * Uses a two-tier resolution strategy:
+ * Uses a three-tier resolution strategy:
  *   Tier 1: Local workspace node_modules (workspace root, then agency dir)
- *   Tier 2: npm global root
+ *   Tier 2: Shared packages volume (/shared-packages/node_modules)
+ *   Tier 3: npm global root
  * Returns the resolved commands directory path, or null if not found.
  */
 function resolveSpeckitCommandsDir(config: BuildConfig): string | null {
@@ -286,7 +294,14 @@ function resolveSpeckitCommandsDir(config: BuildConfig): string | null {
     }
   }
 
-  // Tier 2: npm global
+  // Tier 2: Shared packages volume (cluster-templates pattern)
+  const sharedPath = join(SHARED_PACKAGES_DIR, 'node_modules', pkgSubpath);
+  if (existsSync(sharedPath)) {
+    logger.info({ path: sharedPath }, 'Resolved speckit commands from shared packages volume');
+    return sharedPath;
+  }
+
+  // Tier 3: npm global
   const globalRoot = resolveNpmGlobalRoot();
   if (globalRoot) {
     const globalPath = join(globalRoot, pkgSubpath);
@@ -332,6 +347,7 @@ function installClaudeCodeIntegration(config: BuildConfig): void {
           join(config.agencyDir, 'packages', 'agency-plugin-spec-kit', 'commands'),
           join(config.generacyDir, 'node_modules', '@generacy-ai', 'agency-plugin-spec-kit', 'commands'),
           join(config.agencyDir, 'node_modules', '@generacy-ai', 'agency-plugin-spec-kit', 'commands'),
+          join(SHARED_PACKAGES_DIR, 'node_modules', '@generacy-ai', 'agency-plugin-spec-kit', 'commands'),
           '{npm root -g}/@generacy-ai/agency-plugin-spec-kit/commands',
         ],
       },
@@ -351,13 +367,20 @@ function installClaudeCodeIntegration(config: BuildConfig): void {
     agencyCli = sourceAgencyCli;
     agencyCwd = config.agencyDir;
   } else {
-    // Find globally installed @generacy-ai/agency package
-    const globalRoot = resolveNpmGlobalRoot();
-    if (globalRoot) {
-      const globalCliPath = join(globalRoot, '@generacy-ai', 'agency', 'dist', 'cli.js');
-      if (existsSync(globalCliPath)) {
-        agencyCli = globalCliPath;
-        logger.info({ path: agencyCli }, 'Using globally installed agency CLI');
+    // Check shared packages volume (cluster-templates pattern)
+    const sharedCliPath = join(SHARED_PACKAGES_DIR, 'node_modules', '@generacy-ai', 'agency', 'dist', 'cli.js');
+    if (existsSync(sharedCliPath)) {
+      agencyCli = sharedCliPath;
+      logger.info({ path: agencyCli }, 'Using agency CLI from shared packages volume');
+    } else {
+      // Find globally installed @generacy-ai/agency package
+      const globalRoot = resolveNpmGlobalRoot();
+      if (globalRoot) {
+        const globalCliPath = join(globalRoot, '@generacy-ai', 'agency', 'dist', 'cli.js');
+        if (existsSync(globalCliPath)) {
+          agencyCli = globalCliPath;
+          logger.info({ path: agencyCli }, 'Using globally installed agency CLI');
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds `/shared-packages/node_modules/` as a resolution tier for speckit commands and agency CLI
- Fixes external projects using cluster-templates where packages are installed via `npm install --prefix /shared-packages` by the orchestrator
- Previously only checked local workspace paths and `npm root -g`, missing the shared volume entirely

## Changes
- `resolveSpeckitCommandsDir`: added Tier 2 (`/shared-packages/node_modules/`) between local workspace (Tier 1) and npm global (now Tier 3)
- Agency CLI resolution: checks shared volume before falling back to npm global
- Error `checkedPaths` updated to include the shared volume path
- 3 new tests covering shared volume resolution for both speckit commands and agency CLI

## Test plan
- [x] All 47 tests pass (44 existing + 3 new)
- [ ] Verify in external project (cluster-templates) that `generacy setup build` Phase 4 resolves from `/shared-packages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)