### PR TITLE
fix(launch): honor channel from cloud launch-config

### DIFF
--- a/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
@@ -15,6 +15,7 @@ const mockConfig: LaunchConfig = {
   projectId: 'proj_abc123',
   projectName: 'my-project',
   variant: 'cluster-base',
+  channel: 'stable',
   cloudUrl: 'https://api.generacy.ai',
   clusterId: 'cluster_abc123',
   imageTag: 'ghcr.io/generacy-ai/cluster-base:1.5.0',
@@ -87,6 +88,23 @@ describe('scaffoldProject', () => {
     expect(parsed).not.toHaveProperty('imageTag');
     expect(parsed).not.toHaveProperty('cloudUrl');
     expect(parsed).not.toHaveProperty('ports');
+  });
+
+  it('writes channel=preview to cluster.yaml when config.channel is preview', () => {
+    const projectDir = join(tempDir, 'new-project');
+    scaffoldProject(projectDir, { ...mockConfig, channel: 'preview' });
+
+    const parsed = parse(readFileSync(join(projectDir, '.generacy', 'cluster.yaml'), 'utf-8'));
+    expect(parsed.channel).toBe('preview');
+  });
+
+  it('defaults to channel=preview when config.channel is undefined', () => {
+    const projectDir = join(tempDir, 'new-project');
+    const { channel: _omitted, ...configWithoutChannel } = mockConfig;
+    scaffoldProject(projectDir, configWithoutChannel as LaunchConfig);
+
+    const parsed = parse(readFileSync(join(projectDir, '.generacy', 'cluster.yaml'), 'utf-8'));
+    expect(parsed.channel).toBe('preview');
   });
 
   it('cluster.yaml output validates against ClusterYamlSchema', () => {

--- a/packages/generacy/src/cli/commands/launch/index.ts
+++ b/packages/generacy/src/cli/commands/launch/index.ts
@@ -188,7 +188,7 @@ async function launchAction(opts: LaunchOptions): Promise<void> {
       path: projectDir,
       composePath,
       variant: (config.variant as 'cluster-base' | 'cluster-microservices') ?? 'cluster-base',
-      channel: 'stable',
+      channel: config.channel ?? 'preview',
       cloudUrl: config.cloudUrl,
       lastSeen: now,
       createdAt: now,

--- a/packages/generacy/src/cli/commands/launch/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/launch/scaffolder.ts
@@ -57,7 +57,7 @@ export function scaffoldProject(projectDir: string, config: LaunchConfig): void 
   });
 
   scaffoldClusterYaml(generacyDir, {
-    channel: 'stable',
+    channel: config.channel ?? 'preview',
     workers: 1,
     variant: config.variant as 'cluster-base' | 'cluster-microservices',
   });

--- a/packages/generacy/src/cli/commands/launch/types.ts
+++ b/packages/generacy/src/cli/commands/launch/types.ts
@@ -19,6 +19,7 @@ export const LaunchConfigSchema = z.object({
   projectId: z.string().min(1),
   projectName: z.string().min(1),
   variant: z.string().min(1),
+  channel: z.enum(['stable', 'preview']).optional(),
   cloudUrl: z.string().url(),
   clusterId: z.string().min(1),
   imageTag: z.string().min(1),


### PR DESCRIPTION
## Summary

The cloud UI lets users pick a channel (`preview` / `stable`), but that selection was being silently dropped between cloud and CLI. Two stacked bugs:

1. **Cloud-side** (companion PR generacy-ai/generacy-cloud#TBD): the `buildLaunchConfig` service reads `project.channel` and uses it to pick the right cluster image tag (`cluster-base:preview` vs `cluster-base:stable`), then **discards** it — `LaunchConfig` doesn't include a `channel` field at all.
2. **CLI-side (this PR)**: even if the cloud sent the channel, [scaffolder.ts:60](https://github.com/generacy-ai/generacy/blob/develop/packages/generacy/src/cli/commands/launch/scaffolder.ts#L60) and [index.ts:191](https://github.com/generacy-ai/generacy/blob/develop/packages/generacy/src/cli/commands/launch/index.ts#L191) hardcoded `channel: 'stable'`.

## Why this matters

The cluster-base orchestrator entrypoint runs `npm install @generacy-ai/generacy@${CHANNEL}` at boot, where `${CHANNEL}` comes from `.generacy/cluster.yaml`. With both bugs, every scaffolded cluster wrote `channel: stable` regardless of user choice. But:

```
$ npm view @generacy-ai/generacy dist-tags
{ latest: '0.0.0-preview-20260304013206',
  preview: '0.0.0-preview-20260508172549' }
$ npm view @generacy-ai/generacy@stable version
npm error 404 No match found for version stable
```

There is no `@stable` dist-tag (v1.5 hasn't been promoted to main yet). So the orchestrator's `npm install` 404s, exits non-zero under `set -e`, `restart: unless-stopped` revives it, → crash loop. **Every** v1.5 cluster scaffolded today by today's CLI failed this way.

## Fix

- Add optional `channel: z.enum(['stable', 'preview'])` to `LaunchConfigSchema`. Optional means the CLI gracefully handles old cloud responses (pre-companion-PR) and new ones.
- Thread `config.channel` through the two call sites that previously hardcoded `'stable'`.
- Default to `'preview'` when missing — the only working channel right now, and matches what every staging-cloud project page is defaulting to. The default also gives users on this PR a working cluster even before the companion cloud PR ships.

## Test plan

- [x] `pnpm test -- src/cli/commands/launch/__tests__/` — 52/52 pass (added 2 new tests for channel pass-through + default-fallback).
- [ ] Once both PRs merge and staging redeploys, run a fresh `npx -y @generacy-ai/generacy@preview launch --claim=<fresh>` and verify `~/Generacy/<project>/.generacy/cluster.yaml` contains `channel: preview` (assuming the project's channel is set to preview in the cloud UI).
- [ ] Cluster boots cleanly without crash-looping.

## Companion

generacy-ai/generacy-cloud#517 (TBD link) — adds `channel` to the `LaunchConfig` response.

## Follow-ups (not blockers)

- The `@stable` and `@latest` dist-tags need a promotion path. Right now they're stuck — `@latest` on the broken March 4 build, `@stable` doesn't exist. A separate workflow or manual `npm dist-tag add` is needed once v1.5 is promoted to main.
- The CLI's lossy 4xx error mapping ("Claim code is invalid or expired") has now masked **three** distinct bugs in this debugging session: an auth middleware leak, a regex/alphabet mismatch, and now this channel bug. Worth differentiating error messages by status code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)