### PR TITLE
chore: catch-up changeset for #727 + #730

### DIFF
--- a/.changeset/release-followup-727-730.md
+++ b/.changeset/release-followup-727-730.md
@@ -1,0 +1,28 @@
+---
+"@generacy-ai/activation-client": minor
+"@generacy-ai/orchestrator": patch
+"@generacy-ai/generacy": patch
+---
+
+Catch stable up after #727 (cluster-side `tier-limit-exceeded` handling per
+[generacy-cloud#700](https://github.com/generacy-ai/generacy-cloud/issues/700))
+and #730 (empty-tier formatter fix per #728) shipped without their own
+changesets. The latter should have been caught by the new gate from #729, but
+slipped through because the PR branch predated the gate's merge by minutes and
+was never rebased — the workflow YAML resolved from the PR's HEAD (old/permissive
+version) rather than from develop's HEAD (new/strict version).
+
+Per-package summary:
+
+- `@generacy-ai/activation-client` — **minor** (additive public-API surface):
+  new `tier-limit-exceeded` variant on `PollResponseSchema` carrying
+  `{ cap, requested, tier }`; new exported `formatTierLimitError` function
+  shared between the resolver-side gate and the poll-time reject; empty-tier
+  formatter rendering fixed.
+- `@generacy-ai/orchestrator` — **patch**: new `TIER_LIMIT_EXCEEDED`
+  `ActivationError` code; activation flow throws on the new poll variant
+  with the formatted message.
+- `@generacy-ai/generacy` — **patch**: deploy command's activation poll
+  branches on the new variant; `worker-count-resolver` refactored to use
+  the shared `formatTierLimitError` instead of an inline string (closes
+  the wording-drift between resolver-side and poll-time error messages).


### PR DESCRIPTION
## Summary

Bumps stable for two PRs that shipped to preview without their own changesets:

- **#727** (closed [generacy-cloud#700](https://github.com/generacy-ai/generacy-cloud/issues/700) via [generacy#726](https://github.com/generacy-ai/generacy/issues/726)) — cluster-side \`tier-limit-exceeded\` variant on \`PollResponseSchema\`, new exported \`formatTierLimitError\` function, new \`TIER_LIMIT_EXCEEDED\` \`ActivationError\` code, orchestrator + deploy command + worker-count-resolver consumers wired through.
- **#730** (closed [#728](https://github.com/generacy-ai/generacy/issues/728)) — \`formatTierLimitError\` renders cleanly when \`tier\` is empty (fixes the double-space bug in the resolver-side gate's most common error path).

## Affected packages

- \`@generacy-ai/activation-client\` — **minor** (additive public-API surface: new union variant, new exported function)
- \`@generacy-ai/orchestrator\` — **patch** (new error code + activation branch)
- \`@generacy-ai/generacy\` — **patch** (deploy + resolver consumers)

## Why this was needed

Both PRs merged through the window where the new changeset gate ([#720](https://github.com/generacy-ai/generacy/issues/720) → [#729](https://github.com/generacy-ai/generacy/pull/729)) either didn't exist yet (#727 was before) or didn't apply because the branch predated the gate (#730 — branched before #729 merged; not rebased; GitHub Actions resolves workflow YAML from the PR's HEAD, which was the old permissive version).

This is a one-time backlog. New PRs branched off develop after #729 merged will see the strict workflow on their HEAD and be gated correctly. The remaining manual step on the user side is flipping \`Changeset Check\` to required in develop's branch protection.

## Flow after merge

1. Merge this → develop has the new changeset.
2. dev→main sync.
3. Changesets bot opens \`changeset-release/main\` PR bumping activation-client → 0.3.0, orchestrator → 0.2.1, generacy → 0.2.2.
4. Merge that PR → Release workflow publishes new stable versions.

## Verification after publish

\`\`\`bash
npm view @generacy-ai/activation-client@stable version   # expect 0.3.0 (was 0.2.0)
npm view @generacy-ai/orchestrator@stable version         # expect 0.2.1 (was 0.2.0)
npm view @generacy-ai/generacy@stable version             # expect 0.2.2 (was 0.2.1)

# A Basic-tier user running \`npx -y @generacy-ai/generacy@stable launch --workers=5\`
# should see "exceeds your Basic plan limit of 2" (or "exceeds your plan limit of 2"
# at the resolver site until launch-config also exposes \`tier\`).
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)