### PR TITLE
fix(release): build packages before root; bring `--tag stable` back to develop

### DIFF
--- a/.changeset/initial-stable-release.md
+++ b/.changeset/initial-stable-release.md
@@ -1,0 +1,6 @@
+---
+"@generacy-ai/generacy": patch
+"@generacy-ai/cluster-relay": patch
+---
+
+Initial `stable` dist-tag release. Publishes current main under the `stable` channel so the orchestrator's `npm install @generacy-ai/<pkg>@stable` resolves.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: pnpm -r --filter '!generacy-extension' publish --no-git-checks --provenance
+          publish: pnpm -r --filter '!generacy-extension' publish --tag stable --no-git-checks --provenance
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build (root)
-        run: pnpm build
-
       - name: Build (packages)
         run: pnpm -r run --if-present build
+
+      - name: Build (root)
+        run: pnpm build
 
       - name: Create Release PR or Publish
         id: changesets


### PR DESCRIPTION
## Summary

Fixes two issues blocking the next `develop → main` release:

1. **Build order regression** — root `tsc` was running before workspace packages were built, failing today's release at [run 26113387230](https://github.com/generacy-ai/generacy/actions/runs/26113387230) with:

   ```
   src/agents/claude-code-invoker.ts(8,50): error TS2307: Cannot find module '@generacy-ai/orchestrator'
   src/worker/main.ts(21,88): error TS2307: Cannot find module '@generacy-ai/orchestrator'
   ```

   Root imports types from `@generacy-ai/orchestrator` (and other workspace packages), so the orchestrator's `dist/` must exist first. Swapped "Build (packages)" and "Build (root)" to match the already-passing order in [.github/workflows/ci.yml](.github/workflows/ci.yml).

2. **`--tag stable` missing on develop** — fix #485 added `--tag stable` to `release.yml` *on main only*. The workflow_run that fires after a develop→main merge ends up using the develop-side workflow file (which lacks the flag), so packages have still been landing on `latest`. This PR cherry-picks #485 onto develop so both branches agree.

   While we're here, this also pulls the `initial-stable-release.md` changeset from main onto develop, mirroring exactly what already exists on main.

## Why now

`@generacy-ai/generacy` and the other 12 generacy npm packages have **no `stable` dist-tag** — the orchestrator's `npm install @generacy-ai/*@stable` fails with `ETARGET`. The open Release PR #486 has been sitting since 2026-04-17 waiting for an actual successful publish, and today's develop→main merge would have published it — except the build error stopped it.

## Validation

Built locally to confirm the fix:

```
$ pnpm -r run --if-present build  # packages first
…
packages/orchestrator build: Done
packages/generacy build: Done

$ pnpm build  # then root
> tsc
(exits 0)
```

## Test plan

- [ ] PR CI passes (uses `ci.yml`, which already has the correct order)
- [ ] After merge to develop, then develop→main, the Release workflow gets past `Build (root)`
- [ ] Open Release PR #486 picks up the new changeset and gets merged
- [ ] After publish, verify `npm view @generacy-ai/generacy dist-tags` includes `stable`
- [ ] Rebuild orchestrator container and confirm `npm install @generacy-ai/*@stable` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)