### PR TITLE
feat: control-plane code-server lifecycle (cluster-base#12)

### DIFF
--- a/packages/control-plane/__tests__/integration/all-routes.test.ts
+++ b/packages/control-plane/__tests__/integration/all-routes.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { ControlPlaneServer } from '../../src/server.js';
+import {
+  setCodeServerManager,
+  type CodeServerManager,
+} from '../../src/services/code-server-manager.js';
 
 let server: ControlPlaneServer;
 let socketPath: string;
@@ -55,7 +59,16 @@ function request(
 }
 
 describe('integration: all routes', () => {
+  const fakeCodeServer: CodeServerManager = {
+    start: vi.fn(async () => ({ status: 'starting' as const, socket_path: '/run/code-server.sock' })),
+    stop: vi.fn(async () => {}),
+    touch: vi.fn(),
+    getStatus: vi.fn(() => 'stopped' as const),
+    shutdown: vi.fn(async () => {}),
+  };
+
   beforeAll(async () => {
+    setCodeServerManager(fakeCodeServer);
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cp-test-'));
     socketPath = path.join(tmpDir, 'control.sock');
     server = new ControlPlaneServer();
@@ -64,6 +77,7 @@ describe('integration: all routes', () => {
 
   afterAll(async () => {
     await server.close();
+    setCodeServerManager(null);
   });
 
   // GET /state
@@ -123,10 +137,18 @@ describe('integration: all routes', () => {
     expect(res.body).toEqual({ accepted: true, action: 'clone-peer-repos' });
   });
 
-  it('POST /lifecycle/code-server-start returns accepted', async () => {
+  it('POST /lifecycle/code-server-start returns runtime status + socket_path', async () => {
     const res = await request('POST', '/lifecycle/code-server-start');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ accepted: true, action: 'code-server-start' });
+    expect(fakeCodeServer.start).toHaveBeenCalled();
+    expect(res.body).toEqual({ status: 'starting', socket_path: '/run/code-server.sock' });
+  });
+
+  it('POST /lifecycle/code-server-stop calls manager.stop and returns accepted', async () => {
+    const res = await request('POST', '/lifecycle/code-server-stop');
+    expect(res.status).toBe(200);
+    expect(fakeCodeServer.stop).toHaveBeenCalled();
+    expect(res.body).toEqual({ accepted: true, action: 'code-server-stop' });
   });
 
   // POST /lifecycle/:action (invalid)

--- a/packages/control-plane/__tests__/routes/lifecycle.test.ts
+++ b/packages/control-plane/__tests__/routes/lifecycle.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { handlePostLifecycle } from '../../src/routes/lifecycle.js';
 import { ControlPlaneError } from '../../src/errors.js';
+import {
+  setCodeServerManager,
+  type CodeServerManager,
+} from '../../src/services/code-server-manager.js';
 
 function createMockResponse() {
   const headers: Record<string, string> = {};
@@ -18,7 +22,6 @@ function createMockResponse() {
     end: vi.fn((data?: string) => {
       if (data) body = data;
     }),
-    // Expose captured values for assertions
     get _headers() {
       return headers;
     },
@@ -37,7 +40,22 @@ function createMockResponse() {
   return res;
 }
 
+function createFakeManager(overrides: Partial<CodeServerManager> = {}): CodeServerManager {
+  return {
+    start: vi.fn(async () => ({ status: 'starting' as const, socket_path: '/tmp/cs.sock' })),
+    stop: vi.fn(async () => {}),
+    touch: vi.fn(),
+    getStatus: vi.fn(() => 'stopped' as const),
+    shutdown: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
 describe('handlePostLifecycle', () => {
+  afterEach(() => {
+    setCodeServerManager(null);
+  });
+
   it('returns 200 with accepted: true for clone-peer-repos', async () => {
     const req = {} as IncomingMessage;
     const res = createMockResponse();
@@ -49,23 +67,46 @@ describe('handlePostLifecycle', () => {
     expect(body).toEqual({ accepted: true, action: 'clone-peer-repos' });
   });
 
-  it('returns 200 with accepted: true for code-server-start', async () => {
+  it('starts code-server and returns its status + socket_path', async () => {
+    const manager = createFakeManager({
+      start: vi.fn(async () => ({ status: 'starting', socket_path: '/run/code-server.sock' })),
+    });
+    setCodeServerManager(manager);
+
     const req = {} as IncomingMessage;
     const res = createMockResponse();
-
     await handlePostLifecycle(req, res, {}, { action: 'code-server-start' });
 
+    expect(manager.start).toHaveBeenCalledOnce();
     expect(res.writeHead).toHaveBeenCalledWith(200);
     const body = JSON.parse(res._body);
-    expect(body).toEqual({ accepted: true, action: 'code-server-start' });
+    expect(body).toEqual({ status: 'starting', socket_path: '/run/code-server.sock' });
   });
 
-  it('returns 200 with accepted: true for code-server-stop', async () => {
+  it('surfaces SERVICE_UNAVAILABLE if code-server fails to start', async () => {
+    const manager = createFakeManager({
+      start: vi.fn(async () => {
+        throw new Error('binary not found');
+      }),
+    });
+    setCodeServerManager(manager);
+
+    await expect(
+      handlePostLifecycle({} as IncomingMessage, createMockResponse(), {}, {
+        action: 'code-server-start',
+      }),
+    ).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE', message: 'binary not found' });
+  });
+
+  it('stops code-server and returns accepted: true', async () => {
+    const manager = createFakeManager();
+    setCodeServerManager(manager);
+
     const req = {} as IncomingMessage;
     const res = createMockResponse();
-
     await handlePostLifecycle(req, res, {}, { action: 'code-server-stop' });
 
+    expect(manager.stop).toHaveBeenCalledOnce();
     expect(res.writeHead).toHaveBeenCalledWith(200);
     const body = JSON.parse(res._body);
     expect(body).toEqual({ accepted: true, action: 'code-server-stop' });

--- a/packages/control-plane/__tests__/services/code-server-manager.test.ts
+++ b/packages/control-plane/__tests__/services/code-server-manager.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import net from 'node:net';
+import path from 'node:path';
+import {
+  CodeServerProcessManager,
+  loadOptionsFromEnv,
+  DEFAULT_CODE_SERVER_BIN,
+  DEFAULT_CODE_SERVER_SOCKET,
+  DEFAULT_IDLE_TIMEOUT_MS,
+} from '../../src/services/code-server-manager.js';
+
+// Build a tiny shell script that pretends to be code-server: it parses the
+// --socket arg and binds a Unix socket so the manager's "running" detection
+// triggers. We then SIGTERM/SIGKILL it like the real binary.
+async function makeFakeCodeServer(scriptPath: string, listenerPath: string): Promise<void> {
+  const helper = `#!/usr/bin/env node
+const net = require('node:net');
+const fs = require('node:fs');
+
+const args = process.argv.slice(2);
+let socketPath = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--socket') socketPath = args[i + 1];
+}
+if (!socketPath) { console.error('no --socket arg'); process.exit(2); }
+
+try { fs.unlinkSync(socketPath); } catch (_) {}
+
+const server = net.createServer();
+server.listen(socketPath, () => {
+  process.send && process.send('ready');
+});
+
+let shutting = false;
+function shutdown() {
+  if (shutting) return;
+  shutting = true;
+  server.close(() => {
+    try { fs.unlinkSync(socketPath); } catch (_) {}
+    process.exit(0);
+  });
+}
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+// keep alive
+setInterval(() => {}, 1000);
+`;
+  await fs.writeFile(scriptPath, helper, { mode: 0o755 });
+  // listenerPath is unused in the script body; included so the test reads/cleans the same path.
+  void listenerPath;
+}
+
+describe('CodeServerProcessManager', () => {
+  let tmpDir: string;
+  let socketPath: string;
+  let fakeBin: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cs-mgr-'));
+    socketPath = path.join(tmpDir, 'code-server.sock');
+    fakeBin = path.join(tmpDir, 'fake-code-server.js');
+    await makeFakeCodeServer(fakeBin, socketPath);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('starts code-server, returns socket_path, and a TCP/Unix client can connect', async () => {
+    const mgr = new CodeServerProcessManager({
+      binPath: process.execPath,
+      socketPath,
+      idleTimeoutMs: 60_000,
+    });
+    // Override the binary spawn: we want node to run the fake script
+    const start = mgr.start();
+    // Patch by reissuing with an arg-prepending wrapper bin: instead, replace via subclassing.
+    // Simplest: re-create with a wrapper script.
+    await mgr.stop().catch(() => {});
+    await start.catch(() => {});
+
+    const wrapperBin = path.join(tmpDir, 'wrapper.sh');
+    await fs.writeFile(
+      wrapperBin,
+      `#!/bin/sh\nexec "${process.execPath}" "${fakeBin}" "$@"\n`,
+      { mode: 0o755 },
+    );
+
+    const wrapped = new CodeServerProcessManager({
+      binPath: wrapperBin,
+      socketPath,
+      idleTimeoutMs: 60_000,
+    });
+    const result = await wrapped.start();
+    expect(result.socket_path).toBe(socketPath);
+    expect(['starting', 'running']).toContain(result.status);
+
+    // Wait briefly until the socket exists, then connect.
+    await waitForFile(socketPath, 5000);
+    await new Promise<void>((resolve, reject) => {
+      const c = net.createConnection(socketPath);
+      c.on('connect', () => {
+        c.end();
+        resolve();
+      });
+      c.on('error', reject);
+    });
+
+    await wrapped.stop();
+    expect(wrapped.getStatus()).toBe('stopped');
+  });
+
+  it('start() is idempotent — second call returns the same socket and reuses the child', async () => {
+    const wrapperBin = path.join(tmpDir, 'wrapper.sh');
+    await fs.writeFile(
+      wrapperBin,
+      `#!/bin/sh\nexec "${process.execPath}" "${fakeBin}" "$@"\n`,
+      { mode: 0o755 },
+    );
+    const mgr = new CodeServerProcessManager({
+      binPath: wrapperBin,
+      socketPath,
+      idleTimeoutMs: 60_000,
+    });
+    const a = await mgr.start();
+    const b = await mgr.start();
+    expect(a.socket_path).toBe(b.socket_path);
+    await mgr.stop();
+  });
+
+  it('auto-stops after the configured idle window', async () => {
+    const wrapperBin = path.join(tmpDir, 'wrapper.sh');
+    await fs.writeFile(
+      wrapperBin,
+      `#!/bin/sh\nexec "${process.execPath}" "${fakeBin}" "$@"\n`,
+      { mode: 0o755 },
+    );
+    const mgr = new CodeServerProcessManager({
+      binPath: wrapperBin,
+      socketPath,
+      idleTimeoutMs: 150,
+      forceKillTimeoutMs: 1000,
+    });
+    await mgr.start();
+    await waitForFile(socketPath, 5000);
+    // Wait past the idle window — manager's setTimeout should fire and stop.
+    await waitFor(() => mgr.getStatus() === 'stopped', 3000);
+    expect(mgr.getStatus()).toBe('stopped');
+  });
+
+  it('touch() resets the idle timer', async () => {
+    const wrapperBin = path.join(tmpDir, 'wrapper.sh');
+    await fs.writeFile(
+      wrapperBin,
+      `#!/bin/sh\nexec "${process.execPath}" "${fakeBin}" "$@"\n`,
+      { mode: 0o755 },
+    );
+    const mgr = new CodeServerProcessManager({
+      binPath: wrapperBin,
+      socketPath,
+      idleTimeoutMs: 200,
+      forceKillTimeoutMs: 1000,
+    });
+    await mgr.start();
+    await waitForFile(socketPath, 5000);
+    // Touch repeatedly so the timer never fires within ~500ms
+    const start = Date.now();
+    while (Date.now() - start < 500) {
+      mgr.touch();
+      await sleep(50);
+    }
+    expect(mgr.getStatus()).not.toBe('stopped');
+    await mgr.stop();
+  });
+
+  it('stop() is a no-op when not running', async () => {
+    const mgr = new CodeServerProcessManager({
+      binPath: '/bin/false',
+      socketPath,
+      idleTimeoutMs: 60_000,
+    });
+    await expect(mgr.stop()).resolves.toBeUndefined();
+  });
+});
+
+describe('loadOptionsFromEnv', () => {
+  it('uses defaults when no env is set', () => {
+    const opts = loadOptionsFromEnv({});
+    expect(opts.binPath).toBe(DEFAULT_CODE_SERVER_BIN);
+    expect(opts.socketPath).toBe(DEFAULT_CODE_SERVER_SOCKET);
+    expect(opts.idleTimeoutMs).toBe(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(opts.userDataDir).toBeUndefined();
+    expect(opts.extensionsDir).toBeUndefined();
+  });
+
+  it('reads overrides from env', () => {
+    const opts = loadOptionsFromEnv({
+      CODE_SERVER_BIN: '/opt/code-server/bin/code-server',
+      CODE_SERVER_SOCKET_PATH: '/tmp/cs.sock',
+      CODE_SERVER_IDLE_TIMEOUT_MS: '1000',
+      CODE_SERVER_USER_DATA_DIR: '/data/code-server',
+      CODE_SERVER_EXTENSIONS_DIR: '/data/code-server/exts',
+    });
+    expect(opts.binPath).toBe('/opt/code-server/bin/code-server');
+    expect(opts.socketPath).toBe('/tmp/cs.sock');
+    expect(opts.idleTimeoutMs).toBe(1000);
+    expect(opts.userDataDir).toBe('/data/code-server');
+    expect(opts.extensionsDir).toBe('/data/code-server/exts');
+  });
+
+  it('falls back to default for non-positive idle timeouts', () => {
+    expect(loadOptionsFromEnv({ CODE_SERVER_IDLE_TIMEOUT_MS: '0' }).idleTimeoutMs).toBe(
+      DEFAULT_IDLE_TIMEOUT_MS,
+    );
+    expect(loadOptionsFromEnv({ CODE_SERVER_IDLE_TIMEOUT_MS: 'abc' }).idleTimeoutMs).toBe(
+      DEFAULT_IDLE_TIMEOUT_MS,
+    );
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitForFile(target: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fs.stat(target);
+      return;
+    } catch {
+      await sleep(25);
+    }
+  }
+  throw new Error(`timed out waiting for ${target}`);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(25);
+  }
+  throw new Error(`timed out waiting for predicate`);
+}

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -10,6 +10,7 @@ export {
   ClusterStateSchema,
   LifecycleActionSchema,
   LifecycleResponseSchema,
+  CodeServerStartResponseSchema,
   CredentialStubResponseSchema,
   ErrorResponseSchema,
   CredentialEntrySchema,
@@ -21,12 +22,28 @@ export {
   type ClusterState,
   type LifecycleAction,
   type LifecycleResponse,
+  type CodeServerStartResponse,
   type CredentialStubResponse,
   type ErrorResponse,
   type CredentialEntry,
   type RoleConfig,
   type RoleCredentialRef,
 } from './schemas.js';
+
+// Services
+export {
+  CodeServerProcessManager,
+  getCodeServerManager,
+  setCodeServerManager,
+  loadOptionsFromEnv,
+  DEFAULT_CODE_SERVER_BIN,
+  DEFAULT_CODE_SERVER_SOCKET,
+  DEFAULT_IDLE_TIMEOUT_MS,
+  type CodeServerManager,
+  type CodeServerManagerOptions,
+  type CodeServerStartResult,
+  type CodeServerStatus,
+} from './services/code-server-manager.js';
 
 // Errors
 export {

--- a/packages/control-plane/src/routes/lifecycle.ts
+++ b/packages/control-plane/src/routes/lifecycle.ts
@@ -2,6 +2,7 @@ import type http from 'node:http';
 import type { ActorContext } from '../context.js';
 import { LifecycleActionSchema } from '../schemas.js';
 import { ControlPlaneError } from '../errors.js';
+import { getCodeServerManager } from '../services/code-server-manager.js';
 
 export async function handlePostLifecycle(
   _req: http.IncomingMessage,
@@ -16,12 +17,32 @@ export async function handlePostLifecycle(
     throw new ControlPlaneError('UNKNOWN_ACTION', `Unknown lifecycle action: ${action}`);
   }
 
-  const body = {
-    accepted: true as const,
-    action: parsed.data,
-  };
-
   res.setHeader('Content-Type', 'application/json');
+
+  if (parsed.data === 'code-server-start') {
+    const manager = getCodeServerManager();
+    let result;
+    try {
+      result = await manager.start();
+    } catch (err) {
+      throw new ControlPlaneError(
+        'SERVICE_UNAVAILABLE',
+        err instanceof Error ? err.message : 'Failed to start code-server',
+      );
+    }
+    res.writeHead(200);
+    res.end(JSON.stringify(result));
+    return;
+  }
+
+  if (parsed.data === 'code-server-stop') {
+    const manager = getCodeServerManager();
+    await manager.stop();
+    res.writeHead(200);
+    res.end(JSON.stringify({ accepted: true, action: parsed.data }));
+    return;
+  }
+
   res.writeHead(200);
-  res.end(JSON.stringify(body));
+  res.end(JSON.stringify({ accepted: true, action: parsed.data }));
 }

--- a/packages/control-plane/src/schemas.ts
+++ b/packages/control-plane/src/schemas.ts
@@ -42,6 +42,14 @@ export const LifecycleResponseSchema = z.object({
 });
 export type LifecycleResponse = z.infer<typeof LifecycleResponseSchema>;
 
+// code-server-start returns its own runtime status + socket path so the caller
+// (typically the cloud UI proxying through the relay) can connect immediately.
+export const CodeServerStartResponseSchema = z.object({
+  status: z.enum(['starting', 'running']),
+  socket_path: z.string(),
+});
+export type CodeServerStartResponse = z.infer<typeof CodeServerStartResponseSchema>;
+
 // Credential stub response (wraps entry with runtime status)
 export const CredentialStubResponseSchema = z.object({
   id: z.string(),

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import { extractActorContext } from './context.js';
 import { ControlPlaneError, sendError } from './errors.js';
 import { dispatch } from './router.js';
+import { getCodeServerManager } from './services/code-server-manager.js';
 
 export class ControlPlaneServer {
   private server: http.Server;
@@ -61,6 +62,11 @@ export class ControlPlaneServer {
   close(): Promise<void> {
     return new Promise((resolve) => {
       this.server.close(async () => {
+        try {
+          await getCodeServerManager().shutdown();
+        } catch {
+          // Best-effort: don't block server shutdown on a wedged code-server child
+        }
         if (this.socketPath) {
           try {
             await fs.unlink(this.socketPath);

--- a/packages/control-plane/src/services/code-server-manager.ts
+++ b/packages/control-plane/src/services/code-server-manager.ts
@@ -1,0 +1,200 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export type CodeServerStatus = 'stopped' | 'starting' | 'running';
+
+export interface CodeServerStartResult {
+  status: 'starting' | 'running';
+  socket_path: string;
+}
+
+export interface CodeServerManager {
+  start(): Promise<CodeServerStartResult>;
+  stop(): Promise<void>;
+  touch(): void;
+  getStatus(): CodeServerStatus;
+  shutdown(): Promise<void>;
+}
+
+export interface CodeServerManagerOptions {
+  binPath: string;
+  socketPath: string;
+  idleTimeoutMs: number;
+  userDataDir?: string;
+  extensionsDir?: string;
+  forceKillTimeoutMs?: number;
+}
+
+export const DEFAULT_CODE_SERVER_BIN = '/usr/local/bin/code-server';
+export const DEFAULT_CODE_SERVER_SOCKET = '/run/code-server.sock';
+export const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+export function loadOptionsFromEnv(env: NodeJS.ProcessEnv = process.env): CodeServerManagerOptions {
+  const idleRaw = env['CODE_SERVER_IDLE_TIMEOUT_MS'];
+  const idleTimeoutMs = idleRaw ? Number.parseInt(idleRaw, 10) : DEFAULT_IDLE_TIMEOUT_MS;
+
+  const opts: CodeServerManagerOptions = {
+    binPath: env['CODE_SERVER_BIN'] ?? DEFAULT_CODE_SERVER_BIN,
+    socketPath: env['CODE_SERVER_SOCKET_PATH'] ?? DEFAULT_CODE_SERVER_SOCKET,
+    idleTimeoutMs:
+      Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0 ? idleTimeoutMs : DEFAULT_IDLE_TIMEOUT_MS,
+  };
+  if (env['CODE_SERVER_USER_DATA_DIR']) opts.userDataDir = env['CODE_SERVER_USER_DATA_DIR'];
+  if (env['CODE_SERVER_EXTENSIONS_DIR']) opts.extensionsDir = env['CODE_SERVER_EXTENSIONS_DIR'];
+  return opts;
+}
+
+export class CodeServerProcessManager implements CodeServerManager {
+  private child: ChildProcess | null = null;
+  private status: CodeServerStatus = 'stopped';
+  private idleTimer: NodeJS.Timeout | null = null;
+  private exitWaiters: Array<() => void> = [];
+
+  constructor(private readonly opts: CodeServerManagerOptions) {}
+
+  getStatus(): CodeServerStatus {
+    return this.status;
+  }
+
+  async start(): Promise<CodeServerStartResult> {
+    if (this.child) {
+      this.touch();
+      return { status: this.status === 'running' ? 'running' : 'starting', socket_path: this.opts.socketPath };
+    }
+
+    await this.ensureSocketDir();
+    await this.removeStaleSocket();
+
+    const args = [
+      '--socket', this.opts.socketPath,
+      '--socket-mode', '0660',
+      '--auth', 'none',
+      '--disable-telemetry',
+      '--disable-update-check',
+    ];
+    if (this.opts.userDataDir) args.push('--user-data-dir', this.opts.userDataDir);
+    if (this.opts.extensionsDir) args.push('--extensions-dir', this.opts.extensionsDir);
+
+    this.status = 'starting';
+    const child = spawn(this.opts.binPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: false,
+    });
+
+    child.on('exit', () => {
+      this.child = null;
+      this.status = 'stopped';
+      this.clearIdleTimer();
+      const waiters = this.exitWaiters;
+      this.exitWaiters = [];
+      for (const w of waiters) w();
+    });
+
+    child.on('error', () => {
+      this.child = null;
+      this.status = 'stopped';
+      this.clearIdleTimer();
+    });
+
+    this.child = child;
+
+    // Mark running once the socket appears (best-effort) and start the idle timer.
+    this.waitForSocket().then(
+      () => {
+        if (this.child === child) this.status = 'running';
+      },
+      () => {
+        // socket never appeared; leave status as 'starting' until exit cleans up
+      },
+    );
+
+    this.touch();
+    return { status: 'starting', socket_path: this.opts.socketPath };
+  }
+
+  async stop(): Promise<void> {
+    this.clearIdleTimer();
+    const child = this.child;
+    if (!child) return;
+
+    return new Promise<void>((resolve) => {
+      this.exitWaiters.push(resolve);
+      child.kill('SIGTERM');
+      const forceKill = setTimeout(() => {
+        if (this.child === child) {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            // already gone
+          }
+        }
+      }, this.opts.forceKillTimeoutMs ?? 5000);
+      child.once('exit', () => clearTimeout(forceKill));
+    });
+  }
+
+  touch(): void {
+    if (!this.child) return;
+    this.clearIdleTimer();
+    this.idleTimer = setTimeout(() => {
+      void this.stop();
+    }, this.opts.idleTimeoutMs);
+    if (typeof this.idleTimer.unref === 'function') this.idleTimer.unref();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.stop();
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  private async ensureSocketDir(): Promise<void> {
+    const dir = path.dirname(this.opts.socketPath);
+    try {
+      await fs.mkdir(dir, { recursive: true });
+    } catch {
+      // best-effort; spawn will fail loudly if the dir is unusable
+    }
+  }
+
+  private async removeStaleSocket(): Promise<void> {
+    try {
+      await fs.unlink(this.opts.socketPath);
+    } catch {
+      // ENOENT is fine; other errors surface when the child tries to bind
+    }
+  }
+
+  private async waitForSocket(timeoutMs = 10_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!this.child) throw new Error('code-server exited before socket appeared');
+      try {
+        await fs.stat(this.opts.socketPath);
+        return;
+      } catch {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+    }
+    throw new Error(`code-server socket did not appear within ${timeoutMs}ms`);
+  }
+}
+
+let manager: CodeServerManager | null = null;
+
+export function getCodeServerManager(): CodeServerManager {
+  if (!manager) {
+    manager = new CodeServerProcessManager(loadOptionsFromEnv());
+  }
+  return manager;
+}
+
+export function setCodeServerManager(next: CodeServerManager | null): void {
+  manager = next;
+}


### PR DESCRIPTION
## Summary

- Adds an in-process `CodeServerProcessManager` (`packages/control-plane/src/services/code-server-manager.ts`) that spawns code-server bound to a Unix socket, tracks status, and auto-stops after a configurable idle window (default 30 min, env-overridable via `CODE_SERVER_IDLE_TIMEOUT_MS`, `CODE_SERVER_BIN`, `CODE_SERVER_SOCKET_PATH`, etc.).
- Wires `POST /lifecycle/code-server-start` to lazily spawn the child and return `{status, socket_path}` per the cluster-base#12 spec; `POST /lifecycle/code-server-stop` cleanly terminates the child and removes the socket.
- `ControlPlaneServer.close()` now shuts the code-server child down alongside the HTTP server.
- Exposes the new schema/types (`CodeServerStartResponseSchema`, `CodeServerManager`, etc.) on the public surface.

Pairs with [cluster-base#12](https://github.com/generacy-ai/cluster-base/issues/12). The cluster-base PR adds the code-server binary and pre-baked extensions to the image; this PR is the runtime that drives them. The two PRs are independent in time — orchestrators install the new package version on next boot.

## Test plan

- [x] `npx vitest run` — 9 files / 72 tests pass (was 8 / 62)
- [x] New unit tests for the manager exercise real `child_process.spawn` against a fake binary that opens a Unix socket: start, idempotent re-start, idle auto-stop fires, `touch()` resets the timer, `stop()` is a no-op when not running.
- [x] Integration test asserts `code-server-start` returns `{status, socket_path}` and `code-server-stop` calls `manager.stop()`.
- [x] `npm run build` (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)