### PR TITLE
fix: quote glob in preValidateCommand to prevent shell expansion

### DIFF
--- a/packages/orchestrator/src/worker/__tests__/cli-spawner.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/cli-spawner.test.ts
@@ -423,7 +423,7 @@ describe('CliSpawner', () => {
 describe('WorkerConfigSchema - preValidateCommand', () => {
   it('defaults to pnpm install && pnpm -r --filter ./packages/* build', () => {
     const config = WorkerConfigSchema.parse({});
-    expect(config.preValidateCommand).toBe('pnpm install && pnpm -r --filter ./packages/* build');
+    expect(config.preValidateCommand).toBe("pnpm install && pnpm -r --filter './packages/*' build");
   });
 
   it('accepts empty string', () => {

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.test.ts
@@ -95,7 +95,7 @@ function createConfig(overrides: Partial<WorkerConfig> = {}): WorkerConfig {
     workspaceDir: '/tmp',
     shutdownGracePeriodMs: 5000,
     validateCommand: 'pnpm test && pnpm build',
-    preValidateCommand: 'pnpm install && pnpm -r --filter ./packages/* build',
+    preValidateCommand: "pnpm install && pnpm -r --filter './packages/*' build",
     gates: {},
     maxImplementRetries: 2,
     ...overrides,

--- a/packages/orchestrator/src/worker/config.ts
+++ b/packages/orchestrator/src/worker/config.ts
@@ -26,7 +26,7 @@ export const WorkerConfigSchema = z.object({
   /** Command to run during the validate phase */
   validateCommand: z.string().default('pnpm test && pnpm build'),
   /** Command to run before validation to install dependencies (empty string to skip) */
-  preValidateCommand: z.string().default('pnpm install && pnpm -r --filter ./packages/* build'),
+  preValidateCommand: z.string().default("pnpm install && pnpm -r --filter './packages/*' build"),
   /** Maximum retries for implement phase when partial progress is detected */
   maxImplementRetries: z.number().int().min(0).max(5).default(2),
   /** Gate definitions keyed by issue label */


### PR DESCRIPTION
## Summary

- The `preValidateCommand` default (`pnpm -r --filter ./packages/* build`) runs via `sh -c`, which glob-expands `./packages/*` into 14 separate directory paths before pnpm sees it
- pnpm only receives the first directory as `--filter`, silently builds nothing, and exits 0
- The subsequent root `pnpm build` (tsc) then fails with exit code 2 against stale/missing package type declarations
- This is the root cause of all validate phase failures since #454 introduced the glob

## Root cause trace

```
sh -c 'pnpm -r --filter ./packages/* build'
```
expands to:
```
pnpm -r --filter ./packages/cluster-relay ./packages/config ... build
```
pnpm interprets only `--filter ./packages/cluster-relay`; the rest become misinterpreted args. Result: **no packages built**.

## Fix

Quote the glob so it reaches pnpm intact:
```
pnpm -r --filter './packages/*' build
```

## Test plan

- [x] `pnpm -r --filter './packages/*' build` confirmed to build all 14 packages on worker container
- [x] Unquoted version confirmed to build 0 packages (reproduced on tetrad-development-worker-2)
- [x] Orchestrator package builds (`tsc`)
- [x] cli-spawner.test.ts — 17/17 pass
- [x] phase-loop.test.ts — 22/22 pass

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)