### PR TITLE
ci: build cluster images for linux/amd64 + linux/arm64

### DIFF
--- a/.github/workflows/publish-cluster-base-image.yml
+++ b/.github/workflows/publish-cluster-base-image.yml
@@ -33,6 +33,8 @@ jobs:
           fi
           echo "sha=sha-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -48,6 +50,7 @@ jobs:
           # repo-internal publish workflow that knew this; this generacy-side
           # workflow had been inheriting `.` (repo root) which has no Dockerfile.
           context: .devcontainer/generacy
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/generacy-ai/cluster-base:${{ steps.tags.outputs.channel }}

--- a/.github/workflows/publish-cluster-microservices-image.yml
+++ b/.github/workflows/publish-cluster-microservices-image.yml
@@ -33,6 +33,8 @@ jobs:
           fi
           echo "sha=sha-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -44,6 +46,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .devcontainer/generacy
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/generacy-ai/cluster-microservices:${{ steps.tags.outputs.channel }}


### PR DESCRIPTION
## Summary

- `publish-cluster-base-image.yml` and `publish-cluster-microservices-image.yml` ran on `ubuntu-latest` with no `platforms:` set on `docker/build-push-action`, so only a `linux/amd64` manifest was pushed to GHCR.
- Mac (Apple Silicon) developers running `generacy launch` hit `no matching manifest for linux/arm64/v8 in the manifest list entries` and couldn't pull `ghcr.io/generacy-ai/cluster-base:stable` (confirmed via direct `docker pull` on a developer's machine).
- Adds `docker/setup-qemu-action@v3` + `platforms: linux/amd64,linux/arm64` to both workflows so future tags carry an arm64 manifest.

## Caveats

- QEMU-emulated arm64 roughly doubles the publish job's wall-clock. If that becomes painful, the follow-up is splitting to a native-arm runner matrix (`ubuntu-24.04-arm`) with `docker/build-push-action`'s manifest merge.
- Once merged, existing `:stable` / `:preview` / `sha-…` tags on GHCR are still single-arch. To unblock Mac devs without waiting for the next commit, manually dispatch:
  ```
  gh workflow run publish-cluster-base-image.yml --repo generacy-ai/generacy -f ref=main
  gh workflow run publish-cluster-base-image.yml --repo generacy-ai/generacy -f ref=develop
  gh workflow run publish-cluster-microservices-image.yml --repo generacy-ai/generacy -f ref=main
  gh workflow run publish-cluster-microservices-image.yml --repo generacy-ai/generacy -f ref=develop
  ```
- The `cluster-base` / `cluster-microservices` Dockerfiles live in separate repos and weren't audited for arm64-clean apt/curl sources. First republish run will surface any issues.

## Test plan

- [ ] Merge to develop.
- [ ] Either wait for `poll-cluster-images.yml` to pick up the next cluster-base commit, or manually dispatch the publish workflows (see commands above).
- [ ] Verify resulting GHCR tag exposes both architectures: `docker manifest inspect ghcr.io/generacy-ai/cluster-base:sha-<new-sha>` shows entries for `linux/amd64` and `linux/arm64`.
- [ ] Have an Apple Silicon developer retry `generacy launch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)