### PR TITLE
fix(launch/deploy): propagate repos.primaryBranch into scaffolded .env

### DIFF
--- a/.changeset/propagate-primary-branch.md
+++ b/.changeset/propagate-primary-branch.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+Propagate `repos.primaryBranch` from the cloud LaunchConfig into the scaffolded `.generacy/.env` file. Previously the Zod schema silently stripped the field, so `generacy launch` and `generacy deploy` always wrote a `.env` without `REPO_BRANCH=`. The orchestrator container then fell back to `${REPO_BRANCH:-main}` and `git clone --branch main` aborted for any project whose default branch isn't `main`.

--- a/packages/generacy/src/cli/commands/deploy/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/deploy/scaffolder.ts
@@ -63,6 +63,7 @@ export function scaffoldBundle(
     cloudUrl,
     projectName: config.projectName,
     repoUrl: config.repos?.primary,
+    repoBranch: config.repos?.primaryBranch,
     channel: 'stable',
     workers: 1,
   });

--- a/packages/generacy/src/cli/commands/launch/__tests__/cloud-client.test.ts
+++ b/packages/generacy/src/cli/commands/launch/__tests__/cloud-client.test.ts
@@ -474,4 +474,23 @@ describe('LaunchConfigSchema — cloud object', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('preserves repos.primaryBranch when present', () => {
+    const result = LaunchConfigSchema.safeParse({
+      ...BASE,
+      repos: { ...BASE.repos, primaryBranch: 'develop' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repos.primaryBranch).toBe('develop');
+    }
+  });
+
+  it('parses without repos.primaryBranch (backward compat)', () => {
+    const result = LaunchConfigSchema.safeParse(BASE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repos.primaryBranch).toBeUndefined();
+    }
+  });
 });

--- a/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
@@ -291,6 +291,25 @@ describe('scaffoldProject', () => {
     expect(content).toContain('GENERACY_RELAY_URL=wss://api.generacy.ai/relay?projectId=proj_abc123');
   });
 
+  it('writes REPO_BRANCH=<primaryBranch> when cloud provides one', () => {
+    const projectDir = join(tempDir, 'branch-project');
+    scaffoldProject(projectDir, {
+      ...mockConfig,
+      repos: { ...mockConfig.repos, primaryBranch: 'develop' },
+    });
+
+    const content = readFileSync(join(projectDir, '.generacy', '.env'), 'utf-8');
+    expect(content).toContain('REPO_BRANCH=develop');
+  });
+
+  it('omits REPO_BRANCH entirely when cloud does not provide primaryBranch', () => {
+    const projectDir = join(tempDir, 'no-branch-project');
+    scaffoldProject(projectDir, mockConfig);
+
+    const content = readFileSync(join(projectDir, '.generacy', '.env'), 'utf-8');
+    expect(content).not.toContain('REPO_BRANCH=');
+  });
+
   // -------------------------------------------------------------------------
   // Error: .generacy/ already exists
   // -------------------------------------------------------------------------

--- a/packages/generacy/src/cli/commands/launch/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/launch/scaffolder.ts
@@ -97,6 +97,7 @@ export function scaffoldProject(projectDir: string, config: LaunchConfig): void 
     cloudUrl: config.cloudUrl,
     projectName: config.projectName,
     repoUrl: config.repos?.primary,
+    repoBranch: config.repos?.primaryBranch,
     channel: config.channel ?? 'preview',
     workers: 1,
     cloud: config.cloud

--- a/packages/generacy/src/cli/commands/launch/types.ts
+++ b/packages/generacy/src/cli/commands/launch/types.ts
@@ -55,6 +55,7 @@ export const LaunchConfigSchema = z.object({
   orgId: z.string().min(1),
   repos: z.object({
     primary: z.string().min(1),
+    primaryBranch: z.string().min(1).optional(),
     dev: z.array(z.string()).optional(),
     clone: z.array(z.string()).optional(),
   }),

--- a/packages/generacy/tests/unit/deploy/scaffolder.test.ts
+++ b/packages/generacy/tests/unit/deploy/scaffolder.test.ts
@@ -142,5 +142,23 @@ describe('scaffoldBundle', () => {
       expect(content).toContain('GENERACY_RELAY_URL=wss://api.generacy.ai/relay?projectId=proj-123');
       expect(content).not.toContain('GENERACY_CLOUD_URL');
     });
+
+    it('writes REPO_BRANCH=<primaryBranch> when cloud provides one', () => {
+      const dir = scaffoldBundle(
+        { ...testConfig, repos: { ...testConfig.repos, primaryBranch: 'develop' } },
+        testActivation,
+        testCloudUrl,
+      );
+      tmpDirs.push(dir);
+
+      const content = readFileSync(join(dir, '.generacy', '.env'), 'utf-8');
+      expect(content).toContain('REPO_BRANCH=develop');
+    });
+
+    it('omits REPO_BRANCH entirely when cloud does not provide primaryBranch', () => {
+      const dir = callScaffold();
+      const content = readFileSync(join(dir, '.generacy', '.env'), 'utf-8');
+      expect(content).not.toContain('REPO_BRANCH=');
+    });
   });
 });


