### PR TITLE
chore(ci): re-enable auto preview publish on push to develop

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,16 +1,12 @@
 name: Publish Preview
 
-# Manual dispatch only (was: on push to develop).
-# Changed during spawn-refactor to prevent partial in-progress work
-# from being accidentally published to the "preview" npm channel.
-#
-# To trigger a preview release:
-#   CLI:  gh workflow run publish-preview.yml --ref develop
-#   UI:   Actions tab → Publish Preview → Run workflow → select branch
-#
-# Revert to "on: push: branches: [develop]" once the refactor lands.
+# Publishes a preview release on every push to develop. Also supports
+# manual dispatch via the Actions UI or:
+#   gh workflow run publish-preview.yml --ref <branch>
 
 on:
+  push:
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Restore the original `on: push: branches: [develop]` trigger for `publish-preview.yml`. The workflow was switched to manual dispatch during the spawn-refactor; that refactor has shipped (the `launch` CLI command lives on develop and runs end-to-end), so the original "don't publish partial work" concern no longer applies.

`workflow_dispatch` is kept alongside the push trigger so the workflow can still be re-run on demand from the UI or via `gh workflow run publish-preview.yml --ref <branch>`.

## Why now

The manual-dispatch toggle had a real cost: every preview-channel consumer was stuck on the April 7 build, the v1.5 onboarding work that landed late April never reached npm, and the only way users could test the launch flow was if someone remembered to dispatch the workflow by hand. Restoring auto-publish brings the preview channel back in line with develop.

## Test plan

- [ ] After merge, this very push triggers a publish run automatically
- [ ] A new `0.0.0-preview-<timestamp>` version of `@generacy-ai/generacy` shows up on npm
- [ ] `npx -y @generacy-ai/generacy@preview launch --help` lists the `launch` command without re-publishing manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)