### PR TITLE
fix(ci): split verify-pack into its own step (changesets/action doesn't shell)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,20 @@ jobs:
       - name: Build (root)
         run: pnpm build
 
+      - name: Verify no workspace protocol leaks in packed tarballs
+        # Run as its own workflow step (not chained into the changesets/action
+        # `publish:` input). `changesets/action@v1` splits the publish string
+        # by whitespace and runs it via execa, not a shell — so a `node …
+        # && pnpm …` chain was silently truncated to just `node`, causing
+        # `pnpm changeset publish` to never run on the prior release.
+        run: node scripts/verify-pack-no-workspace-deps.js
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: node scripts/verify-pack-no-workspace-deps.js && pnpm changeset publish --tag stable --provenance
+          publish: pnpm changeset publish --tag stable --provenance
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:


### PR DESCRIPTION
## Summary

Direct cause of why merging Version PR #681 today resulted in **no new npm publishes**, even though the run completed ✓.

`changesets/action@v1` splits its `publish:` input by `/\s+/` and feeds it to `getExecOutput` — not a shell. PR #676 set the publish input to

```
node scripts/verify-pack-no-workspace-deps.js && pnpm changeset publish --tag stable --provenance
```

which the action parsed as `node` + positional args `['scripts/verify-pack…', '&&', 'pnpm', 'changeset', 'publish', '--tag', 'stable', '--provenance']`. Node ran the verify-pack script, ignored the rest, exited 0. The action reported success, but `pnpm changeset publish` **never ran**.

Confirmed by run [26185485856](https://github.com/generacy-ai/generacy/actions/runs/26185485856)'s timing: verify-pack's "OK: no workspace protocol leaks" at `19:38:05.19`, post-cleanup at `19:38:05.22`. 30ms gap — no real publish could happen in that.

So today: main.git has the correctly-bumped `@generacy-ai/generacy@0.1.4`, `@generacy-ai/orchestrator@0.1.2`, `@generacy-ai/control-plane@0.2.0` from PR #681, but npm still serves `@stable = 0.1.3` (with broken `orchestrator@0.1.1` workspace:^ literals). The user is still hitting the original #669 install failure.

## Fix

Hoist verify-pack to its own workflow step so it runs through the normal step shell. The action's `publish:` input becomes just `pnpm changeset publish --tag stable --provenance`. Same shape as `publish-preview.yml` already uses (where verify has always been a separate step and works).

## What happens after this merges

1. Lands on develop
2. Promote develop → main (separate PR)
3. The next push to main triggers `release.yml` with the fixed workflow
4. No pending changesets (consumed by #681 already) → changesets/action enters publish mode
5. Verify-pack runs in its own step ✓
6. `pnpm changeset publish` runs, sees main.git's 0.1.4/0.1.2/0.2.0 versions are unpublished, publishes all three to npm with `--tag stable`

After step 6, `npx -y @generacy-ai/generacy@stable launch --claim=…` resolves to 0.1.4 → depends on `orchestrator@0.1.2` (deps properly rewritten this time) → install succeeds.

## Test plan

- [x] Local YAML parse of the updated release.yml is clean
- [ ] After merge to develop + main, the next release-workflow run shows `pnpm changeset publish` output and emits new npm versions
- [ ] `npm view @generacy-ai/generacy@stable version` returns `0.1.4`
- [ ] `npm view @generacy-ai/orchestrator@0.1.2 dependencies` shows no `workspace:` literals
- [ ] Fresh `npx @generacy-ai/generacy@stable launch …` reaches the wizard

## Related

- generacy#676 — the PR that introduced this (well-intentioned but worked locally because shells interpret `&&` and broke in CI's execa-not-shell path)
- generacy#681 — Version PR; merged, but never resulted in npm publishes because of this
- generacy-cloud#657 — production image-tag fix (still needs to ship after this so the cluster image also picks up today's fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)