### PR TITLE
fix: pass orchestratorUrl and orchestratorApiKey through relay client

### DIFF
--- a/packages/cluster-relay/src/relay.ts
+++ b/packages/cluster-relay/src/relay.ts
@@ -25,6 +25,10 @@ export interface ClusterRelayClientOptions {
   cloudUrl?: string;
   /** Base reconnect delay in ms (default: 5000) */
   baseReconnectDelayMs?: number;
+  /** URL of the local orchestrator API (default: http://localhost:3000) */
+  orchestratorUrl?: string;
+  /** API key for authenticating relay-proxied requests to the orchestrator */
+  orchestratorApiKey?: string;
 }
 
 type EventMap = {
@@ -76,6 +80,8 @@ export class ClusterRelay {
         apiKey: opts.apiKey,
         relayUrl: opts.cloudUrl,
         baseReconnectDelayMs: opts.baseReconnectDelayMs,
+        orchestratorUrl: opts.orchestratorUrl,
+        orchestratorApiKey: opts.orchestratorApiKey,
       });
     }
     this.logger = logger ?? defaultLogger;

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import Fastify, { type FastifyInstance, type FastifyServerOptions } from 'fastify';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
@@ -258,9 +259,20 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
     try {
       // Dynamic import — @generacy-ai/cluster-relay may not be installed yet (Phase 2.1)
       const { ClusterRelayClient: RelayClientImpl } = await import('@generacy-ai/cluster-relay');
+
+      // Generate internal API key for relay-proxied requests
+      const relayInternalKey = crypto.randomUUID();
+      apiKeyStore.addKey(relayInternalKey, {
+        name: 'relay-internal',
+        scopes: ['admin'],
+        createdAt: new Date().toISOString(),
+      });
+
       const relayClient = new RelayClientImpl({
         apiKey: config.relay.apiKey,
         cloudUrl: config.relay.cloudUrl,
+        orchestratorUrl: `http://127.0.0.1:${config.server.port}`,
+        orchestratorApiKey: relayInternalKey,
       });
       relayBridge = new RelayBridge({
         client: relayClient,

--- a/packages/orchestrator/src/types/relay.ts
+++ b/packages/orchestrator/src/types/relay.ts
@@ -61,6 +61,12 @@ export interface ClusterRelayClientOptions {
 
   /** Base reconnect delay in ms (default: 5000). Backoff: 5s→10s→20s→...→300s. */
   baseReconnectDelayMs?: number;
+
+  /** URL of the local orchestrator API (default: http://localhost:3000) */
+  orchestratorUrl?: string;
+
+  /** API key for authenticating relay-proxied requests to the orchestrator */
+  orchestratorApiKey?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- **Fix wrong port**: The `ClusterRelayClientOptions` interface lacked `orchestratorUrl`, causing relay-proxied HTTP requests to hit the default `http://localhost:3000` instead of the orchestrator's actual port (3100), resulting in 502 errors.
- **Fix missing auth**: The orchestrator never generated or passed an internal API key for relay-proxied requests. The proxy's `X-API-Key` header was always empty, resulting in 401 errors.
- **Solution**: Added `orchestratorUrl` and `orchestratorApiKey` to `ClusterRelayClientOptions` (both cluster-relay and orchestrator type definitions), forwarded them through the constructor, and generated+registered an internal admin API key during relay initialization in `server.ts`.

## Changes

| File | Change |
|------|--------|
| `packages/cluster-relay/src/relay.ts` | Added `orchestratorUrl` and `orchestratorApiKey` to `ClusterRelayClientOptions`; forward them in constructor |
| `packages/orchestrator/src/server.ts` | Import `crypto`; generate internal API key, register in `apiKeyStore`, pass both fields to relay client |
| `packages/orchestrator/src/types/relay.ts` | Added `orchestratorUrl` and `orchestratorApiKey` to the orchestrator's copy of `ClusterRelayClientOptions` |

## Test plan

- [x] `pnpm --filter @generacy-ai/cluster-relay build` passes
- [x] `pnpm --filter @generacy-ai/orchestrator exec tsc --noEmit` passes
- [ ] Verify relay-proxied API requests reach the orchestrator on the correct port (no more 502)
- [ ] Verify relay-proxied API requests include `X-API-Key` header and pass auth (no more 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)