### PR TITLE
fix: register waiting-for:sibling-review in WORKFLOW_LABELS

### DIFF
--- a/packages/workflow-engine/src/actions/github/label-definitions.ts
+++ b/packages/workflow-engine/src/actions/github/label-definitions.ts
@@ -33,6 +33,7 @@ export const WORKFLOW_LABELS: LabelDefinition[] = [
   { name: 'waiting-for:plan-review', color: 'FBCA04', description: 'Waiting for plan review' },
   { name: 'waiting-for:tasks-review', color: 'FBCA04', description: 'Waiting for tasks review' },
   { name: 'waiting-for:implementation-review', color: 'FBCA04', description: 'Waiting for implementation review' },
+  { name: 'waiting-for:sibling-review', color: 'FBCA04', description: 'Waiting for sibling repo PR reviews' },
   { name: 'waiting-for:manual-validation', color: 'FBCA04', description: 'Waiting for manual validation' },
   { name: 'waiting-for:pr-feedback', color: 'FBCA04', description: 'Waiting to address PR feedback' },
   { name: 'waiting-for:address-pr-feedback', color: 'FBCA04', description: 'Agent is addressing PR review feedback' },


### PR DESCRIPTION
## Summary

The `on-sibling-review` gate added in #692 applies the `waiting-for:sibling-review` label on activation, but that label was never added to `WORKFLOW_LABELS` in [packages/workflow-engine/src/actions/github/label-definitions.ts](packages/workflow-engine/src/actions/github/label-definitions.ts). As a result, `LabelManager.sync()` doesn't create or maintain the label on target repos, and gate activation would attempt to apply a label that doesn't exist.

One-line addition matching the existing `waiting-for:*` convention.

## Why no paired `completed:` label

Other `waiting-for:*` labels have paired `completed:*` labels because a human reviewer flips the label to signal "I'm done." For sibling review, the approval signal comes from GitHub's native PR `reviewDecision === 'APPROVED'` (per #692 Q2), not a label on the primary issue — so no `completed:sibling-review` is needed.

## Context

Surfaced during the final pre-test audit of the multi-repo workflow feature. With this fix, all of #687–#692 + #702 should be ready for end-to-end testing. See [multi-repo workflows plan](https://github.com/generacy-ai/tetrad-development/blob/develop/docs/multi-repo-workflows-plan.md).

## Test plan

- [ ] `LabelManager.sync()` creates the `waiting-for:sibling-review` label on a target repo on first run
- [ ] Triggering `on-sibling-review` gate activation successfully applies the label without 404/422
- [ ] No regression in existing label sync behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)