### PR TITLE
fix(ci): drop colon from verify step name (invalid YAML)

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Version (snapshot)
         run: pnpm changeset version --snapshot preview
 
-      - name: Verify no workspace: leaks in packed tarballs
+      - name: Verify no workspace protocol leaks in packed tarballs
         run: node scripts/verify-pack-no-workspace-deps.js
 
       - name: Publish preview


### PR DESCRIPTION
## Summary

- One-line follow-up to #676. The new step's name contained an unquoted colon (`name: Verify no workspace: leaks in packed tarballs`), so YAML parsed `workspace:` as a key and GitHub rejected the workflow ([run 26139685926](https://github.com/generacy-ai/generacy/actions/runs/26139685926): "You have an error in your yaml syntax on line 69").
- Rephrased to `Verify no workspace protocol leaks in packed tarballs` — no colon, no quoting needed.

## Test plan

- [x] Validated locally with `yaml.parse` on both `publish-preview.yml` and `release.yml`
- [ ] Publish Preview CI run on develop completes once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)