### PR TITLE
fix: drop duplicate deploy placeholder so CLI can start

### DIFF
--- a/packages/generacy/src/cli/commands/placeholders.ts
+++ b/packages/generacy/src/cli/commands/placeholders.ts
@@ -7,7 +7,6 @@ interface PlaceholderDef {
 }
 
 const PLACEHOLDERS: PlaceholderDef[] = [
-  { name: 'deploy',       description: 'Deploy to production',               phase: 'phase 10' },
   { name: 'rebuild',      description: 'Rebuild cluster from scratch',       phase: 'phase 7' },
 ];
 


### PR DESCRIPTION
## Summary
- The real `deploy` command was added to `createProgram()` (PR #514) but the matching entry in `PLACEHOLDERS` was left in place
- Commander threw `cannot add command 'deploy' as already have command 'deploy'` during CLI construction, which broke `generacy --version` and put the orchestrator dev container in a restart loop
- Removes the obsolete placeholder; the real command is the only registration left

## Test plan
- [ ] `pnpm --filter @generacy-ai/generacy build` succeeds
- [ ] `node packages/generacy/bin/generacy.js --version` prints a version instead of throwing
- [ ] `node packages/generacy/bin/generacy.js deploy --help` resolves to the real `deploy` command (not the placeholder message)
- [ ] Rebuilding the tetrad-development orchestrator container completes bootstrap without the duplicate-command crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)