### PR TITLE
fix(launch): mount shared-packages at /shared-packages (cluster-base contract)

### DIFF
--- a/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
@@ -300,6 +300,20 @@ describe('scaffoldDockerCompose', () => {
     expect(parsed.volumes).toHaveProperty('redis-data');
   });
 
+  it('mounts shared-packages at /shared-packages (cluster-base entrypoint contract)', () => {
+    // The cluster-base entrypoint scripts (`entrypoint-orchestrator.sh`,
+    // `entrypoint-worker.sh`) run `npm install --prefix /shared-packages`
+    // and resolve `/shared-packages/node_modules/.bin/generacy`. The volume
+    // MUST mount at that exact path on both services — mounting it elsewhere
+    // means orchestrator and worker each install/resolve against their own
+    // empty overlay filesystem, and the worker exits with MODULE_NOT_FOUND.
+    scaffoldDockerCompose(dir, baseInput);
+    const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
+
+    expect(parsed.services.orchestrator.volumes).toContain('shared-packages:/shared-packages');
+    expect(parsed.services.worker.volumes).toContain('shared-packages:/shared-packages');
+  });
+
   it('sanitizes project name', () => {
     scaffoldDockerCompose(dir, { ...baseInput, projectName: 'My Awesome Project!' });
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));

--- a/packages/generacy/src/cli/commands/cluster/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/cluster/scaffolder.ts
@@ -133,11 +133,21 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
       ? ['${ORCHESTRATOR_PORT:-3100}:3100']
       : ['${ORCHESTRATOR_PORT:-3100}'];
 
-  // Shared volumes for orchestrator and worker
+  // Shared volumes for orchestrator and worker.
+  //
+  // shared-packages MUST mount at /shared-packages — that's where the
+  // cluster-base entrypoint scripts (`entrypoint-orchestrator.sh`) run
+  // `npm install --prefix /shared-packages`, and the worker's entrypoint
+  // resolves `/shared-packages/node_modules/.bin/generacy` to spawn the
+  // worker process. Mounting it anywhere else means the orchestrator's
+  // install writes to its own overlay filesystem (not the volume), the
+  // worker's resolve looks at its own overlay (empty), and the worker
+  // exits with "Cannot find module '/shared-packages/node_modules/.bin/generacy'".
+  // Matches the canonical cluster-base devcontainer compose.
   const sharedVolumes = [
     'workspace:/workspaces',
     claudeConfigVolume,
-    'shared-packages:/home/node/.local/share/generacy/packages',
+    'shared-packages:/shared-packages',
     'npm-cache:/home/node/.npm',
     'generacy-data:/var/lib/generacy',
   ];


### PR DESCRIPTION
## Summary

The launch CLI's scaffolder was mounting the \`shared-packages\` named volume at \`/home/node/.local/share/generacy/packages\`, but cluster-base's entrypoint scripts use \`/shared-packages\`. This mismatch meant:

- Orchestrator's \`entrypoint-orchestrator.sh\` ran \`npm install --prefix /shared-packages\` — but \`/shared-packages\` was the orchestrator container's local overlay (not the shared volume), so the install was invisible to the worker.
- Worker's \`entrypoint-worker.sh\` resolved \`/shared-packages/node_modules/.bin/generacy\` against its own local overlay (empty) → \`Error: Cannot find module '/shared-packages/node_modules/.bin/generacy'\` → worker crash-loop.
- Worker crash-loop → control-plane process never started.
- Cloud forwarded credential \`PUT\` through the relay → orchestrator's Fastify (no \`/control-plane/*\` route) → \`404 /control-plane/credentials/github-main-org\` in the bootstrap wizard.

Fix the mount path so both orchestrator's install and worker's resolve hit the same volume.

## Test plan

- [x] Added regression test asserting orchestrator and worker volumes both contain \`shared-packages:/shared-packages\`
- [x] 43/43 scaffolder tests passing locally
- [ ] User to delete their existing cluster, \`npx generacy launch --claim=<code>\` again, verify worker stays up and bootstrap wizard credential PUT reaches the control-plane

🤖 Generated with [Claude Code](https://claude.com/claude-code)