### PR TITLE
fix(launch): set compose project name from project name

### DIFF
--- a/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
@@ -7,6 +7,7 @@ import {
   scaffoldClusterJson,
   scaffoldClusterYaml,
   scaffoldDockerCompose,
+  sanitizeComposeProjectName,
 } from '../scaffolder.js';
 
 describe('scaffoldClusterJson', () => {
@@ -127,6 +128,7 @@ describe('scaffoldDockerCompose', () => {
       imageTag: 'ghcr.io/generacy-ai/cluster-base:1.5.0',
       clusterId: 'clust_abc',
       projectId: 'proj_def',
+      projectName: 'todo-list-example',
       cloudUrl: 'https://api.generacy.ai',
       variant: 'cluster-base',
     });
@@ -134,11 +136,56 @@ describe('scaffoldDockerCompose', () => {
     const raw = readFileSync(join(dir, 'docker-compose.yml'), 'utf-8');
     const parsed = parse(raw);
 
+    expect(parsed.name).toBe('todo-list-example');
     expect(parsed.services.cluster.image).toBe('ghcr.io/generacy-ai/cluster-base:1.5.0');
     expect(parsed.services.cluster.environment).toContain('GENERACY_CLUSTER_ID=clust_abc');
     expect(parsed.services.cluster.environment).toContain('GENERACY_PROJECT_ID=proj_def');
     expect(parsed.services.cluster.environment).toContain('GENERACY_CLOUD_URL=https://api.generacy.ai');
     expect(parsed.services.cluster.environment).toContain('DEPLOYMENT_MODE=local');
     expect(parsed.services.cluster.environment).toContain('CLUSTER_VARIANT=cluster-base');
+  });
+
+  it('sanitizes uppercase, spaces, and other illegal characters in projectName', () => {
+    scaffoldDockerCompose(dir, {
+      imageTag: 'ghcr.io/generacy-ai/cluster-base:1.5.0',
+      clusterId: 'clust_abc',
+      projectId: 'proj_def',
+      projectName: 'My Awesome Project!',
+      cloudUrl: 'https://api.generacy.ai',
+      variant: 'cluster-base',
+    });
+
+    const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
+    expect(parsed.name).toBe('my-awesome-project');
+  });
+});
+
+describe('sanitizeComposeProjectName', () => {
+  it('lowercases and replaces illegal characters with hyphens', () => {
+    expect(sanitizeComposeProjectName('My Project!', 'clust_abc')).toBe('my-project');
+  });
+
+  it('preserves leading digits (they are valid)', () => {
+    expect(sanitizeComposeProjectName('123-project', 'clust_abc')).toBe('123-project');
+  });
+
+  it('strips leading hyphens and underscores', () => {
+    expect(sanitizeComposeProjectName('--foo-bar', 'clust_abc')).toBe('foo-bar');
+    expect(sanitizeComposeProjectName('__foo', 'clust_abc')).toBe('foo');
+  });
+
+  it('collapses runs of hyphens', () => {
+    expect(sanitizeComposeProjectName('foo----bar', 'clust_abc')).toBe('foo-bar');
+  });
+
+  it('falls back to a clusterId-derived name when nothing usable remains', () => {
+    expect(sanitizeComposeProjectName('!!!', 'clust_abc123')).toBe('generacy-clustabc123');
+    expect(sanitizeComposeProjectName('', 'XYZ-789')).toBe('generacy-xyz789');
+    expect(sanitizeComposeProjectName('!!!', '')).toBe('generacy-cluster');
+  });
+
+  it('truncates to 63 characters', () => {
+    const long = 'a'.repeat(100);
+    expect(sanitizeComposeProjectName(long, 'clust_abc').length).toBe(63);
   });
 });

