### PR TITLE
chore: bulk minor changeset for worker-scale architecture

### DIFF
--- a/.changeset/bulk-worker-scale-release.md
+++ b/.changeset/bulk-worker-scale-release.md
@@ -1,0 +1,42 @@
+---
+"@generacy-ai/generacy": minor
+"@generacy-ai/orchestrator": minor
+"@generacy-ai/control-plane": minor
+"@generacy-ai/activation-client": minor
+"@generacy-ai/config": minor
+"@generacy-ai/cluster-relay": minor
+---
+
+Worker-scale architecture: catch `stable` up with `preview` after ~10 feature
+PRs shipped without per-PR changesets. The whole story is around treating
+worker count as host capacity rather than project intent.
+
+Highlights:
+
+- `@generacy-ai/control-plane` — Engine API client + worker-scaler refactor
+  (no compose-file dependency); merged cluster.yaml / cluster.local.yaml
+  read helper; app-config wired to the merged view; `enumerateWorkers`
+  and `computeProjectName` exported for orchestrator use (#707, #711, #713).
+- `@generacy-ai/orchestrator` — metadata reports actual running container
+  count via Engine API enumeration; Docker container-event subscription
+  with reconnect+backoff for sub-10s responsiveness; CWD fix for
+  workspace-relative file reads; reads `GENERACY_INITIAL_WORKERS` at boot
+  (#715, #717).
+- `@generacy-ai/generacy` (CLI) — `--workers <N>` flag and interactive
+  prompt at launch; tier-cap-bounded resolver (`CLI_FALLBACK_TIER_CAP=8`,
+  `SUGGESTED_FROM_HOST=2`); no-TTY default with warning; reconcile path
+  reads merged config and writes `.env`'s `WORKER_COUNT` ahead of compose
+  (#713, #717).
+- `@generacy-ai/activation-client` — device-code poll body carries the
+  host-chosen `workers` value so the cloud can set `targetWorkers` at
+  activation (#717).
+- `@generacy-ai/config` — new `readMergedClusterConfig` helper providing
+  shallow per-top-level-key merge of `cluster.yaml` + `cluster.local.yaml`
+  (local wins); the canonical reader used by orchestrator's relay-bridge
+  and control-plane's app-config / worker-scaler (#711).
+- `@generacy-ai/cluster-relay` — wire-format rename `workerCount` →
+  `workers` to match the cluster.yaml schema flatten (#697 on cloud side).
+
+Minor across the board because the API surface is additive (new flags,
+new helpers, new fields) but substantial enough that semver-patch would
+undersell the scope.


### PR DESCRIPTION
## Summary

Catch `stable` up with `preview` after ~10 feature PRs shipped the worker-scale architecture without per-PR changesets. Six `@generacy-ai/*` packages have been frozen on `stable` since May 19/20 even though the equivalent code has been live on `preview` for days. This bulk minor changeset triggers the next version-packages PR on main to bump them so the Release workflow publishes new stable versions.

**Affected packages** (all bumped minor):
- `@generacy-ai/generacy`
- `@generacy-ai/orchestrator`
- `@generacy-ai/control-plane`
- `@generacy-ai/activation-client`
- `@generacy-ai/config`
- `@generacy-ai/cluster-relay`

Minor across the board — the API surface is additive (new flags, new helpers, new fields, new exports) but substantial enough that semver-patch would undersell it. See the changeset markdown for per-package highlights.

**Precedent**: [`69989cd`](https://github.com/generacy-ai/generacy/commit/69989cd) (PR #664) did the same kind of catch-up bulk patch on May 19 after a similar drift episode.

## Flow after merge

1. This PR merges → develop has the new `.changeset/*.md`.
2. Next develop→main sync (manual or automated) lands the changeset on main.
3. Changesets bot opens a `changeset-release/main` "Version Packages" PR that bumps the six packages' versions and rewrites changelogs.
4. Merging that PR triggers the Release workflow → `pnpm publish` → new `stable` versions on npm.
5. `npx -y @generacy-ai/generacy@stable launch …` will prompt for workers count.

## Follow-up worth filing separately

The reason ~10 feature PRs landed without changesets is that the changeset-bot CI gate (`Changeset Bot` workflow) doesn't block PRs missing them. Worth a small follow-up to make the bot a required check on PRs into develop so future feature batches don't drift from stable.

## Test plan

- [ ] Merge to develop.
- [ ] Sync develop→main.
- [ ] Confirm changesets bot opens the version-packages PR.
- [ ] Merge the version-packages PR.
- [ ] Verify Release workflow succeeds.
- [ ] Verify `npm view @generacy-ai/generacy@stable version` returns a bumped value (`0.2.0` from `0.1.4`).
- [ ] Verify `npx -y @generacy-ai/generacy@stable launch --help` shows the `--workers` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)