### PR TITLE
fix(launch): exclude backslash + quotes from verification URL regex capture

### DIFF
--- a/packages/generacy/src/cli/commands/launch/__tests__/compose.test.ts
+++ b/packages/generacy/src/cli/commands/launch/__tests__/compose.test.ts
@@ -134,6 +134,28 @@ describe('streamLogsUntilActivation', () => {
     expect(result.userCode).toBe('ABCD-1234');
   });
 
+  it('does not include trailing JSON-escaped newline in extracted URL', async () => {
+    // The orchestrator's pino logger emits its activation message as JSON
+    // where embedded newlines are encoded as literal \n (backslash-n).
+    // The regex must NOT capture the trailing two-character escape sequence.
+    const mockChild = createMockChildProcess();
+    mockedSpawn.mockReturnValue(mockChild);
+
+    const promise = streamLogsUntilActivation('/project', 5000);
+
+    mockChild.stdout.emit(
+      'data',
+      Buffer.from(
+        // Realistic JSON log line as docker compose logs would surface it:
+        '{"level":30,"msg":"  Go to: https://staging.generacy.ai/cluster-activate\\n  Enter code: ABCD-1234\\n"}\n',
+      ),
+    );
+
+    const result = await promise;
+    expect(result.verificationUri).toBe('https://staging.generacy.ai/cluster-activate');
+    expect(result.userCode).toBe('ABCD-1234');
+  });
+
   it('resolves when both patterns are matched', async () => {
     const mockChild = createMockChildProcess();
     mockedSpawn.mockReturnValue(mockChild);

--- a/packages/generacy/src/cli/commands/launch/compose.ts
+++ b/packages/generacy/src/cli/commands/launch/compose.ts
@@ -53,11 +53,21 @@ export function startCluster(projectDir: string): void {
 /** Default timeout for waiting on activation output (120 seconds). */
 const DEFAULT_TIMEOUT_MS = 120_000;
 
-/** Pattern to extract the verification URI from container logs. */
-const VERIFICATION_URI_RE = /Go to:\s+(https?:\/\/\S+)/;
+/** Pattern to extract the verification URI from container logs.
+ *
+ * The orchestrator's pino logger emits its activation message as JSON, where
+ * embedded newlines are encoded as literal `\n` two-character escape sequences.
+ * `\S+` would greedily include those two chars in the captured URL, and the
+ * trailing backslash gets rewritten by the OS / browser into a slash —
+ * yielding e.g. `https://app/cluster-activate/n` (404).
+ * Restrict to URL-safe characters so the capture stops at the backslash. */
+const VERIFICATION_URI_RE = /Go to:\s+(https?:\/\/[^\s\\"']+)/;
 
-/** Pattern to extract the user code from container logs. */
-const USER_CODE_RE = /Enter code:\s+(\S+)/;
+/** Pattern to extract the user code from container logs.
+ *
+ * Same JSON-log concern as VERIFICATION_URI_RE — stop at quote/backslash
+ * boundaries so the captured code doesn't trail off into the next field. */
+const USER_CODE_RE = /Enter code:\s+([^\s\\"']+)/;
 
 /**
  * Stream `docker compose logs -f` and watch for activation patterns.


### PR DESCRIPTION
## Summary

When the launch CLI auto-opens the browser at the verification URL emitted by the orchestrator, the browser navigates to a malformed URL with `/n` appended (e.g. `https://staging.generacy.ai/cluster-activate/n`) and 404s.

## Root cause

The verification URI regex at [compose.ts:57](https://github.com/generacy-ai/generacy/blob/develop/packages/generacy/src/cli/commands/launch/compose.ts#L57):

```ts
const VERIFICATION_URI_RE = /Go to:\s+(https?:\/\/\S+)/;
```

The orchestrator's pino logger emits its multi-line activation message as a single JSON line where embedded newlines are encoded as the two-character escape sequence `\n` (backslash + n in the string body):

```json
{"level":30,"msg":"  Go to: https://staging.generacy.ai/cluster-activate\n  Enter code: ABCD-1234\n"}
```

`docker compose logs -f` surfaces this as a literal line. `\S+` greedy-matches non-whitespace, which includes both the backslash AND the `n` that follows the URL. So the regex captures:

```
https://staging.generacy.ai/cluster-activate\n
```

When `openBrowser` hands that URL to the OS, the backslash gets normalized to a slash (Windows convention, and browsers normalize it for URL inputs), yielding `https://staging.generacy.ai/cluster-activate/n` — a 404 on the staging frontend.

`USER_CODE_RE` has the same bug — the captured code would trail off into the next field of the JSON message if it weren't for the dash+digits in the user code being incidentally URL-safe enough that nothing checks.

## Fix

Tighten both regexes to exclude backslash and quote characters:

```diff
-const VERIFICATION_URI_RE = /Go to:\s+(https?:\/\/\S+)/;
+const VERIFICATION_URI_RE = /Go to:\s+(https?:\/\/[^\s\\"']+)/;

-const USER_CODE_RE = /Enter code:\s+(\S+)/;
+const USER_CODE_RE = /Enter code:\s+([^\s\\"']+)/;
```

The character classes still allow every URL-safe character (slashes, query strings, fragments, IDN encoding, port numbers) — they just stop at the JSON-escape boundary.

## Test plan

- [x] Added a test that feeds in a realistic JSON-formatted log line with `\n` escapes and asserts both the URL and user code come out clean: \`Cluster activation URI\` → \`https://staging.generacy.ai/cluster-activate\` (no \`/n\`), user code → \`ABCD-1234\` (no trailing escape).
- [x] All 10 existing/new tests in \`compose.test.ts\` pass.
- [ ] After merge + auto-publish, retry the v1.5 launch flow: the auto-opened browser should land on the actual `/cluster-activate` page (which renders the form, post-[generacy-cloud#535](https://github.com/generacy-ai/generacy-cloud/pull/535)) rather than the 404.

## Surfaced via

v1.5 staging end-to-end testing on Windows after generacy-cloud#534 (correct staging URL) and generacy-cloud#535 (OrgProvider) shipped. Cluster boots, emits the activation message, browser opens — at the wrong URL.

## Related

- generacy-ai/generacy-cloud#535 — the page itself works now; this PR makes sure we actually arrive at it
- generacy-ai/generacy#567 — still pending; until that lands, `compose up` fails before `streamLogsUntilActivation` ever gets called. The workaround (`docker compose up -d redis orchestrator` skipping the worker dep) bypasses the failure and exercises the path this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)