### PR TITLE
fix: clarification answer parsing fails for heading-format answers

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
@@ -553,6 +553,108 @@ describe('integrateClarificationAnswers', () => {
     expect(result.reason).toBe('no-answers');
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
+
+  it('integrates answers from heading format (### Q1: Topic + **Answer: X**)', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: 1,
+        body: `## Clarification Answers
+
+### Q1: Authentication method
+**Answer: A** — OAuth 2.0 is the standard for our stack.
+
+We already use OAuth in the existing services.
+
+### Q2: Database choice
+**Answer: B** — Use PostgreSQL for consistency with our other services.`,
+      },
+    ]);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(2);
+    const writtenContent = mockWriteFileSync.mock.calls[0]![1] as string;
+    expect(writtenContent).toContain('**Answer**: A — OAuth 2.0 is the standard for our stack.');
+    expect(writtenContent).toContain('**Answer**: B — Use PostgreSQL for consistency with our other services.');
+    // No phantom Q2 injected into Q1's section
+    expect(writtenContent).not.toContain('**Answer**: *Pending*');
+  });
+
+  it('heading-format answers override template instructions text (last wins)', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      // System-posted comment with template instructions
+      {
+        id: 1,
+        body: `<!-- generacy-clarifications:42 -->
+## Clarification Questions
+
+### Q1: Authentication method
+**Context**: The spec mentions user auth.
+**Question**: Which authentication method?
+
+---
+
+**How to answer**: Reply to this issue with your answers in the format:
+\`\`\`
+Q1: your answer here
+Q2: your answer here
+\`\`\`
+`,
+      },
+      // User's answer in heading format
+      {
+        id: 2,
+        body: `## Answers
+
+### Q1: Authentication method
+**Answer: A** — Use OAuth 2.0.
+
+### Q2: Database choice
+**Answer**: PostgreSQL`,
+      },
+    ]);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(2);
+    const writtenContent = mockWriteFileSync.mock.calls[0]![1] as string;
+    // Real answers should win, not "your answer here" from template
+    expect(writtenContent).toContain('**Answer**: A — Use OAuth 2.0.');
+    expect(writtenContent).toContain('**Answer**: PostgreSQL');
+    expect(writtenContent).not.toContain('your answer here');
+  });
+
+  it('does not treat *Pending* from question comments as real answers', async () => {
+    mockReaddirSync.mockReturnValue(['42-feature-branch']);
+    mockReadFileSync.mockReturnValue(SAMPLE_CLARIFICATIONS);
+    // Only the question comment exists — no user answers
+    (context.github.getIssueComments as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: 1,
+        body: `### Q1: Authentication method
+**Context**: The spec mentions user auth.
+**Question**: Which authentication method?
+
+**Answer**: *Pending*
+
+### Q2: Database choice
+**Context**: Multiple databases could work.
+**Question**: PostgreSQL or MongoDB?
+
+**Answer**: *Pending*`,
+      },
+    ]);
+
+    const result = await integrateClarificationAnswers(context, logger);
+
+    expect(result.integrated).toBe(0);
+    expect(result.reason).toBe('no-answers');
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/orchestrator/src/worker/clarification-poster.ts
+++ b/packages/orchestrator/src/worker/clarification-poster.ts
@@ -244,11 +244,42 @@ export function hasPendingClarifications(
 // ---------------------------------------------------------------------------
 
 /**
+ * Extract the actual answer from a multi-line captured section.
+ *
+ * When Q is inside a heading (`### Q1: Topic`), the text after `Q1:` starts
+ * with the topic name, not the answer. This helper looks for an embedded
+ * `**Answer: value**` or `**Answer**: value` line and returns the answer
+ * portion. Returns `undefined` if no embedded answer is found.
+ */
+function extractEmbeddedAnswer(text: string): string | undefined {
+  // Format: **Answer: value** with optional trailing text
+  const m1 = text.match(/\*\*Answer:\s*(.+?)\*\*(.*)$/m);
+  if (m1) {
+    return (m1[1]! + m1[2]!).trim();
+  }
+
+  // Format: **Answer**: value
+  const m2 = text.match(/\*\*Answer\*\*:\s*(.+)$/m);
+  if (m2) {
+    return m2[1]!.trim();
+  }
+
+  return undefined;
+}
+
+/**
  * Parse answers from GitHub issue comments.
  *
  * Scans comment bodies for patterns like `Q1: answer text` and extracts
  * answers keyed by question number. Later answers for the same question
  * override earlier ones (last wins).
+ *
+ * Supports two answer formats:
+ * - Simple:  `Q1: answer text`
+ * - Heading: `### Q1: Topic\n**Answer: B** — explanation`
+ *
+ * For heading format, the actual answer is extracted from the embedded
+ * `**Answer**` line rather than the topic name after `Q1:`.
  */
 function parseAnswersFromComments(
   comments: Array<{ body: string }>,
@@ -257,8 +288,12 @@ function parseAnswersFromComments(
   const answers = new Map<number, string>();
 
   for (const comment of comments) {
+    // Match Q patterns with optional heading markers (### Q1:) and bold (**Q1**:).
+    // The lookahead also handles heading-prefixed Q patterns so that sections
+    // like `### Q1: ...` and `### Q2: ...` are properly delimited instead of
+    // Q1 consuming everything up to $ when headings are used.
     const regex =
-      /(?:\*\*)?Q(\d+)(?:\*\*)?:\s*(.*?)(?=(?:\n(?:\*\*)?Q\d+(?:\*\*)?:)|$)/gs;
+      /(?:#{1,6}\s+)?(?:\*\*)?Q(\d+)(?:\*\*)?:\s*(.*?)(?=(?:\n(?:#{1,6}\s+)?(?:\*\*)?Q\d+(?:\*\*)?:)|$)/gs;
 
     let match: RegExpExecArray | null;
     while ((match = regex.exec(comment.body)) !== null) {
@@ -266,9 +301,19 @@ function parseAnswersFromComments(
       const answerStr = match[2];
       if (!numStr || answerStr === undefined) continue;
       const questionNumber = parseInt(numStr, 10);
-      const answer = answerStr.trim();
+      let answer = answerStr.trim();
 
-      if (answer && questionNumbers.includes(questionNumber)) {
+      // When Q is in a heading (### Q1: Topic), the captured text starts with
+      // the topic name, not the answer. Look for an embedded **Answer** line.
+      if (answer.includes('\n')) {
+        const embedded = extractEmbeddedAnswer(answer);
+        if (embedded) {
+          answer = embedded;
+        }
+      }
+
+      // Skip placeholder text that is not a real answer
+      if (answer && answer !== '*Pending*' && questionNumbers.includes(questionNumber)) {
         answers.set(questionNumber, answer);
       }
     }


### PR DESCRIPTION
## Summary
- The `parseAnswersFromComments` regex lookahead didn't handle markdown heading prefixes (`### Q1:`), so Q1's match consumed the entire comment body including Q2's section
- This injected a phantom unanswered Q2 into `clarifications.md`, causing `hasPendingClarifications()` to return `true` and re-activating the clarification gate in an infinite loop
- Discovered on #367 where the user posted answers in heading format (`### Q1: Topic` + `**Answer: B**`) but the gate kept re-activating

## Changes
- **Regex fix**: Updated the lookahead in `parseAnswersFromComments` to also match heading-prefixed Q patterns (`\n### Q1:`)
- **Answer extraction**: When captured text is multi-line (heading format), extracts the actual answer from the embedded `**Answer: X**` or `**Answer**: X` line instead of using the topic name
- **Pending filter**: Skips `*Pending*` placeholder text so question-listing comments don't pollute the answer map
- **Tests**: Added 3 new test cases covering heading-format answers, template text override (last wins), and `*Pending*` filtering

## Test plan
- [x] All 40 clarification-poster tests pass (37 existing + 3 new)
- [x] Full orchestrator test suite: no regressions (12 pre-existing failures in `claude-cli-worker.test.ts` unrelated to this change)
- [ ] Verify #367 resumes correctly after this fix is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)