### PR TITLE
chore: skip CI on draft PRs

### DIFF
--- a/.github/workflows/changeset-bot.yml
+++ b/.github/workflows/changeset-bot.yml
@@ -2,13 +2,14 @@ name: Changeset Bot
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [develop]
 
 jobs:
   changeset-check:
     name: Changeset Check
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [develop, main]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [develop, main]
 
@@ -16,6 +17,7 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -3,6 +3,7 @@ name: Extension CI
 on:
   pull_request:
     branches: [develop, main]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'packages/generacy-extension/**'
 
@@ -16,6 +17,7 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Adds `ready_for_review` to `pull_request.types` and gates jobs on `github.event.pull_request.draft == false`.
- CI now stays idle while a PR is in draft and kicks in the moment the PR is marked ready.
- Push-triggered runs on `develop`/`main` are unaffected (guarded by `github.event_name != 'pull_request'`).

Affects: `ci.yml`, `extension-ci.yml`, `changeset-bot.yml`.

## Test plan
- [ ] Open a draft PR and confirm CI does not run.
- [ ] Mark it ready for review and confirm CI runs.
- [ ] Push to `develop` and confirm CI still runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)