### PR TITLE
fix(release): switch to `pnpm changeset publish`; mark extension private

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: pnpm -r --filter '@generacy-ai/*' publish --tag stable --no-git-checks --provenance
+          publish: pnpm changeset publish --tag stable --provenance
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:

--- a/packages/generacy-extension/package.json
+++ b/packages/generacy-extension/package.json
@@ -3,6 +3,7 @@
   "displayName": "Generacy",
   "description": "Workflow development IDE for local development and cloud orchestration management",
   "version": "0.1.0",
+  "private": true,
   "publisher": "generacy-ai",
   "license": "Apache-2.0",
   "icon": "resources/icon.png",


### PR DESCRIPTION
## Summary

Today's six generacy Release runs all reported `success` but **published nothing**. The repeated symptom in every run since the workflow was first attempted:

```
[command] pnpm -r --filter '@generacy-ai/*' publish --tag stable --no-git-checks --provenance
No projects matched the filters in "/home/runner/work/generacy/generacy"
```

…even though the install one step earlier always says `Scope: all 19 workspace projects` and the build says `Scope: 18 of 19 workspace projects`. The same command finds 16 packages locally on origin/main with identical pnpm 9.15.9 and identical lockfile state.

I tried [#661](https://github.com/generacy-ai/generacy/pull/661) (positive filter) and [#663](https://github.com/generacy-ai/generacy/pull/663) (set `NPM_TOKEN` so it leaves OIDC mode). Both landed. Both runs after them still got the same `No projects matched` no-op. Whatever combination of changesets/action + pnpm + ubuntu-runner is breaking, I can't repro outside CI to root-cause.

## Fix

Stop fighting `pnpm -r`'s filter and switch to the pattern that demonstrably works in this org:

```diff
-          publish: pnpm -r --filter '@generacy-ai/*' publish --tag stable --no-git-checks --provenance
+          publish: pnpm changeset publish --tag stable --provenance
```

`pnpm changeset publish` reads the workspace from `.changeset/config.json` rather than going through pnpm's filter machinery. It's exactly the command [agency uses](https://github.com/generacy-ai/agency/blob/main/.github/workflows/release.yml#L47) (and agency successfully published 7/7 packages to stable today) and what [latency uses](https://github.com/generacy-ai/latency/blob/main/.github/workflows/release.yml#L43) (16/16 stable).

### Secondary change: mark `generacy-extension` as private

`changeset publish` will try to publish *every* non-private workspace package whose source version isn't on npm. `generacy-extension` (currently `0.1.0` in source, never published to npm) would be picked up — but it's a VS Code extension, published to the Marketplace via [extension-publish.yml](.github/workflows/extension-publish.yml) using `vsce`. Adding `"private": true` to its package.json:

- ✅ Stops `pnpm changeset publish` and `pnpm publish` from trying to push it to npm.
- ✅ `vsce publish` ignores the field — Marketplace pipeline is unaffected.
- ✅ Existing `ignore: ["generacy-extension"]` in `.changeset/config.json` already prevents auto-versioning, so combined with `private: true` the extension is now fully insulated from the npm publish path.

## Local validation

Ran the new command on a fresh `pnpm install --frozen-lockfile` of origin/main with the changes applied. `changeset publish` correctly identifies the 16 publishable packages and would push:

```
Publishing "@generacy-ai/activation-client" at "0.1.1"
Publishing "@generacy-ai/cluster-relay" at "0.1.2"
…
Publishing "@generacy-ai/orchestrator" at "0.1.1"
Publishing "@generacy-ai/workflow-engine" at "0.1.1"
```

Without the `private: true` change, the dry-run also tried to publish `generacy-extension` at `0.1.0` — confirming why this part is needed.

## Test plan

- [ ] After merge → develop → main, next Release run logs `Publishing "@generacy-ai/<name>" at "<version>"` for the 16 packages (no `No projects matched` line)
- [ ] `npm view @generacy-ai/generacy dist-tags` shows `stable=0.1.3`
- [ ] `npm view @generacy-ai/orchestrator dist-tags` shows `stable=0.1.1`
- [ ] `npm view generacy-extension` returns 404 or no new version (was not pushed to npm)
- [ ] The next push to `develop` that touches `packages/generacy-extension/**` still publishes to the VS Code Marketplace via extension-publish.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)