### PR TITLE
fix(ci): poll workflow needs --repo flag + fail-fast: false

### DIFF
--- a/.github/workflows/poll-cluster-images.yml
+++ b/.github/workflows/poll-cluster-images.yml
@@ -17,6 +17,7 @@ jobs:
       group: poll-cluster-${{ matrix.repo }}-${{ matrix.branch }}
       cancel-in-progress: false
     strategy:
+      fail-fast: false
       matrix:
         include:
           - repo: cluster-base
@@ -65,5 +66,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "${{ matrix.workflow }}" -f "ref=${{ matrix.branch }}"
+          # gh workflow run defaults to detecting the repo via `git`, but this
+          # workflow has no actions/checkout step (polling doesn't need source).
+          # Pass --repo explicitly to bypass git detection.
+          gh workflow run "${{ matrix.workflow }}" \
+            --repo "${{ github.repository }}" \
+            -f "ref=${{ matrix.branch }}"
           echo "Dispatched ${{ matrix.workflow }} for ${{ matrix.branch }}"


### PR DESCRIPTION
## Summary

Two bugs in the just-merged Poll Cluster Images workflow ([#564](https://github.com/generacy-ai/generacy/pull/564)) surfaced on its first manual dispatch ([run 25645507867](https://github.com/generacy-ai/generacy/actions/runs/25645507867)):

1. **\`gh workflow run\` exits 1 with \`failed to run git: fatal: not a git repository\`.** The workflow correctly has no \`actions/checkout@v4\` step (polling only uses the GitHub API, doesn't need source). But \`gh workflow run\` falls back to \`git\` for repo detection when no \`--repo\` is given, and there's no .git directory to detect from.

2. **No \`fail-fast: false\` on the matrix.** GitHub Actions defaults matrix \`fail-fast\` to \`true\`. So when one matrix entry fails, the others get \`cancelled\` mid-flight. Saw this exact behavior — \`cluster-microservices, main\` failed first; \`cluster-base, develop\` and \`cluster-base, main\` showed as cancelled despite each being independent polling targets.

## Fix

```diff
     strategy:
+      fail-fast: false
       matrix:
         include:
           - repo: cluster-base
             ...

           gh workflow run "${{ matrix.workflow }}" \
+            --repo "${{ github.repository }}" \
             -f "ref=${{ matrix.branch }}"
```

Total diff: +7 / -1.

## Why both belong in one PR

They surface together (the missing flag triggers the failure; the missing fail-fast amplifies it) and they would otherwise both be discovered on the next scheduled run anyway. Keeping them paired avoids a second cycle of "cron fires, one matrix entry fails, cancels the others, file another fix."

## Test plan

- [x] PR shipped with the workflow file change
- [ ] After merge, manually dispatch the workflow and verify all 4 matrix entries complete (whether they dispatch a build or skip because the SHA is already published)
- [ ] Verify next scheduled cron tick (5 min cadence) runs cleanly
- [ ] Within ~10 minutes, confirm \`docker pull ghcr.io/generacy-ai/cluster-base:preview\` and \`...cluster-microservices:preview\` both reflect their respective develop HEAD (this validates the end-to-end auto-publish loop the original #559 was about)

## Related

- generacy-ai/generacy#559 / #564 — original auto-publish poll spec/PR; this is a follow-up bug fix on the freshly-shipped workflow
- generacy-ai/cluster-base — the polling target (currently in sync, but the loop needs to actually work for future merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)