### PR TITLE
fix(ci): build packages before root in publish-preview workflow

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build (root)
-        run: pnpm build
-
       - name: Build (packages)
         run: pnpm -r run --if-present build
+
+      - name: Build (root)
+        run: pnpm build
 
       - name: Ensure changesets for preview
         run: |


### PR DESCRIPTION
## Summary

Two related fixes to unblock the `Publish Preview` workflow on `develop`:

1. **Build order** — swap `Build (root)` and `Build (packages)` in `publish-preview.yml`. The root `tsc` build imports `@generacy-ai/orchestrator`, so the orchestrator package's `dist/` must exist before the root build runs. `ci.yml` already orders these steps correctly; this brings `publish-preview.yml` in line.
2. **Missing `publishConfig.access` on three scoped packages** — `activation-client`, `control-plane`, `credhelper-daemon`. For scoped names, npm defaults to `restricted` (paid private), which causes publish to fail with `E402 Payment Required`. The other 14 workspace packages already have `access: public`; this brings the laggards in line.

## Why this is broken now

- Last successful publish: `0.0.0-preview-20260407041110` on April 7.
- April 12-13: spawn-refactor / credentials work added the orchestrator imports to root `src/` (commits `b32770c`, `b068c0f`).
- The workflow was switched from `on: push: develop` to manual `workflow_dispatch` around the same time, so this regression was hidden until someone manually dispatched it.
- First manual run [25515867226](https://github.com/generacy-ai/generacy/actions/runs/25515867226) hit the build-order bug.
- Second run [25517608469](https://github.com/generacy-ai/generacy/actions/runs/25517608469) cleared the build but hit `E402` on the first scoped package without `publishConfig.access`.

## Test plan

- [ ] Re-run `Publish Preview` workflow on `develop` after this lands (`gh workflow run publish-preview.yml --ref develop`)
- [ ] Confirm a new `0.0.0-preview-<timestamp>` version appears on npm for `@generacy-ai/generacy`, `@generacy-ai/workflow-engine`, `@generacy-ai/activation-client`, `@generacy-ai/control-plane`
- [ ] Confirm `npx -y @generacy-ai/generacy@preview launch --help` lists the `launch` command (i.e. the v1.5 onboarding work made it into the preview channel)

## Open follow-ups (out of scope here)

- The `@latest` dist-tag is pinned to the broken March 4 build forever and is never advanced by this workflow. Decide whether to advance `@latest` after each preview, or change the cloud copy-paste command at `generacy-cloud/services/api/src/routes/projects/projects.ts:311` to pin `@preview`.
- Decide whether `@generacy-ai/credhelper-daemon` should remain publishable or be marked `private: true` (it has no workspace dependents and per CLAUDE.md ships via a Docker volume, but its package.json is set up like a publishable package).
- Re-enable `on: push: branches: [develop]` on this workflow once the spawn-refactor lands (per the comment at the top of the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)