### PR TITLE
feat(control-plane): add prepare-workspace lifecycle action

### DIFF
--- a/.changeset/prepare-workspace-lifecycle.md
+++ b/.changeset/prepare-workspace-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/control-plane": minor
+---
+
+Add `prepare-workspace` lifecycle action: a subset of `bootstrap-complete` that unseals whatever wizard credentials are currently stored and writes the post-activation sentinel, but **does not** start code-server or VS Code Tunnel. Intended for use by the wizard's GitHubAppInstall step so the cluster's workspace clone runs in parallel with the remaining wizard steps (peer-repos, app-config), making the app-config manifest available by the time the user reaches that wizard step. `bootstrap-complete` remains the action fired by ReadyStep at the end of the wizard.

--- a/packages/control-plane/__tests__/routes/lifecycle.test.ts
+++ b/packages/control-plane/__tests__/routes/lifecycle.test.ts
@@ -421,6 +421,140 @@ describe('handlePostLifecycle', () => {
     });
   });
 
+  // --- prepare-workspace tests ---
+  // Same wire shape as bootstrap-complete but deliberately skips
+  // code-server / tunnel start so the wizard can fire it earlier (after the
+  // GitHub App step) to kick off the workspace clone in parallel with the
+  // remaining wizard steps.
+
+  describe('prepare-workspace', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), 'lifecycle-test-'));
+    });
+
+    afterEach(() => {
+      delete process.env.POST_ACTIVATION_TRIGGER;
+      delete process.env.AGENCY_DIR;
+      delete process.env.WIZARD_CREDS_PATH;
+      rmSync(tempDir, { recursive: true, force: true });
+      vi.mocked(writeWizardEnvFile).mockReset();
+      vi.mocked(writeWizardEnvFile).mockResolvedValue({ written: [], failed: [] });
+    });
+
+    it('writes the same sentinel path bootstrap-complete uses', async () => {
+      const sentinelPath = join(tempDir, 'prepare-workspace-sentinel');
+      process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+
+      const req = {} as IncomingMessage;
+      const res = createMockResponse();
+
+      await handlePostLifecycle(req, res, { userId: 'u-test' }, { action: 'prepare-workspace' });
+
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      const body = JSON.parse(res._body);
+      expect(body).toEqual({ accepted: true, action: 'prepare-workspace', sentinel: sentinelPath });
+      expect(existsSync(sentinelPath)).toBe(true);
+    });
+
+    it('unseals whatever credentials are currently stored (partial is fine)', async () => {
+      const sentinelPath = join(tempDir, 'prepare-workspace-partial');
+      const agencyDir = join(tempDir, 'agency');
+      const envFilePath = join(tempDir, 'wizard-credentials.env');
+
+      process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+      process.env.AGENCY_DIR = agencyDir;
+      process.env.WIZARD_CREDS_PATH = envFilePath;
+
+      vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({
+        written: ['github-main-org'],
+        failed: [],
+      });
+
+      const req = {} as IncomingMessage;
+      const res = createMockResponse();
+
+      await handlePostLifecycle(req, res, { userId: 'u-test' }, { action: 'prepare-workspace' });
+
+      expect(writeWizardEnvFile).toHaveBeenCalledWith({ agencyDir, envFilePath });
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+    });
+
+    it('does NOT start code-server (that waits for bootstrap-complete)', async () => {
+      const sentinelPath = join(tempDir, 'prepare-workspace-no-cs');
+      process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+
+      const manager = createFakeManager();
+      setCodeServerManager(manager);
+
+      const req = {} as IncomingMessage;
+      const res = createMockResponse();
+
+      await handlePostLifecycle(req, res, { userId: 'u-test' }, { action: 'prepare-workspace' });
+
+      expect(manager.start).not.toHaveBeenCalled();
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+    });
+
+    it('idempotent — bootstrap-complete after prepare-workspace still succeeds', async () => {
+      const sentinelPath = join(tempDir, 'prepare-then-bootstrap');
+      process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+
+      const req = {} as IncomingMessage;
+
+      const res1 = createMockResponse();
+      await handlePostLifecycle(req, res1, { userId: 'u-test' }, { action: 'prepare-workspace' });
+      expect(res1.writeHead).toHaveBeenCalledWith(200);
+
+      const res2 = createMockResponse();
+      await handlePostLifecycle(req, res2, { userId: 'u-test' }, { action: 'bootstrap-complete' });
+      expect(res2.writeHead).toHaveBeenCalledWith(200);
+
+      expect(existsSync(sentinelPath)).toBe(true);
+    });
+
+    it('unseal failure is non-fatal (sentinel still written)', async () => {
+      const sentinelPath = join(tempDir, 'prepare-workspace-unseal-fail');
+      process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+
+      vi.mocked(writeWizardEnvFile).mockRejectedValueOnce(new Error('unseal exploded'));
+
+      const req = {} as IncomingMessage;
+      const res = createMockResponse();
+
+      await handlePostLifecycle(req, res, { userId: 'u-test' }, { action: 'prepare-workspace' });
+
+      expect(existsSync(sentinelPath)).toBe(true);
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+    });
+
+    it('partial unseal emits the same cluster.bootstrap relay warning', async () => {
+      const sentinelPath = join(tempDir, 'prepare-workspace-partial-warn');
+      process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+
+      vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({
+        written: ['good-cred'],
+        failed: ['bad-cred'],
+      });
+
+      const mockPushEvent = vi.fn();
+      vi.mocked(getRelayPushEvent).mockReturnValueOnce(mockPushEvent);
+
+      const req = {} as IncomingMessage;
+      const res = createMockResponse();
+
+      await handlePostLifecycle(req, res, { userId: 'u-test' }, { action: 'prepare-workspace' });
+
+      expect(mockPushEvent).toHaveBeenCalledWith('cluster.bootstrap', {
+        warning: 'credential-unseal-partial',
+        failed: ['bad-cred'],
+        written: ['good-cred'],
+      });
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+    });
+  });
+
   // --- schema validation tests ---
 
   it('stop is a valid action (not UNKNOWN_ACTION)', async () => {

--- a/packages/control-plane/src/routes/lifecycle.ts
+++ b/packages/control-plane/src/routes/lifecycle.ts
@@ -96,6 +96,43 @@ export async function handlePostLifecycle(
     return;
   }
 
+  if (parsed.data === 'prepare-workspace') {
+    // Subset of bootstrap-complete: unseal whatever credentials are currently
+    // stored (typically just GitHub after the wizard's GitHubAppInstall step)
+    // and create the post-activation sentinel so the cluster clones the
+    // workspace in the background. Deliberately skips code-server / tunnel
+    // start — those wait for bootstrap-complete at the end of the wizard.
+    //
+    // Idempotent w.r.t. bootstrap-complete: both use the same sentinel path
+    // and the same writeWizardEnvFile call (which writes whatever is sealed
+    // at the moment), so calling bootstrap-complete after prepare-workspace
+    // re-writes the env file with the now-full credential set without
+    // disturbing the already-clone (the post-activation watcher only fires
+    // its hook on the first sentinel appearance).
+    const agencyDir = process.env.AGENCY_DIR ?? '/workspaces/.agency';
+    const envFilePath = process.env.WIZARD_CREDS_PATH ?? '/var/lib/generacy/wizard-credentials.env';
+    try {
+      const envResult = await writeWizardEnvFile({ agencyDir, envFilePath });
+      if (envResult.failed.length > 0) {
+        const pushEvent = getRelayPushEvent();
+        pushEvent?.('cluster.bootstrap', {
+          warning: 'credential-unseal-partial',
+          failed: envResult.failed,
+          written: envResult.written,
+        });
+      }
+    } catch {
+      // Non-fatal: log and continue — post-activation will see missing env vars
+    }
+
+    const sentinel = process.env.POST_ACTIVATION_TRIGGER ?? '/tmp/generacy-bootstrap-complete';
+    await writeFile(sentinel, '', { flag: 'w' });
+
+    res.writeHead(200);
+    res.end(JSON.stringify({ accepted: true, action: parsed.data, sentinel }));
+    return;
+  }
+
   if (parsed.data === 'bootstrap-complete') {
     // Unseal wizard credentials and write transient env file before sentinel
     const agencyDir = process.env.AGENCY_DIR ?? '/workspaces/.agency';

--- a/packages/control-plane/src/schemas.ts
+++ b/packages/control-plane/src/schemas.ts
@@ -41,6 +41,7 @@ export const LifecycleActionSchema = z.enum([
   'clone-peer-repos',
   'code-server-start',
   'code-server-stop',
+  'prepare-workspace',
   'stop',
   'vscode-tunnel-start',
   'vscode-tunnel-stop',


### PR DESCRIPTION
## Summary

Phase 1 of the wizard architectural fix. Adds a new lifecycle action that lets the wizard kick off the workspace clone *earlier* (after the GitHub App install step) instead of waiting for `bootstrap-complete` at the very last wizard step.

Phase 2 (follow-up PR in `generacy-ai/generacy-cloud`) wires the wizard to call this new action.

## Background

The wizard step order ([register-steps.ts](https://github.com/generacy-ai/generacy-cloud/blob/develop/packages/web/src/components/clusters/bootstrap/register-steps.ts)) is:

```
github-app (0)  →  peer-repos (3)  →  app-config (3.5)  →  ready (4)
```

`bootstrap-complete` is fired only by ReadyStep ([ReadyStep.tsx:66](https://github.com/generacy-ai/generacy-cloud/blob/develop/packages/web/src/components/clusters/bootstrap/steps/ReadyStep.tsx#L66)). It's what writes `/tmp/generacy-bootstrap-complete`, which the cluster's `post-activation-watcher` waits for before running the clone. So **the clone cannot happen until the user reaches the last wizard step** — meaning the app-config step's manifest fetch is structurally guaranteed to come back null. Observed end-to-end during `Painworth/ai-lawfirm` launch from staging: the sentinel file never existed on the cluster while the user was sitting on app-config; `/workspaces/ai-lawfirm/` stayed empty until the user clicked through to ReadyStep.

(generacy-ai/generacy-cloud#653's polling + settling state is a UX improvement for the brief race window, but doesn't fix the ordering — see #653's comments.)

## Fix

New `prepare-workspace` lifecycle action that does the minimum needed to start the clone:

- Same `writeWizardEnvFile` call as `bootstrap-complete` to unseal whatever credentials are currently stored. After the wizard's GitHub App install step that's typically just `GH_TOKEN` / `GH_USERNAME` / `GH_EMAIL`.
- Same sentinel path (`/tmp/generacy-bootstrap-complete`) — the existing watcher and `entrypoint-post-activation.sh` need no changes.
- Deliberately **does not** start code-server or VS Code Tunnel — those still wait for `bootstrap-complete` at the end of the wizard.

### Why partial credentials are safe

[`entrypoint-post-activation.sh`](https://github.com/generacy-ai/cluster-base/blob/develop/.devcontainer/generacy/scripts/entrypoint-post-activation.sh) hard-requires `GH_TOKEN` for the clone itself. Everything after — `generacy setup auth`, `generacy setup workspace`, `generacy setup build` — is wrapped in `|| log "WARNING: …"`. So a partial wizard-credentials.env at the moment the watcher fires its hook results in: clone succeeds, setup tries best-effort, warnings logged. Later when `bootstrap-complete` fires at ReadyStep, the env file is overwritten with the full credential set.

### Idempotency

`writeFile(sentinel, '', { flag: 'w' })` truncates if the file already exists, so calling `bootstrap-complete` after `prepare-workspace`:
- Re-writes `wizard-credentials.env` with the now-full credential set ✓
- Re-writes the sentinel (no-op, watcher already fired its hook on the first appearance and exited) ✓
- Starts code-server + VS Code Tunnel (the new bit `prepare-workspace` deliberately skipped) ✓

## Test plan

- [x] `pnpm vitest run __tests__/routes/lifecycle.test.ts` — 26/26 pass (6 new prepare-workspace tests + 20 existing)
- [x] Full control-plane suite — 330/330 pass
- [ ] After preview publishes, follow-up PR in `generacy-ai/generacy-cloud` adds `usePrepareWorkspace` hook + wires it into GitHubAppInstallStep on install success
- [ ] End-to-end: launch a fresh cluster, wizard fires `prepare-workspace` after GitHub App install, manifest is ready when user reaches the app-config step

## Related

- generacy-ai/generacy-cloud#653 — wizard polling/settling UX (complementary; handles the brief window where the user races ahead of even the now-earlier clone)
- generacy-ai/generacy#678 — `repos.primaryBranch` propagation (the previous blocker on this same launch attempt)
- generacy-ai/cluster-base#43 — orchestrator install fix (the one before that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)