### PR TITLE
fix(orchestrator): append ?projectId to relay URL after activation

### DIFF
--- a/packages/orchestrator/src/__tests__/server-background-activation.test.ts
+++ b/packages/orchestrator/src/__tests__/server-background-activation.test.ts
@@ -124,9 +124,14 @@ describe('T007: Relay bridge initializes after background activation succeeds', 
       expect(config.relay.apiKey).toBe('test-api-key');
     }, { timeout: 5000 });
 
-    // Config should be updated
+    // Config should be updated. The relay URL must include ?projectId=<id> —
+    // the relay-server's auth middleware (generacy-cloud relay-auth.ts) rejects
+    // connections without it as 401 "projectId query parameter required",
+    // leaving the cluster permanently offline.
     expect(config.relay.clusterApiKeyId).toBe('test-key-id');
-    expect(config.relay.cloudUrl).toBe('wss://test.example.com/relay');
+    expect(config.relay.cloudUrl).toBe(
+      'wss://test.example.com/relay?projectId=test-project',
+    );
   }, 15_000);
 });
 

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -580,10 +580,17 @@ async function activateInBackground(
   config.relay.clusterApiKeyId = activationResult.clusterApiKeyId;
   if (activationResult.cloudUrl) {
     config.activation.cloudUrl = activationResult.cloudUrl;
+    // Relay-server's auth middleware requires ?projectId=<id> on the upgrade
+    // request (see generacy-cloud/services/api/src/middleware/relay-auth.ts).
+    // Append it here so the cluster's WS connection isn't rejected with
+    // 401 "projectId query parameter required" — without the relay link,
+    // the cloud treats the cluster as offline and rejects credential pushes
+    // with "Cluster is not connected for this project".
     const relayUrl = activationResult.cloudUrl
       .replace(/^https:/, 'wss:')
       .replace(/^http:/, 'ws:')
-      .replace(/\/$/, '') + '/relay';
+      .replace(/\/$/, '') + '/relay'
+      + `?projectId=${encodeURIComponent(activationResult.projectId)}`;
     config.relay.cloudUrl = relayUrl;
   }
   server.log.info('Cluster activation complete');


### PR DESCRIPTION
## Summary

Cluster boots, activates successfully, then permanently loops on `Relay connection rejected (HTTP 401) — projectId query parameter required`. The cloud treats the cluster as offline → bootstrap wizard's credential PUT returns `Cluster is not connected for this project`.

## Root cause

[server.ts:583-586](https://github.com/generacy-ai/generacy/blob/develop/packages/orchestrator/src/server.ts#L583-L586):

```ts
const relayUrl = activationResult.cloudUrl
  .replace(/^https:/, 'wss:')
  .replace(/^http:/, 'ws:')
  .replace(/\/$/, '') + '/relay';
```

Produces `wss://api-staging.generacy.ai/relay` — no query string. But the relay-server's auth middleware at [generacy-cloud/services/api/src/middleware/relay-auth.ts:138-142](https://github.com/generacy-ai/generacy-cloud/blob/develop/services/api/src/middleware/relay-auth.ts#L138-L142) requires `?projectId=<id>`:

```ts
const projectId = extractProjectId(req);
if (!projectId) {
  throw new RelayAuthError('projectId query parameter required', 401);
}
```

The orchestrator has `activationResult.projectId` available in scope right where the URL is built — the append step was just missing.

## Why this is the orchestrator-side counterpart of fixes we already shipped

The pattern of "emit a relay URL with ?projectId=<id> appended" is already correct in:

- Cloud's worker template generator (`services/worker/src/lib/templates.ts:122`)
- Cloud's DigitalOcean cloud-deploy (`services/api/src/services/cloud-deploy/digitalocean.ts`)
- Cloud's `buildLaunchConfig` response (`services/api/src/services/launch-config.ts` — populates `cloud.relayUrl` with projectId pre-appended per [generacy#549 Q2=A](https://github.com/generacy-ai/generacy/issues/549))

The orchestrator's activation-driven path (taking the cluster-activation response's `cloud_url` field and deriving a relay URL from it) was the one writer that didn't get updated. The cluster-side activation response only returns `cloud_url` (an HTTP API URL), not a structured cloud object — so the orchestrator has to assemble the relay URL itself.

## Fix

```diff
   const relayUrl = activationResult.cloudUrl
     .replace(/^https:/, 'wss:')
     .replace(/^http:/, 'ws:')
-    .replace(/\/$/, '') + '/relay';
+    .replace(/\/$/, '') + '/relay'
+    + `?projectId=${encodeURIComponent(activationResult.projectId)}`;
```

## Test plan

- [x] Existing T007 test updated to assert the full URL shape (`wss://test.example.com/relay?projectId=test-project`). 3/3 passing locally.
- [ ] After merge + auto-publish + cluster rebuild, retry the v1.5 onboarding flow. Cluster should boot, activate, then log:
  ```
  [relay] Starting cluster relay { relayUrl: 'wss://api-staging.generacy.ai/relay?projectId=...' }
  [relay] Relay connection established
  ```
  …with **no** "Relay connection rejected" loop.
- [ ] Bootstrap wizard's "Install GitHub App" step should accept the user's selection without "Failed to write credential / Cluster is not connected for this project".

## Surfaced via

v1.5 staging end-to-end test on Windows. This was the failure mode that surfaced *after* the prior fix layers (auth middleware leak, base64url regex, channel mismatch, scaffolded compose runtime, bootstrap mode, post-activation hook, label monitor graceful degrade, background activation, regex/n bug, camelCase response, OrgProvider wrap, github-installations URL) all shipped. Each one peeled off the next layer of the onion.

## Related

- generacy-ai/generacy#549 — env var disambiguation umbrella
- generacy-ai/generacy#568 (closing #567) — background activation; this fix builds directly on that PR's relay-init path
- Architectural follow-up worth a note: the orchestrator constructs its relay URL by string-munging the activation result's `cloud_url`. A cleaner shape would be for the activation response to return a structured cloud object (matching `LaunchConfig.cloud.{apiUrl, appUrl, relayUrl}`), so the orchestrator just reads `result.cloud.relayUrl` directly. That'd subsume this bug entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)