### PR TITLE
fix(release): set NPM_TOKEN so changesets/action uses token mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Add @stable dist-tag


### PR DESCRIPTION
## Summary

The previous "fix the filter" theory ([#661](https://github.com/generacy-ai/generacy/pull/661)) was wrong. Even after switching to `--filter '@generacy-ai/*'`, today's Release run [26122595695](https://github.com/generacy-ai/generacy/actions/runs/26122595695) (off PR #662 develop→main) still reported:

```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
[command] pnpm -r --filter '@generacy-ai/*' publish --tag stable --no-git-checks --provenance
No projects matched the filters in "/home/runner/work/generacy/generacy"
```

But the install one step earlier said `Scope: all 19 workspace projects`, and the build said `Scope: 18 of 19 workspace projects`. So the workspace IS discoverable — pnpm doesn't suddenly lose it.

## Actual root cause

The env block on the changesets/action step in [release.yml](.github/workflows/release.yml) only sets `NODE_AUTH_TOKEN`, not `NPM_TOKEN`. `changesets/action@v1` inspects the env for `NPM_TOKEN` — when it's absent, it falls back to OIDC trusted publishing. In that fallback path the action does not run our `publish:` command verbatim; it routes through its own internal logic which silently ignores pnpm's `--filter` argument, so the filter expression appears to "match nothing" even though the workspace has 16 matching packages.

Compare:

- agency [release.yml](https://github.com/generacy-ai/agency/blob/main/.github/workflows/release.yml) → sets `NPM_TOKEN` → publishes fine (7/7 packages on stable today)
- latency [release.yml](https://github.com/generacy-ai/latency/blob/main/.github/workflows/release.yml) → sets both `NPM_TOKEN` and `NODE_AUTH_TOKEN` → publishes fine (13/16 packages on stable today, the other 3 backfilled by hand)
- generacy → only `NODE_AUTH_TOKEN` → silent no-op every release

## Fix

One-line: add `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` to the env on the changesets/action step. `NODE_AUTH_TOKEN` stays (npm itself reads that for the actual publish).

```diff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

## Test plan

- [ ] After merge develop → main, next Release run logs the publish command actually finding packages (no "No NPM_TOKEN found" or "No projects matched")
- [ ] `npm view @generacy-ai/generacy dist-tags` shows `stable=0.1.2`
- [ ] `npm view @generacy-ai/cluster-relay dist-tags` shows `stable=0.1.2`

Note: only those two packages got bumped by changeset #660 — the other 14 generacy packages are still at `0.1.0` in source and will need a separate "bump everything once" changeset to fully populate `stable` across the repo. That's a follow-up; this PR just unblocks the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)