### PR TITLE
fix(orchestrator): warn-and-disable label monitor instead of exiting on empty repos

### DIFF
--- a/packages/generacy/src/cli/commands/__tests__/orchestrator-repos.test.ts
+++ b/packages/generacy/src/cli/commands/__tests__/orchestrator-repos.test.ts
@@ -102,12 +102,17 @@ describe('orchestrator CLI repos resolution', () => {
     ]);
   });
 
-  it('exits with error when label monitor enabled but no repos', async () => {
+  it('warns and disables label monitor when enabled but no repos', async () => {
     mockConfig.repositories = [];
 
     await runCommand(['--label-monitor']);
 
-    expect(mockExit).toHaveBeenCalledWith(1);
+    // Should NOT exit — server handles labelMonitor + empty repos gracefully.
+    expect(mockExit).not.toHaveBeenCalled();
+
+    // Label monitor should be disabled in the resulting config passed to the server.
+    const callArgs = vi.mocked(createServer).mock.calls[0]![0];
+    expect(callArgs.config.labelMonitor).toBe(false);
   });
 
   it('delegates config file fallback to loadConfig', async () => {

--- a/packages/generacy/src/cli/commands/orchestrator.ts
+++ b/packages/generacy/src/cli/commands/orchestrator.ts
@@ -120,13 +120,18 @@ export function orchestratorCommand(): Command {
         config.labelMonitor = true;
       }
 
-      // Validate label monitor requirements
+      // Label monitor needs at least one repo to monitor. If it's enabled but
+      // no repos are configured (e.g. wizard-mode bootstrap where the workspace
+      // hasn't been cloned yet), warn and disable rather than exit — the server
+      // itself only initializes the label monitor when both labelMonitor and
+      // repositories.length > 0 are truthy (see server.ts), so a CLI exit here
+      // is stricter than what the runtime requires.
       if (config.labelMonitor && config.repositories.length === 0) {
-        console.error(
-          'Label monitor enabled but no valid repositories configured. ' +
-          'Set MONITORED_REPOS env var or use --monitored-repos flag.',
+        console.warn(
+          'Label monitor requested but no repositories configured — disabling. ' +
+          'Set MONITORED_REPOS env var or use --monitored-repos flag, then restart.',
         );
-        process.exit(1);
+        config.labelMonitor = false;
       }
 
       // Setup auth with CLI token


### PR DESCRIPTION
## Summary

Surfaced during the first full end-to-end v1.5 onboarding test on Windows. After all four bootstrap-mode PRs landed (#562, #561, #564, etc.), the cluster scaffolds correctly, pulls latest cluster-base, detects \`GENERACY_BOOTSTRAP_MODE=wizard\`, skips the clone — but then the orchestrator CLI immediately exits 1 with:

\`\`\`
Label monitor enabled but no valid repositories configured. Set MONITORED_REPOS env var or use --monitored-repos flag.
\`\`\`

Container restarts, loops, wizard UI never advances past "Waiting for cluster…".

## Root cause

[orchestrator.ts:124-130](https://github.com/generacy-ai/generacy/blob/develop/packages/generacy/src/cli/commands/orchestrator.ts#L124-L130) exits when \`labelMonitor && repositories.length === 0\`. But [server.ts:260](https://github.com/generacy-ai/generacy/blob/develop/packages/orchestrator/src/server.ts#L260) only *initializes* the label monitor when both \`labelMonitor && repositories.length > 0\` are truthy — so the server itself handles empty-repos gracefully. The CLI's pre-flight validation is stricter than the runtime.

This bites the wizard flow specifically: the cluster-base entrypoint script unconditionally passes \`--label-monitor\` based on \`LABEL_MONITOR_ENABLED=true\` in [.env.template](https://github.com/generacy-ai/cluster-base/blob/develop/.devcontainer/generacy/.env.template). In wizard mode the workspace isn't cloned yet (deferred to post-activation), so the CLI sees an empty repos list and bails before the server can prove it'd be fine.

## Fix

Downgrade the CLI exit to a warning + auto-disable. The user's stated intent (\`LABEL_MONITOR_ENABLED=true\`) is preserved as a log message; the orchestrator boots; the wizard runs; post-activation can re-run with the now-populated workspace.

\`\`\`diff
-      if (config.labelMonitor && config.repositories.length === 0) {
-        console.error(
-          'Label monitor enabled but no valid repositories configured. ' +
-          'Set MONITORED_REPOS env var or use --monitored-repos flag.',
-        );
-        process.exit(1);
-      }
+      if (config.labelMonitor && config.repositories.length === 0) {
+        console.warn(
+          'Label monitor requested but no repositories configured — disabling. ' +
+          'Set MONITORED_REPOS env var or use --monitored-repos flag, then restart.',
+        );
+        config.labelMonitor = false;
+      }
\`\`\`

## Test plan

- [x] Updated existing \`exits with error when label monitor enabled but no repos\` test to assert warn-and-disable (4/4 passing in \`orchestrator-repos.test.ts\`)
- [ ] After merge + auto-publish, retry the v1.5 launch flow on Windows; cluster should boot through to the orchestrator's "Starting orchestrator on port 3100" step without exit-looping
- [ ] Wizard UI in browser should advance past "Waiting for cluster…"

## Follow-up worth considering (not in scope here)

The label monitor IS desired eventually for a wizard-mode cluster — it just can't run until the workspace is cloned and \`MONITORED_REPOS\` is populated. After this fix, the orchestrator boots without it. A separate issue should track:

- post-activation hook signaling the orchestrator to re-evaluate / restart with label monitor enabled, OR
- the orchestrator's runtime reloading config when the workspace is populated, OR
- the launch scaffolder writing \`LABEL_MONITOR_ENABLED=false\` initially, with the wizard UI offering to enable it later.

The "warn-and-disable" behavior in this PR is the right semantic for "we asked but it can't run right now"; the follow-up is "enable it later when conditions are met."

## Related

- generacy-ai/cluster-base#21 — bootstrap mode env var (sets the wizard-mode path that exposes this)
- generacy-ai/cluster-base#23 — post-activation watcher (where label monitor would be re-enabled in the follow-up)