### PR TITLE
fix: use git checkout -B to handle existing local branches in worker

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/repo-checkout.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/repo-checkout.test.ts
@@ -176,7 +176,7 @@ describe('RepoCheckout', () => {
 
       await checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop');
 
-      const call = findCall('git', ['checkout', '-b', 'develop', 'origin/develop']);
+      const call = findCall('git', ['checkout', '-B', 'develop', 'origin/develop']);
       expect(call).toBeDefined();
     });
 
@@ -361,7 +361,7 @@ describe('RepoCheckout', () => {
 
       await checkout.switchBranch('/workspace/worker-1/octocat/repo', 'feature-42');
 
-      const call = findCall('git', ['checkout', '-b', 'feature-42', 'origin/feature-42']);
+      const call = findCall('git', ['checkout', '-B', 'feature-42', 'origin/feature-42']);
       expect(call).toBeDefined();
     });
 

--- a/packages/orchestrator/src/worker/repo-checkout.ts
+++ b/packages/orchestrator/src/worker/repo-checkout.ts
@@ -108,7 +108,7 @@ export class RepoCheckout {
       await execFileAsync('git', ['checkout', branch], { cwd: checkoutPath });
     } catch {
       this.logger.debug({ checkoutPath, branch }, 'Local branch not found, creating tracking branch');
-      await execFileAsync('git', ['checkout', '-b', branch, `origin/${branch}`], {
+      await execFileAsync('git', ['checkout', '-B', branch, `origin/${branch}`], {
         cwd: checkoutPath,
       });
     }
@@ -202,7 +202,7 @@ export class RepoCheckout {
         { checkoutPath, branch },
         'Local branch not found, creating tracking branch',
       );
-      await execFileAsync('git', ['checkout', '-b', branch, `origin/${branch}`], {
+      await execFileAsync('git', ['checkout', '-B', branch, `origin/${branch}`], {
         cwd: checkoutPath,
       });
     }


### PR DESCRIPTION
## Summary

- Fixes worker crash when `git checkout -b <branch>` fails with "a branch named 'X' already exists" during repo checkout
- Changes `-b` (create new) to `-B` (create or reset) in both `updateRepo()` and `switchBranch()` methods in `repo-checkout.ts`
- This was causing all items on worker-4 (including #363) to fail and dead-letter after 3 retries

## Root Cause

When multiple workers share a bootstrapped repo checkout, `git checkout <branch>` can fail for reasons other than "branch doesn't exist" (e.g. dirty state, concurrent access). The fallback `git checkout -b` then also fails because the branch *does* exist locally. Using `-B` handles both "branch exists" and "branch doesn't exist" cases.

## Test plan

- [x] Unit tests updated and passing (32/32)
- [ ] Verify worker-4 can process queued items after deploying this fix

Fixes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)