### PR TITLE
fix(packages): mark activation-client, control-plane, credhelper-daemon public

### DIFF
--- a/packages/activation-client/package.json
+++ b/packages/activation-client/package.json
@@ -36,5 +36,8 @@
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",
     "directory": "packages/activation-client"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -44,5 +44,8 @@
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",
     "directory": "packages/control-plane"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/credhelper-daemon/package.json
+++ b/packages/credhelper-daemon/package.json
@@ -45,5 +45,8 @@
     "type": "git",
     "url": "git+https://github.com/generacy-ai/generacy.git",
     "directory": "packages/credhelper-daemon"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Add `publishConfig.access: "public"` to three scoped `@generacy-ai/*` packages that were missing it.

For scoped packages, npm defaults to `restricted` (paid private). Without `publishConfig.access: "public"` in the manifest (or `--access public` on the publish CLI), publish fails with `E402 Payment Required`. The other 14 workspace packages already have this set; this brings the laggards in line.

## Why now

- This was originally part of #536 (commit `2c0cd52` on the same branch) but only the build-order commit got merged from that PR — the publishConfig commit was pushed after the merge had been kicked off, so it was excluded.
- Confirmed live: post-#536 publish run [25518709642](https://github.com/generacy-ai/generacy/actions/runs/25518709642) passed both build steps and then failed with `E402 Payment Required` on `@generacy-ai/activation-client`, the first scoped package to hit `npm publish`.

## Packages fixed

| Package | Why it must publish |
|---|---|
| `@generacy-ai/activation-client` | Workspace dep of `@generacy-ai/generacy` and `@generacy-ai/orchestrator`; resolved at install time when users run `npx @generacy-ai/generacy launch`. |
| `@generacy-ai/control-plane` | Workspace dep of `@generacy-ai/orchestrator`. |
| `@generacy-ai/credhelper-daemon` | No workspace dependents and per CLAUDE.md ships via Docker volume, but its package.json declares `bin`/`main`/`exports`/`files` like a publishable package. Adding `access:public` matches the existing intent without broadening scope; whether it should instead be marked `private: true` is a separate decision. |

## Test plan

- [ ] Re-run `Publish Preview` on `develop` after merge: `gh workflow run publish-preview.yml --ref develop --repo generacy-ai/generacy`
- [ ] Confirm a new `0.0.0-preview-<timestamp>` version appears for `@generacy-ai/generacy`, `@generacy-ai/workflow-engine`, `@generacy-ai/activation-client`, `@generacy-ai/control-plane`
- [ ] Confirm `npx -y @generacy-ai/generacy@preview launch --help` lists the `launch` command (i.e. v1.5 onboarding work reaches the preview channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)