### PR TITLE
chore: patch bump workflow-engine — fixes stable orchestrator crash-loop

### DIFF
--- a/.changeset/release-followup-workflow-engine.md
+++ b/.changeset/release-followup-workflow-engine.md
@@ -1,0 +1,20 @@
+---
+"@generacy-ai/workflow-engine": patch
+---
+
+Follow-up to the bulk worker-scale catch-up (#719). The orchestrator was bumped
+to 0.2.0 in that batch with `^0.1.1` pinning on `@generacy-ai/workflow-engine`,
+but workflow-engine itself wasn't bumped — leaving stable on 0.1.1 from May 20.
+The orchestrator's published 0.2.0 imports `FilesystemWorkflowStore` (added to
+`workflow-engine/src/index.ts`'s top-level re-exports in a later develop commit),
+so loading `@generacy-ai/orchestrator@0.2.0` against `workflow-engine@0.1.1`
+fails with:
+
+    Failed to load @generacy-ai/orchestrator: The requested module
+    '@generacy-ai/workflow-engine' does not provide an export named
+    'FilesystemWorkflowStore'
+
+Patch bump (rather than minor) so the orchestrator's existing `^0.1.1` semver
+range picks up `0.1.2` automatically — no orchestrator re-publish needed.
+
+The broader process gap (per-PR changesets not enforced) is tracked in #720.


### PR DESCRIPTION
## Summary

Hot follow-up to [#719](https://github.com/generacy-ai/generacy/pull/719). The bulk catch-up bumped \`@generacy-ai/orchestrator\` to 0.2.0 with \`^0.1.1\` pinning on \`@generacy-ai/workflow-engine\`, but workflow-engine itself wasn't in that changeset. Stable workflow-engine stayed at 0.1.1 (May 20). Orchestrator 0.2.0's code imports \`FilesystemWorkflowStore\` from \`@generacy-ai/workflow-engine\` at the top level — a re-export that was added to \`workflow-engine/src/index.ts\` in a later develop commit but never made it to the published 0.1.1 tarball.

Every stable cluster currently crash-loops on boot:

\`\`\`
Failed to load @generacy-ai/orchestrator: The requested module
'@generacy-ai/workflow-engine' does not provide an export named
'FilesystemWorkflowStore'
\`\`\`

Observed on \`ai-lawfirm-orchestrator-1\` — restart count climbing every ~15 seconds.

## Why patch, not minor

Orchestrator 0.2.0's pinned dep is \`^0.1.1\` — caret on 0.1.x allows patch bumps but not minor. A minor bump on workflow-engine (0.1.1 → 0.2.0) would fall outside the range and require re-publishing the orchestrator with an updated dep, cascading the fix into another version-packages cycle. Patch (0.1.1 → 0.1.2) is automatically picked up by the existing orchestrator 0.2.0 on next \`npm install\`. The orchestrator entrypoint runs \`npm install\` on every boot, so once 0.1.2 is on the registry, crash-looping clusters self-heal on the next restart.

Semver-wise, \"adding an exported symbol\" is technically a feature, but the symbol existed in the package (\`dist/store/index.js\`) — only the top-level re-export was missing. Patch is defensible and operationally simpler.

## Verified non-issues

Audited all other \`@generacy-ai/*\` packages for the same drift:

- \`orchestrator-types\` — had a src commit since May 19 but the published 0.1.0 tarball already contains all symbols the orchestrator imports (\`AgentLauncher\`, \`OrchestratorConfig\`, \`ChildProcessHandle\`). Plus those are \`export type\` only — type imports get stripped at runtime, so even a missing one wouldn't error.
- \`credhelper\`, \`credhelper-daemon\`, \`knowledge-store\`, all \`generacy-plugin-*\` — zero source commits since May 19; stable versions are correct as-is.
- The six packages in #719 (\`generacy\`, \`orchestrator\`, \`control-plane\`, \`activation-client\`, \`config\`, \`cluster-relay\`) — all correctly bumped.

So this is the only remaining gap.

## Flow

1. Merge this → develop has the new changeset.
2. develop → main sync.
3. Changesets bot opens version-packages PR bumping workflow-engine 0.1.1 → 0.1.2.
4. Merge that PR → Release workflow publishes \`@generacy-ai/workflow-engine@stable@0.1.2\`.
5. Running clusters auto-pick up 0.1.2 on next \`npm install\` (which happens on every entrypoint boot). Existing crash-looping clusters self-heal within ~15 seconds of the publish.

## Verification

\`\`\`bash
npm view @generacy-ai/workflow-engine@stable version   # expect 0.1.2
docker logs ai-lawfirm-orchestrator-1 2>&1 | tail -20  # expect no FilesystemWorkflowStore error
docker ps --filter "name=ai-lawfirm-orchestrator-1" --format '{{.Status}}'   # expect "Up X"
\`\`\`

## Related

- [#719](https://github.com/generacy-ai/generacy/pull/719) — original bulk catch-up that missed this package.
- [#720](https://github.com/generacy-ai/generacy/issues/720) — make the changeset-bot gate actually block merges so future feature batches don't drift this way again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)