--- a/packages/generacy/src/cli/commands/cluster/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/cluster/scaffolder.ts
@@ -24,9 +24,30 @@ export interface ScaffoldComposeInput {
   imageTag: string;
   clusterId: string;
   projectId: string;
+  projectName: string;
   cloudUrl: string;
   variant: 'cluster-base' | 'cluster-microservices';
   deploymentMode?: 'local' | 'cloud';
+}
+
+/**
+ * Coerce a project name into a valid Docker Compose project name.
+ *
+ * Compose v2 requires the name to match `^[a-z0-9][a-z0-9_-]*$`. We lowercase,
+ * replace illegal characters with `-`, collapse runs, strip leading
+ * non-alphanumerics, and fall back to `generacy-<clusterId-slice>` when nothing
+ * usable remains.
+ */
+export function sanitizeComposeProjectName(name: string, clusterId: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+/, '')
+    .replace(/[-_]+$/, '')
+    .slice(0, 63);
+  if (cleaned && /^[a-z0-9]/.test(cleaned)) return cleaned;
+  return `generacy-${clusterId.replace(/[^a-z0-9]/gi, '').toLowerCase().slice(0, 12) || 'cluster'}`;
 }
 
 /**
@@ -62,6 +83,7 @@ export function scaffoldClusterYaml(dir: string, input: ScaffoldClusterYamlInput
 export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput): void {
   mkdirSync(dir, { recursive: true });
   const compose = {
+    name: sanitizeComposeProjectName(input.projectName, input.clusterId),
     version: '3.8',
     services: {
       cluster: {

--- a/packages/generacy/src/cli/commands/deploy/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/deploy/scaffolder.ts
@@ -44,6 +44,7 @@ export function scaffoldBundle(
     imageTag: config.imageTag,
     clusterId: activation.clusterId,
     projectId: activation.projectId,
+    projectName: config.projectName,
     cloudUrl,
     variant: config.variant as 'cluster-base' | 'cluster-microservices',
     deploymentMode: 'cloud',

--- a/packages/generacy/src/cli/commands/launch/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/launch/scaffolder.ts
@@ -66,6 +66,7 @@ export function scaffoldProject(projectDir: string, config: LaunchConfig): void 
     imageTag: config.imageTag,
     clusterId: config.clusterId,
     projectId: config.projectId,
+    projectName: config.projectName,
     cloudUrl: config.cloudUrl,
     variant: config.variant as 'cluster-base' | 'cluster-microservices',
   });


### PR DESCRIPTION
## Summary

Closes part of #539 (the immediate naming complaint and the volume-collision side effect). Port-conflict work remains in #539.

[`scaffoldDockerCompose`](https://github.com/generacy-ai/generacy/blob/develop/packages/generacy/src/cli/commands/cluster/scaffolder.ts#L62-L89) generated compose files with no top-level `name:` field. Docker Compose v2 falls back to the parent directory of the compose file (`<projectDir>/.generacy/`), which sanitizes to `generacy`. Two side effects:

- Every scaffolded cluster appeared as `generacy` in `docker compose ls` / Docker Desktop, regardless of project. No way to tell them apart visually.
- Concurrent clusters collided on the named volume `cluster-data` because Docker Compose namespaces volumes by the (now-shared) project name.

## Fix

Thread `projectName` through `ScaffoldComposeInput` from both call sites (launch and deploy), sanitize it to a valid compose project name, and emit it as the top-level `name:`:

```yaml
name: todo-list-example16
version: '3.8'
services:
  cluster:
    ...
```

Sanitization rules (Compose v2 spec: `^[a-z0-9][a-z0-9_-]*$`):

- Lowercase
- Replace non-`[a-z0-9_-]` with `-`
- Collapse runs of `-`
- Strip leading/trailing `-` or `_`
- Truncate to 63 chars
- Fall back to `generacy-<sanitized-clusterId-slice>` if nothing usable remains

## Why this scope only

Issue #539 covers the larger story of running multiple clusters concurrently end-to-end, which also requires dynamic ports + registry/CLI plumbing. Those are user-facing decisions worth a clarify round; this PR keeps to mechanical fixes that don't change interaction surface.

## Test plan

- [x] `pnpm test src/cli/commands/cluster/__tests__/scaffolder.test.ts` — 13/13 pass (6 new sanitizer tests + 1 new compose-name assertion).
- [x] Full `pnpm test` shows the same 20 pre-existing failures on `develop` and on this branch, no new regressions; 7 new passing tests.
- [ ] After merge + auto preview publish, run `npx -y @generacy-ai/generacy@preview launch --claim=<fresh>` and confirm the resulting `docker compose ls` lists the project under its real name (e.g. `todo-list-example16`) rather than `generacy`.
- [ ] In Docker Desktop, two clusters scaffolded for two different projects show up as two distinct compose projects with separate volumes.

## Related

- Issue #539 — full Flow C concurrent-cluster support (dynamic ports, registry plumbing, CLI port discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)