### PR DESCRIPTION
## Summary

`generacy launch` and `generacy deploy` always wrote `.generacy/.env` without `REPO_BRANCH=`, so the orchestrator container fell back to `${REPO_BRANCH:-main}` and the post-activation clone aborted for any project whose default branch isn't `main` (observed for `Painworth/ai-lawfirm`, default `develop`).

## Symptom

Caught on a fresh staging launch of `ai-lawfirm` from `npx -y @generacy-ai/generacy@preview launch --claim=…`:

```
[orchestrator] Cluster activated successfully
[post-activation] Cloning project repo: https://github.com/Painworth/ai-lawfirm.git (branch: main)
fatal: Remote branch main not found in upstream origin
[post-activation-watcher] ERROR: post-activation exited 128
```

Verified with `git ls-remote --symref` against the live repo:

```
ref: refs/heads/develop	HEAD
```

The cloud LaunchConfig **did** carry `repos.primaryBranch: "develop"` (project setting from the wizard), but it never reached the scaffolded `.env`.

## Root cause — three layers

1. **Schema** ([launch/types.ts:56-60](../blob/develop/packages/generacy/src/cli/commands/launch/types.ts#L56-L60))
   `LaunchConfigSchema.repos` didn't declare `primaryBranch`. Zod object schemas strip unknown keys by default, so the field was silently dropped on parse — the CLI literally never saw it.

2. **Launch scaffolder** ([launch/scaffolder.ts:93-105](../blob/develop/packages/generacy/src/cli/commands/launch/scaffolder.ts#L93-L105))
   `scaffoldEnvFile` already accepts `repoBranch` (writes `REPO_BRANCH=...` when present, omits otherwise — see [cluster/scaffolder.ts:295](../blob/develop/packages/generacy/src/cli/commands/cluster/scaffolder.ts#L295)), but `launch/scaffolder.ts` never passed it.

3. **Deploy scaffolder** ([deploy/scaffolder.ts:59-68](../blob/develop/packages/generacy/src/cli/commands/deploy/scaffolder.ts#L59-L68))
   Same omission. Deploy reuses launch/types, so it hit both 1 and 3.

## Fix

- Add `primaryBranch: z.string().min(1).optional()` to `LaunchConfigSchema.repos`.
- Pass `repoBranch: config.repos?.primaryBranch` to `scaffoldEnvFile` in both launch and deploy scaffolders.
- Tests: schema preservation, schema backward-compat (no `primaryBranch`), `.env` writes `REPO_BRANCH=develop`, `.env` omits the line when no `primaryBranch`.

## Test plan

- [x] `pnpm vitest run` over the three affected suites — 62/62 pass, including the 4 new cases
- [x] `git diff` against develop is +59/-0 with no formatting churn
- [ ] After merge + preview publish, a fresh `npx -y @generacy-ai/generacy@preview launch --claim=…` against a non-`main`-default project clones cleanly and post-activation reaches `generacy setup build`
- [ ] Stable release: works for projects whose `primaryBranch` is unset (defaults to `main` via the existing `${REPO_BRANCH:-main}` fallback in `resolve-workspace.sh`)

## Related

- generacy-ai/cluster-base#43 — installed orchestrator package (prior blocker on this same launch attempt)
- The `${REPO_BRANCH:-main}` consumer lives in [cluster-base/.devcontainer/generacy/scripts/resolve-workspace.sh](https://github.com/generacy-ai/cluster-base/blob/develop/.devcontainer/generacy/scripts/resolve-workspace.sh#L51) — unchanged here; the fallback is the right behavior when the cloud genuinely doesn't have a `primaryBranch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)