### PR TITLE
fix(ci): always write synthetic changeset for preview publish

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -42,26 +42,26 @@ jobs:
         run: pnpm build
 
       - name: Ensure changesets for preview
+        # Always write a synthetic changeset covering every non-private package,
+        # alongside any user-authored ones. `changeset version --snapshot preview`
+        # only rewrites internal `workspace:*` deps in packages it bumps, so if a
+        # user changeset bumps only a subset of packages, dependents like
+        # control-plane → credhelper retain `workspace:*` in their source — the
+        # prepublishOnly guardrail then aborts the publish.
         run: |
-          CHANGESET_FILES=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | head -1)
-          if [ -n "$CHANGESET_FILES" ]; then
-            echo "Changeset files found, proceeding with preview publish"
-          else
-            echo "No changeset files found, generating synthetic changeset"
-            node -e "
-              const fs = require('fs'), path = require('path');
-              const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
-              const ignore = new Set(config.ignore || []);
-              const pkgs = fs.readdirSync('packages')
-                .map(d => path.join('packages', d, 'package.json'))
-                .filter(p => fs.existsSync(p))
-                .map(p => JSON.parse(fs.readFileSync(p, 'utf8')))
-                .filter(p => !p.private && p.name && !ignore.has(p.name));
-              const lines = ['---', ...pkgs.map(p => '\"' + p.name + '\": patch'), '---', '', 'Preview publish (synthetic)', ''];
-              fs.writeFileSync('.changeset/preview-publish.md', lines.join('\n'));
-              console.log('Created synthetic changeset for ' + pkgs.length + ' packages');
-            "
-          fi
+          node -e "
+            const fs = require('fs'), path = require('path');
+            const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
+            const ignore = new Set(config.ignore || []);
+            const pkgs = fs.readdirSync('packages')
+              .map(d => path.join('packages', d, 'package.json'))
+              .filter(p => fs.existsSync(p))
+              .map(p => JSON.parse(fs.readFileSync(p, 'utf8')))
+              .filter(p => !p.private && p.name && !ignore.has(p.name));
+            const lines = ['---', ...pkgs.map(p => '\"' + p.name + '\": patch'), '---', '', 'Preview publish (synthetic)', ''];
+            fs.writeFileSync('.changeset/preview-publish.md', lines.join('\n'));
+            console.log('Created synthetic changeset for ' + pkgs.length + ' packages');
+          "
 
       - name: Version (snapshot)
         run: pnpm changeset version --snapshot preview


### PR DESCRIPTION
## Summary

- Fixes the Publish Preview workflow failure on develop ([run 26137543309](https://github.com/generacy-ai/generacy/actions/runs/26137543309))
- Always writes the synthetic all-packages changeset instead of skipping it when user-authored changesets already exist
- Lets the `prepublishOnly` guardrail from #670 pass cleanly while still catching real `workspace:*` leaks

## Root cause

After #670 merged, the develop branch carries `.changeset/fix-workspace-deps-leak.md`, which bumps only `@generacy-ai/orchestrator`. On every push to develop the preview workflow saw that file and skipped the synthetic-changeset step. `pnpm changeset version --snapshot preview` then bumped only orchestrator, so the snapshot rewrite of `workspace:*` → semver only happened in packages with changesets. Dependents like `control-plane` → `credhelper` and `credhelper-daemon` → `credhelper` retained `workspace:*` in their source `package.json`, and the new `prepublishOnly` guardrail aborted the publish at control-plane:

```
ERROR: Found workspace: protocol in package.json
  dependencies.@generacy-ai/credhelper: workspace:*
```

## Fix

In `.github/workflows/publish-preview.yml`, drop the "only if no user changesets" guard around the synthetic changeset. Always write `.changeset/preview-publish.md` covering every non-private package. User-authored changesets coexist and continue to drive the stable release workflow on main — they're orthogonal to preview snapshots.

## Test plan

- [ ] CI triggers Publish Preview on this branch (workflow runs on `push: develop` only, so a merge — or a manual `workflow_dispatch --ref develop` after merge — is needed to fully validate)
- [ ] After merge, confirm the next preview run packs and publishes all non-private packages without the `workspace:` guardrail tripping
- [ ] Confirm the `.changeset/fix-workspace-deps-leak.md` user changeset still survives for the next stable release on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)