### PR TITLE
fix(release): use positive filter for `pnpm publish`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: pnpm -r --filter '!generacy-extension' publish --tag stable --no-git-checks --provenance
+          publish: pnpm -r --filter '@generacy-ai/*' publish --tag stable --no-git-checks --provenance
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:


### PR DESCRIPTION
## Summary

Today's Release run after merging the version-packages PR [#660](https://github.com/generacy-ai/generacy/pull/660) silently no-op'd — no packages got published despite `--tag stable` being in the workflow and the new `npm dist-tag add` fallback step from #658 being present.

Root cause: [release.yml:47](.github/workflows/release.yml#L47) had `pnpm -r --filter '!generacy-extension' publish …`. In CI ([run 26119183148](https://github.com/generacy-ai/generacy/actions/runs/26119183148)) pnpm reports:

```
[command] pnpm -r --filter '!generacy-extension' publish --tag stable --no-git-checks --provenance
No projects matched the filters in "/home/runner/work/generacy/generacy"
```

→ pnpm exits 0, `changesets/action` sets `outputs.published = false`, the `Add @stable dist-tag` step's `if:` guard skips it. End result: `npm view @generacy-ai/generacy dist-tags` is still preview-only.

I couldn't repro the filter mismatch outside CI (same pnpm 9.15.9 locally, same args, finds 16 packages). Rather than chase the negation-filter quirk, switch to a positive filter that matches exactly the publishable set.

## What this changes

```diff
-          publish: pnpm -r --filter '!generacy-extension' publish --tag stable --no-git-checks --provenance
+          publish: pnpm -r --filter '@generacy-ai/*' publish --tag stable --no-git-checks --provenance
```

`@generacy-ai/*` matches:
- ✅ 16 `@generacy-ai/*` scoped workspace packages (the publish target)
- ❌ root `generacy` (private)
- ❌ `generacy-extension` (published via `extension-publish.yml` to the VS Code Marketplace, not npm)
- ❌ `devcontainer-feature` (published via `publish-devcontainer-feature.yml`)
- ❌ `generacy-docs` (private)

Same intent, no negation.

## Validation

Locally on `origin/main`:

```
$ pnpm install --frozen-lockfile
$ pnpm -r run --if-present build
$ pnpm build
$ pnpm -r --filter '@generacy-ai/*' publish --tag stable --no-git-checks --provenance --dry-run
npm notice package: @generacy-ai/cluster-relay@0.1.2
…  (lists all 16 packages with tarball contents)
```

## Note on follow-up state

This PR fixes the filter, but it does not solve all the latent issues that this work surfaced:

1. **Branch drift.** PR #660 merged `changeset-release/main` → `main` (not via develop), so `develop` still has `packages/generacy/package.json@0.1.1` while `main` is at `0.1.2`, and `develop` still carries the consumed `.changeset/initial-stable-release.md`. The next develop→main merge will need a conflict resolution that favors main's bumped versions and drops the changeset.
2. **Coverage gap.** Only `@generacy-ai/generacy` and `@generacy-ai/cluster-relay` were listed in the original changeset, so even after this fix only those two will land on `stable` from the next publish. The other 14 (orchestrator, credhelper, control-plane, etc.) are still at `0.1.0` in source and unpublished. A follow-up changeset covering all of them is needed to fully populate `stable`.

## Test plan

- [ ] After merge to develop → main, confirm the Release run's "Create Release PR or Publish" step actually lists packages being published (no "No projects matched the filters" message)
- [ ] `npm view @generacy-ai/generacy dist-tags` shows `stable=0.1.2`
- [ ] `npm view @generacy-ai/cluster-relay dist-tags` shows `stable=0.1.2`
- [ ] The `Add @stable dist-tag` follow-up step runs (i.e. `steps.changesets.outputs.published == 'true'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)