### PR TITLE
chore: bulk patch changeset to populate `stable` for 14 remaining packages

### DIFF
--- a/.changeset/bulk-stable-release.md
+++ b/.changeset/bulk-stable-release.md
@@ -1,0 +1,20 @@
+---
+"@generacy-ai/activation-client": patch
+"@generacy-ai/config": patch
+"@generacy-ai/control-plane": patch
+"@generacy-ai/credhelper": patch
+"@generacy-ai/credhelper-daemon": patch
+"@generacy-ai/generacy-plugin-claude-code": patch
+"@generacy-ai/generacy-plugin-cloud-build": patch
+"@generacy-ai/generacy-plugin-copilot": patch
+"@generacy-ai/generacy-plugin-github-actions": patch
+"@generacy-ai/generacy-plugin-github-issues": patch
+"@generacy-ai/generacy-plugin-jira": patch
+"@generacy-ai/knowledge-store": patch
+"@generacy-ai/orchestrator": patch
+"@generacy-ai/workflow-engine": patch
+---
+
+Bulk patch bump to populate the `stable` npm dist-tag for the 14 packages that were left at 0.1.0 by the previous changeset cycle (which only listed `@generacy-ai/generacy` and `@generacy-ai/cluster-relay`).
+
+After this changeset is consumed by changesets/action and the resulting version-packages PR merges to main, all 16 public `@generacy-ai/*` packages in this repo will be on `stable` on npm.


### PR DESCRIPTION
## Summary

Adds a single changeset listing the 14 `@generacy-ai/*` public packages that the previous changeset cycle left behind. After merge → changesets/action creates the version-packages PR → that PR merged → develop → main → publish → all 16 generacy packages land on the `stable` dist-tag (matching agency and latency).

## Why this is needed

The original cherry-picked `initial-stable-release.md` only declared:

```
"@generacy-ai/generacy": patch
"@generacy-ai/cluster-relay": patch
```

So only those two got version-bumped (`0.1.0` → `0.1.2`). The other 14 remain at `0.1.0` in source. Since changesets only publishes packages whose source version doesn't exist on npm, the orphan 14 won't publish until they're explicitly bumped.

Packages bumped here:

```
@generacy-ai/activation-client
@generacy-ai/config
@generacy-ai/control-plane
@generacy-ai/credhelper
@generacy-ai/credhelper-daemon
@generacy-ai/generacy-plugin-claude-code
@generacy-ai/generacy-plugin-cloud-build
@generacy-ai/generacy-plugin-copilot
@generacy-ai/generacy-plugin-github-actions
@generacy-ai/generacy-plugin-github-issues
@generacy-ai/generacy-plugin-jira
@generacy-ai/knowledge-store
@generacy-ai/orchestrator
@generacy-ai/workflow-engine
```

`@generacy-ai/generacy` and `@generacy-ai/cluster-relay` are not included — they're already at 0.1.2 in source and will publish on the next run once [#663](https://github.com/generacy-ai/generacy/pull/663) lands.

## Merge order

This PR is **dependent on [#663](https://github.com/generacy-ai/generacy/pull/663) landing first**. Without #663's `NPM_TOKEN` fix, the Release workflow goes into OIDC mode and the publish silently no-ops — the version bumps from this changeset would land in source but nothing would actually go to npm.

Recommended order:
1. Merge #663 → develop → main
2. Merge this PR (#TBD) → develop
3. Auto-generated "chore: version packages" PR → merge to develop
4. Develop → main → Release fires → publishes all 14 to `stable=0.1.1`

## Test plan

- [ ] PR CI passes (just changeset metadata — no code)
- [ ] After the version-packages PR merges and the publish runs, every package below shows `stable=0.1.1`:
  - [ ] @generacy-ai/orchestrator
  - [ ] @generacy-ai/credhelper, @generacy-ai/credhelper-daemon
  - [ ] @generacy-ai/control-plane
  - [ ] @generacy-ai/config, @generacy-ai/activation-client, @generacy-ai/knowledge-store, @generacy-ai/workflow-engine
  - [ ] @generacy-ai/generacy-plugin-{claude-code,cloud-build,copilot,github-actions,github-issues,jira}

🤖 Generated with [Claude Code](https://claude.com/claude-code)