### PR TITLE
fix(ci): point cluster-base publish at .devcontainer/generacy build context

### DIFF
--- a/.github/workflows/publish-cluster-base-image.yml
+++ b/.github/workflows/publish-cluster-base-image.yml
@@ -43,7 +43,11 @@ jobs:
 
       - uses: docker/build-push-action@v6
         with:
-          context: .
+          # Build context = directory containing the Dockerfile + its COPY sources
+          # (scripts/, code-server-extensions.txt). Cluster-base#17 removed the
+          # repo-internal publish workflow that knew this; this generacy-side
+          # workflow had been inheriting `.` (repo root) which has no Dockerfile.
+          context: .devcontainer/generacy
           push: true
           tags: |
             ghcr.io/generacy-ai/cluster-base:${{ steps.tags.outputs.channel }}


### PR DESCRIPTION
## Summary

The `Publish Cluster Base Image` workflow at [.github/workflows/publish-cluster-base-image.yml](https://github.com/generacy-ai/generacy/blob/develop/.github/workflows/publish-cluster-base-image.yml) used `context: .` (repo root of cluster-base) but the Dockerfile lives at `.devcontainer/generacy/Dockerfile`. Every manual dispatch since [cluster-base#17](https://github.com/generacy-ai/cluster-base/pull/17) fails with:

```
ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

The May 4 publishes succeeded only because cluster-base used to have its own internal publish workflow (with the right path) — #17 removed it, leaving only this generacy-side workflow which had been inheriting an incorrect context.

## Reproduction

[Run 25617214204](https://github.com/generacy-ai/generacy/actions/runs/25617214204) — manual dispatch on develop today, fails at the build-push step.

## Fix

```diff
       - uses: docker/build-push-action@v6
         with:
-          context: .
+          context: .devcontainer/generacy
           push: true
```

All `COPY` paths in the Dockerfile (`scripts/`, `code-server-extensions.txt`) are relative and live inside `.devcontainer/generacy/`, so changing the context is mechanical and doesn't require Dockerfile edits.

## Surfaced via

While testing the v1.5 onboarding flow today, the latest cluster-base bootstrap-mode work (cluster-base#21) wasn't reaching live clusters because the `:preview` image was still from May 4. Triggering a manual rebuild surfaced this build failure — meaning the image has been *unbuildable* since #17 merged 2026-05-07, and 2 cluster-base merges (#19 and #21) are sitting unreleased.

## Test plan

- [ ] After merge, manual dispatch on develop should produce a green build and push fresh `:preview` and `:sha-XXXXX` tags
- [ ] `docker pull ghcr.io/generacy-ai/cluster-base:preview && docker image inspect ... --format '{{index .Config.Labels "org.opencontainers.image.revision"}}'` shows the latest develop SHA, not `2a76d23` (May 4)
- [ ] Re-test `npx generacy launch ...` end-to-end — orchestrator should now skip the clone in wizard mode

## Related

- generacy-ai/cluster-base#17 — removed the cluster-base-internal publish workflow that had the right path
- generacy-ai/cluster-base#21 — bootstrap-mode work that's been blocked from publishing
- generacy-ai/cluster-base#19 — `.env.template` split, also blocked since 2026-05-09
- #559 — separate issue: even after this fix, the workflow is still manual-dispatch only; needs auto-trigger on cluster-base develop pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)