### PR TITLE
fix: spawn refactor post-merge cleanup

### DIFF
--- a/packages/generacy/src/agency/subprocess.ts
+++ b/packages/generacy/src/agency/subprocess.ts
@@ -115,10 +115,10 @@ export class SubprocessAgency implements AgencyConnection {
 
         this.process = handle.process;
 
-        handle.process.exitPromise.then((code) => {
+        handle.process.exitPromise.then((code: number | null) => {
           this.connected = false;
           this.logger.info(`Agency process exited with code ${code}`);
-        }, (error) => {
+        }, (error: unknown) => {
           clearTimeout(timeoutId);
           this.logger.error(`Agency process error: ${error instanceof Error ? error.message : String(error)}`);
           reject(error instanceof Error ? error : new Error(String(error)));
@@ -145,11 +145,11 @@ export class SubprocessAgency implements AgencyConnection {
         });
       }
 
-      this.process.stdout?.on('data', (data: Buffer) => {
+      this.process!.stdout?.on('data', (data: Buffer) => {
         this.handleData(data.toString());
       });
 
-      this.process.stderr?.on('data', (data: Buffer) => {
+      this.process!.stderr?.on('data', (data: Buffer) => {
         this.logger.warn(`Agency stderr: ${data.toString()}`);
       });
 

--- a/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
+++ b/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
@@ -36,6 +36,8 @@ import type {
   QueueAdapter,
 } from '../types/index.js';
 import type { Logger } from '../worker/types.js';
+import { AgentLauncher } from '../launcher/agent-launcher.js';
+import { ClaudeCodeLaunchPlugin } from '@generacy-ai/generacy-plugin-claude-code';
 
 // ==========================================================================
 // Mock GitHub Client
@@ -1660,6 +1662,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
   let phaseTracker: MockPhaseTracker;
   let monitorService: PrFeedbackMonitorService;
   let processFactory: any;
+  let agentLauncher: AgentLauncher;
   let mockProcess: any;
 
   beforeEach(async () => {
@@ -1757,6 +1760,8 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     processFactory = {
       spawn: vi.fn(() => mockProcess),
     };
+    agentLauncher = new AgentLauncher(new Map([['default', processFactory]]));
+    agentLauncher.registerPlugin(new ClaudeCodeLaunchPlugin());
   });
 
   afterEach(() => {
@@ -1794,7 +1799,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
         gates: {},
       },
       logger,
-      processFactory,
+      agentLauncher,
     );
 
     // Create queue item
@@ -1959,7 +1964,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
         gates: {},
       },
       logger,
-      processFactory,
+      agentLauncher,
     );
 
     const queueItem = {
@@ -2014,7 +2019,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
         gates: {},
       },
       logger,
-      processFactory,
+      agentLauncher,
     );
 
     const queueItem = {
@@ -2079,7 +2084,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
         gates: {},
       },
       logger,
-      processFactory,
+      agentLauncher,
     );
 
     const queueItem = {
@@ -2147,7 +2152,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
         gates: {},
       },
       logger,
-      processFactory,
+      agentLauncher,
     );
 
     const queueItem = {
@@ -2229,7 +2234,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
         gates: {},
       },
       logger,
-      processFactory,
+      agentLauncher,
     );
 
     const queueItem = {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -234,6 +234,7 @@ export {
 // Launcher
 export {
   createAgentLauncher,
+  type AgentLauncher,
   type GenericSubprocessIntent,
   type ShellIntent,
   type LaunchIntent,

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -233,8 +233,6 @@ export {
 
 // Launcher
 export {
-  AgentLauncher,
-  GenericSubprocessPlugin,
   createAgentLauncher,
   type GenericSubprocessIntent,
   type ShellIntent,

--- a/packages/orchestrator/src/test-utils/index.ts
+++ b/packages/orchestrator/src/test-utils/index.ts
@@ -7,7 +7,7 @@
  * import { RecordingProcessFactory, normalizeSpawnRecords } from '../test-utils/index.js';
  *
  * const factory = new RecordingProcessFactory();
- * const spawner = new CliSpawner(factory, logger);
+ * const spawner = new CliSpawner(launcher, logger);
  *
  * await spawner.spawnPhase('implement', options, capture);
  *

--- a/packages/orchestrator/src/worker/__tests__/__snapshots__/pr-feedback-handler.test.ts.snap
+++ b/packages/orchestrator/src/worker/__tests__/__snapshots__/pr-feedback-handler.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`PrFeedbackHandler > Snapshot test: spawn-arg parity (T008) > launcher path produces identical spawn records to direct path 1`] = `
+exports[`PrFeedbackHandler > Snapshot test: spawn-arg composition (T008) > launcher path produces correct spawn records 1`] = `
 [
   {
     "args": [

--- a/packages/orchestrator/src/worker/__tests__/cli-spawner-snapshot.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/cli-spawner-snapshot.test.ts
@@ -34,7 +34,7 @@ describe('CliSpawner.spawnPhase — spawn snapshots', () => {
     const factory = new RecordingProcessFactory();
     const launcher = new AgentLauncher(new Map([['default', factory]]));
     launcher.registerPlugin(new ClaudeCodeLaunchPlugin());
-    const spawner = new CliSpawner(launcher, factory, noopLogger);
+    const spawner = new CliSpawner(launcher, noopLogger);
 
     const options: CliSpawnOptions = {
       prompt: 'https://github.com/org/repo/issues/42',
@@ -53,7 +53,7 @@ describe('CliSpawner.spawnPhase — spawn snapshots', () => {
     const factory = new RecordingProcessFactory();
     const launcher = new AgentLauncher(new Map([['default', factory]]));
     launcher.registerPlugin(new ClaudeCodeLaunchPlugin());
-    const spawner = new CliSpawner(launcher, factory, noopLogger);
+    const spawner = new CliSpawner(launcher, noopLogger);
 
     const options: CliSpawnOptions = {
       prompt: 'https://github.com/org/repo/issues/42',

--- a/packages/orchestrator/src/worker/__tests__/cli-spawner.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/cli-spawner.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '../types.js';
 import type { OutputCapture } from '../output-capture.js';
 import { AgentLauncher } from '../../launcher/agent-launcher.js';
+import { GenericSubprocessPlugin } from '../../launcher/generic-subprocess-plugin.js';
 import { ClaudeCodeLaunchPlugin } from '@generacy-ai/generacy-plugin-claude-code';
 
 // ---------------------------------------------------------------------------
@@ -93,11 +94,12 @@ describe('CliSpawner', () => {
   beforeEach(() => {
     spawnFn = vi.fn();
     factory = { spawn: spawnFn } as unknown as ProcessFactory;
-    // Wire AgentLauncher with real ClaudeCodeLaunchPlugin and mock factory
+    // Wire AgentLauncher with real plugins and mock factory
     const agentLauncher = new AgentLauncher(new Map([['default', factory]]));
     agentLauncher.registerPlugin(new ClaudeCodeLaunchPlugin());
+    agentLauncher.registerPlugin(new GenericSubprocessPlugin());
     // Use a short grace period (50ms) for tests
-    spawner = new CliSpawner(agentLauncher, factory, mockLogger, 50);
+    spawner = new CliSpawner(agentLauncher, mockLogger, 50);
   });
 
   describe('spawnPhase - successful spawn', () => {

--- a/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.test.ts
@@ -12,7 +12,6 @@ import type { WorkerConfig } from '../config.js';
 import { AgentLauncher } from '../../launcher/agent-launcher.js';
 import { ClaudeCodeLaunchPlugin } from '@generacy-ai/generacy-plugin-claude-code';
 import { RecordingProcessFactory } from '../../test-utils/recording-process-factory.js';
-import { normalizeSpawnRecords } from '../../test-utils/spawn-snapshot.js';
 
 // ---------------------------------------------------------------------------
 // Mock Logger
@@ -149,10 +148,12 @@ describe('PrFeedbackHandler', () => {
     vi.clearAllMocks();
     spawnFn = vi.fn();
     processFactory = { spawn: spawnFn } as unknown as ProcessFactory;
+    const agentLauncher = new AgentLauncher(new Map([['default', processFactory]]));
+    agentLauncher.registerPlugin(new ClaudeCodeLaunchPlugin());
     handler = new PrFeedbackHandler(
       defaultConfig,
       mockLogger,
-      processFactory,
+      agentLauncher,
     );
 
     // Default mock implementations
@@ -761,8 +762,6 @@ describe('PrFeedbackHandler', () => {
       const launcherHandler = new PrFeedbackHandler(
         defaultConfig,
         mockLogger,
-        processFactory,
-        undefined,
         agentLauncher,
       );
 
@@ -802,54 +801,23 @@ describe('PrFeedbackHandler', () => {
     });
   });
 
-  describe('Snapshot test: spawn-arg parity (T008)', () => {
-    it('launcher path produces identical spawn records to direct path', async () => {
-      // --- Direct path ---
-      const directFactory = new RecordingProcessFactory(0);
-      const directSpawn = vi.fn((...args: Parameters<ProcessFactory['spawn']>) =>
-        directFactory.spawn(...args),
-      );
-      const directProcessFactory = { spawn: directSpawn } as unknown as ProcessFactory;
-
-      const directHandler = new PrFeedbackHandler(
-        defaultConfig,
-        mockLogger,
-        directProcessFactory,
-      );
-
-      const item = createQueueItem({ prNumber: 100, reviewThreadIds: [1] });
-      const checkoutPath = '/tmp/workspace/test-owner/test-repo';
-
-      mockGitHub.getPRComments = vi.fn().mockResolvedValue([
-        createMockComment(1, false),
-      ]);
-
-      mockGitHub.getStatus = vi.fn().mockResolvedValue({
-        has_changes: false,
-        staged: [],
-        unstaged: [],
-        untracked: [],
-      });
-
-      await directHandler.handle(item, checkoutPath);
-
-      // --- Launcher path ---
+  describe('Snapshot test: spawn-arg composition (T008)', () => {
+    it('launcher path produces correct spawn records', async () => {
       const launcherFactory = new RecordingProcessFactory(0);
       const agentLauncher = new AgentLauncher(
         new Map([['default', launcherFactory]]),
       );
       agentLauncher.registerPlugin(new ClaudeCodeLaunchPlugin());
 
-      const launcherProcessFactory = { spawn: vi.fn() } as unknown as ProcessFactory;
       const launcherHandler = new PrFeedbackHandler(
         defaultConfig,
         mockLogger,
-        launcherProcessFactory,
-        undefined,
         agentLauncher,
       );
 
-      // Reset mocks for second run
+      const item = createQueueItem({ prNumber: 100, reviewThreadIds: [1] });
+      const checkoutPath = '/tmp/workspace/test-owner/test-repo';
+
       mockGitHub.getPRComments = vi.fn().mockResolvedValue([
         createMockComment(1, false),
       ]);
@@ -862,17 +830,7 @@ describe('PrFeedbackHandler', () => {
 
       await launcherHandler.handle(item, checkoutPath);
 
-      // Both paths should have recorded exactly one spawn call
-      expect(directFactory.calls).toHaveLength(1);
       expect(launcherFactory.calls).toHaveLength(1);
-
-      // Normalize and compare command + args (env differs due to 3-layer merge)
-      const directRecord = directFactory.calls[0];
-      const launcherRecord = launcherFactory.calls[0];
-
-      expect(launcherRecord.command).toBe(directRecord.command);
-      expect(launcherRecord.args).toEqual(directRecord.args);
-      expect(launcherRecord.cwd).toBe(directRecord.cwd);
 
       // Snapshot command/args/cwd for regression detection (env excluded —
       // AgentLauncher's 3-layer merge includes process.env which varies between runs)

--- a/packages/orchestrator/src/worker/claude-cli-worker.ts
+++ b/packages/orchestrator/src/worker/claude-cli-worker.ts
@@ -34,7 +34,7 @@ export const defaultProcessFactory: ProcessFactory = {
   ): ChildProcessHandle {
     const child: ChildProcess = spawn(command, args, {
       cwd: options.cwd,
-      env: { ...process.env, ...options.env },
+      env: options.env,
       stdio: ['ignore', 'pipe', 'pipe'],
       ...(options.uid !== undefined && { uid: options.uid }),
       ...(options.gid !== undefined && { gid: options.gid }),
@@ -208,9 +208,8 @@ export class ClaudeCliWorker {
         const prFeedbackHandler = new PrFeedbackHandler(
           this.config,
           workerLogger,
-          this.processFactory,
-          this.sseEmitter,
           this.agentLauncher,
+          this.sseEmitter,
         );
 
         await prFeedbackHandler.handle(item, checkoutPath);
@@ -333,7 +332,6 @@ export class ClaudeCliWorker {
 
       const cliSpawner = new CliSpawner(
         this.agentLauncher,
-        this.processFactory,
         workerLogger,
         this.config.shutdownGracePeriodMs,
       );

--- a/packages/orchestrator/src/worker/cli-spawner.ts
+++ b/packages/orchestrator/src/worker/cli-spawner.ts
@@ -3,11 +3,11 @@ import type {
   ChildProcessHandle,
   Logger,
   PhaseResult,
-  ProcessFactory,
   WorkflowPhase,
 } from './types.js';
 import type { OutputCapture } from './output-capture.js';
 import type { AgentLauncher } from '../launcher/agent-launcher.js';
+import type { ShellIntent } from '../launcher/types.js';
 
 /** Default timeout for the validate phase (10 minutes). */
 const DEFAULT_VALIDATE_TIMEOUT_MS = 600_000;
@@ -23,7 +23,6 @@ const DEFAULT_INSTALL_TIMEOUT_MS = 300_000;
 export class CliSpawner {
   constructor(
     private readonly agentLauncher: AgentLauncher,
-    private readonly processFactory: ProcessFactory,
     private readonly logger: Logger,
     private readonly shutdownGracePeriodMs: number = 5000,
   ) {}
@@ -86,12 +85,14 @@ export class CliSpawner {
       'Spawning validation command',
     );
 
-    const child = this.processFactory.spawn('sh', ['-c', validateCommand], {
+    const intent: ShellIntent = { kind: 'shell', command: validateCommand };
+    const handle = this.agentLauncher.launch({
+      intent,
       cwd: checkoutPath,
-      env: {} as Record<string, string>,
+      env: {},
     });
 
-    return this.manageProcess(child, phase, timeoutMs, signal, undefined);
+    return this.manageProcess(handle.process, phase, timeoutMs, signal, undefined);
   }
 
   /**
@@ -113,12 +114,14 @@ export class CliSpawner {
       'Spawning pre-validate install command',
     );
 
-    const child = this.processFactory.spawn('sh', ['-c', installCommand], {
+    const intent: ShellIntent = { kind: 'shell', command: installCommand };
+    const handle = this.agentLauncher.launch({
+      intent,
       cwd: checkoutPath,
-      env: {} as Record<string, string>,
+      env: {},
     });
 
-    return this.manageProcess(child, phase, timeoutMs, signal, undefined);
+    return this.manageProcess(handle.process, phase, timeoutMs, signal, undefined);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/orchestrator/src/worker/pr-feedback-handler.ts
+++ b/packages/orchestrator/src/worker/pr-feedback-handler.ts
@@ -1,7 +1,7 @@
 import { createGitHubClient } from '@generacy-ai/workflow-engine';
 import type { GitHubClient } from '@generacy-ai/workflow-engine';
 import type { QueueItem, PrFeedbackMetadata } from '../types/index.js';
-import type { Logger, ProcessFactory } from './types.js';
+import type { Logger } from './types.js';
 import type { WorkerConfig } from './config.js';
 import type { SSEEventEmitter } from './output-capture.js';
 import type { AgentLauncher } from '../launcher/agent-launcher.js';
@@ -65,9 +65,8 @@ export class PrFeedbackHandler {
   constructor(
     private readonly config: WorkerConfig,
     private readonly logger: Logger,
-    private readonly processFactory: ProcessFactory,
+    private readonly agentLauncher: AgentLauncher,
     private readonly sseEmitter?: SSEEventEmitter,
-    private readonly agentLauncher?: AgentLauncher,
   ) {
     this.repoCheckout = new RepoCheckout(config.workspaceDir, logger);
   }
@@ -292,14 +291,6 @@ Please proceed with addressing the feedback.`;
     workflowId: string,
     prNumber: number,
   ): Promise<boolean> {
-    const args = [
-      '-p',
-      '--output-format', 'stream-json',
-      '--dangerously-skip-permissions',
-      '--verbose',
-      prompt,
-    ];
-
     this.logger.info(
       { cwd: checkoutPath, timeoutMs: this.config.phaseTimeoutMs },
       'Spawning Claude CLI for PR feedback',
@@ -307,23 +298,16 @@ Please proceed with addressing the feedback.`;
 
     let child;
     try {
-      if (this.agentLauncher) {
-        const handle = this.agentLauncher.launch({
-          intent: {
-            kind: 'pr-feedback',
-            prNumber,
-            prompt,
-          } as PrFeedbackIntent,
-          cwd: checkoutPath,
-          env: {},
-        });
-        child = handle.process;
-      } else {
-        child = this.processFactory.spawn('claude', args, {
-          cwd: checkoutPath,
-          env: {} as Record<string, string>,
-        });
-      }
+      const handle = this.agentLauncher.launch({
+        intent: {
+          kind: 'pr-feedback',
+          prNumber,
+          prompt,
+        } as PrFeedbackIntent,
+        cwd: checkoutPath,
+        env: {},
+      });
+      child = handle.process;
     } catch (error) {
       this.logger.error(
         { error: String(error), cwd: checkoutPath },


### PR DESCRIPTION
## Summary

Four issues identified during post-merge review of the spawn refactor (#423):

- **Remove `AgentLauncher` from public exports** — only `createAgentLauncher` factory should be exported per resolved open question #1. The class was leaking from `packages/orchestrator/src/index.ts`.
- **Fix `defaultProcessFactory` env double-merge** — `AgentLauncher` owns the `process.env` base layer (per #425 Q4 answer C), so factories should pass env through unchanged. `conversationProcessFactory` was already correct; `defaultProcessFactory` still had `{ ...process.env, ...options.env }`.
- **Route `runValidatePhase`/`runPreValidateInstall` through AgentLauncher** — these were missed by #434 and still called `processFactory.spawn()` directly, bypassing the credentials interceptor when the credentials plan lands.
- **Remove dead fallback in `PrFeedbackHandler`** — the `else` branch spawning `'claude'` via `processFactory` is dead code now that `agentLauncher` is always wired in. Made `agentLauncher` required, removed `processFactory` dependency.

## Test plan

- [x] `pnpm -r --filter @generacy-ai/orchestrator build` passes
- [x] 78/79 test files pass (1515/1530 tests pass)
- [x] Pre-existing 15 failures in `claude-cli-worker.test.ts` are NOT caused by this PR (verified by running tests on clean `develop` — same failures exist)
- [ ] Verify no other packages are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)