### PR TITLE
fix(ci): publish via pnpm publish (not pnpm changeset publish) — finally fix #669

### DIFF
--- a/.changeset/fix-orchestrator-republish-clean-deps.md
+++ b/.changeset/fix-orchestrator-republish-clean-deps.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+Force a republish of `@generacy-ai/orchestrator` after the release workflow was fixed to actually rewrite `workspace:` dependencies. The previous publish (0.1.2) shipped with `workspace:^` literals in `dependencies` because `pnpm changeset publish` internally shells out to `npm publish`, which doesn't understand the workspace protocol. The fixed workflow uses `pnpm -r publish` (matching what `publish-preview.yml` already does) so the rewrite happens at pack time. This release retires the broken 0.1.2.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
+      published: ${{ steps.mode.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
 
@@ -39,36 +39,71 @@ jobs:
       - name: Build (root)
         run: pnpm build
 
-      - name: Verify no workspace protocol leaks in packed tarballs
-        # Run as its own workflow step (not chained into the changesets/action
-        # `publish:` input). `changesets/action@v1` splits the publish string
-        # by whitespace and runs it via execa, not a shell — so a `node …
-        # && pnpm …` chain was silently truncated to just `node`, causing
-        # `pnpm changeset publish` to never run on the prior release.
-        run: node scripts/verify-pack-no-workspace-deps.js
+      # `pnpm changeset publish` shells out to `npm publish`, which does NOT
+      # rewrite `workspace:` deps — only `pnpm publish` does. That's why
+      # @generacy-ai/orchestrator kept leaking `workspace:^` literals into
+      # published tarballs even after we "switched to pnpm changeset publish"
+      # (see generacy-ai/generacy#669). publish-preview.yml has always used
+      # `pnpm -r publish` directly and never hit the bug.
+      #
+      # Split the version and publish paths explicitly:
+      #   - When pending changesets exist → changesets/action runs `pnpm
+      #     changeset version`, opens the Version PR, no publish.
+      #   - When the Version PR has merged (no pending changesets) →
+      #     `pnpm -r publish` runs, which (a) skips already-published
+      #     versions, (b) rewrites workspace: deps at pack time, (c) tags
+      #     with @stable.
 
-      - name: Create Release PR or Publish
-        id: changesets
+      - name: Determine workflow mode
+        id: mode
+        run: |
+          if [ -z "$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | head -1)" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Mode: publish (no pending changesets)"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Mode: version (pending changesets, opening Version PR)"
+          fi
+
+      - name: Create Version PR
+        if: steps.mode.outputs.publish == 'false'
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
-          publish: pnpm changeset publish --tag stable --provenance
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify no workspace protocol leaks in packed tarballs
+        if: steps.mode.outputs.publish == 'true'
+        run: node scripts/verify-pack-no-workspace-deps.js
+
+      - name: Publish to npm
+        if: steps.mode.outputs.publish == 'true'
+        run: pnpm -r --filter '!generacy-extension' publish --tag stable --no-git-checks --provenance
+        env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Advance @latest dist-tag for all stable releases
-        if: steps.changesets.outputs.published == 'true'
+      - name: Advance @latest dist-tag for all published packages
+        if: steps.mode.outputs.publish == 'true'
         run: |
-          echo '${{ steps.changesets.outputs.publishedPackages }}' \
-            | jq -r '.[] | "\(.name) \(.version)"' \
-            | while read name version; do
-                echo "Setting $name@$version as @latest"
-                npm dist-tag add "$name@$version" latest
-              done
+          # pnpm publish doesn't surface a structured published-packages list
+          # the way changesets/action did, so iterate workspace packages and
+          # set @latest = current version for each non-private one. `npm
+          # dist-tag add` is idempotent and silently succeeds if already
+          # pointing at the requested version.
+          for pkg in packages/*/package.json; do
+            node -e "
+              const p = require('./$pkg');
+              if (p.private || !p.name) process.exit(0);
+              console.log(p.name, p.version);
+            " | while read name version; do
+              [ -z "$name" ] && continue
+              echo "Setting $name@$version as @latest"
+              npm dist-tag add "$name@$version" latest || echo "  (skipped — version may not be published, e.g. unchanged since last release)"
+            done
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

`@generacy-ai/orchestrator@0.1.2` (just republished after the #682 fix) **still shipped with `workspace:^` literals in its dependencies**. Same exact shape as the original #669 bug. The release workflow ran, the verify-pack step said "OK", and `pnpm changeset publish` ran — yet the published tarball had unrewritten workspace deps.

## Root cause (third layer of #669)

`pnpm changeset publish` shells out to `npm publish` internally (hardcoded in [@changesets/cli](https://github.com/changesets/changesets/blob/main/packages/cli/src/commands/publish/publishPackages.ts)). `npm publish` doesn't understand pnpm's workspace protocol — only `pnpm publish` does. So the `pnpm` prefix in `pnpm changeset publish` is misleading: it's just running pnpm scripts to invoke changeset's CLI, which then calls npm directly.

`publish-preview.yml` runs `pnpm -r publish` directly. That's why preview tarballs have always been clean.

The 7b457da commit ("switch to pnpm changeset publish") was supposed to fix #669 but never could — that command never rewrites workspace deps.

## Fix

Restructure `release.yml`:

```
            Pending changesets?
                /        \
              YES         NO
               |           |
       changesets/action   verify-pack (own step)
       (version only)      pnpm -r publish --tag stable
       Opens Version PR    Sets @latest dist-tags
```

Specifically:
- New `mode` step detects pending changesets and sets `publish=true|false`.
- changesets/action runs ONLY in version mode (no `publish:` input), so it cleanly opens the Version PR and stops.
- In publish mode, `pnpm -r --filter '!generacy-extension' publish --tag stable --no-git-checks --provenance` runs as a normal workflow step. Same shape `publish-preview.yml` has been using.
- `outputs.published` is sourced from the mode step (so `publish-devcontainer-feature` still gates correctly).
- `@latest` advancement: walk `packages/*/package.json`, run `npm dist-tag add` for each non-private one. `npm dist-tag add` is idempotent.

Plus a changeset bumping `@generacy-ai/orchestrator` to 0.1.3 — npm has 0.1.2 poisoned and won't accept a same-version republish, so we need a new patch.

## Why pnpm publish is safe

- Skips already-published versions — so the publish step is rerunnable.
- Rewrites `workspace:*` / `workspace:^` deps to actual semver at pack time.
- `--tag stable` tags accordingly; `npm dist-tag add` step adds `@latest`.
- `--no-git-checks` matches the preview workflow (the working tree may have uncommitted Version PR mutations during certain flows).

## What happens after this merges

1. Lands on develop.
2. Promote develop → main → triggers `release.yml` with the new shape AND the new `.changeset` file.
3. With pending changesets, changesets/action creates a Version PR bumping `orchestrator` 0.1.2 → 0.1.3 (and any cascading via `updateInternalDependencies: "patch"`).
4. Merge the Version PR → `release.yml` runs again in publish mode → `pnpm -r publish` emits `orchestrator@0.1.3` with **rewritten** deps.
5. `npm view @generacy-ai/orchestrator@0.1.3 dependencies` should show pinned semver, no `workspace:` strings.

## Test plan

- [x] Local YAML parse clean
- [ ] Workflow run on next merge to main produces non-empty `pnpm publish` output and emits `orchestrator@0.1.3`
- [ ] `npm view @generacy-ai/orchestrator@0.1.3 dependencies` shows zero `workspace:` literals
- [ ] Fresh `npx -y @generacy-ai/generacy@stable launch --claim=…` against production reaches the wizard (the cluster image's npm install of `@generacy-ai/orchestrator@stable` will pull 0.1.3 cleanly)

## Related

- #669 — original bug. Closing the loop after three failed prior fix attempts (the misdiagnosis in #670 that introduced the now-removed `prepublishOnly` guardrail; the #676 verify-pack guardrail that was checking the right tarball but couldn't gate the wrong publish command; the #682 fix that surfaced this layer).
- #676 — verify-pack-no-workspace-deps script (still useful! still runs! catches `pnpm pack` regressions if any).
- #682 — workflow chaining fix that exposed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)