### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/changeset-bot.yml
+++ b/.github/workflows/changeset-bot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check for changesets when publishable code changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -55,7 +55,7 @@ jobs:
 
           echo "Branch-channel validation passed: $CHANNEL on $BRANCH"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/publish-cluster-base-image.yml
+++ b/.github/workflows/publish-cluster-base-image.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: generacy-ai/cluster-base
           ref: ${{ inputs.ref }}
@@ -33,17 +33,17 @@ jobs:
           fi
           echo "sha=sha-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           # Build context = directory containing the Dockerfile + its COPY sources
           # (scripts/, code-server-extensions.txt). Cluster-base#17 removed the

--- a/.github/workflows/publish-cluster-microservices-image.yml
+++ b/.github/workflows/publish-cluster-microservices-image.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: generacy-ai/cluster-microservices
           ref: ${{ inputs.ref }}
@@ -33,17 +33,17 @@ jobs:
           fi
           echo "sha=sha-$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .devcontainer/generacy
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-devcontainer-feature.yml
+++ b/.github/workflows/publish-devcontainer-feature.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Stable: use devcontainers/action (tag trigger or explicit stable mode)
       - name: Publish Features (stable)

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -22,7 +22,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       published: ${{ steps.mode.outputs.publish }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary

GitHub Actions runners flip the default Node version from 20 → 24 on **June 2, 2026** ([deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The current action pins surfaced the deprecation warning on every recent publish run (visible in #734's dispatches). Bumping each action to the major that ships with Node 24:

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v6` | v5 added Node 24; v6 (Nov 2025) reworked credential persistence. |
| `docker/setup-qemu-action` | `@v3` | `@v4` | Node 24 + ESM rewrite. |
| `docker/setup-buildx-action` | `@v3` | `@v4` | Node 24 + removed deprecated inputs (none used here). |
| `docker/login-action` | `@v3` | `@v4` | Node 24. |
| `docker/build-push-action` | `@v6` | `@v7` | Node 24 + removed `DOCKER_BUILD_NO_SUMMARY` env (not used here). |

## Safety check performed

I audited every existing `with:` block against each action's release notes:
- No workflow passes `DOCKER_BUILD_NO_SUMMARY` or `DOCKER_BUILD_EXPORT_RETENTION_DAYS`.
- No workflow passes the deprecated `setup-buildx-action` inputs/outputs.
- The 9 `actions/checkout` usages only pass `fetch-depth`, `repository`, and `ref` — all unchanged across v4→v6.

## Out of scope

- `pnpm/action-setup@v4`, `actions/setup-node@v4`, `devcontainers/action@v1`, `softprops/action-gh-release@v2`, `actions/upload-artifact@v4`, `changesets/action@v1` — not flagged by the Node-20 deprecation warning. Could be bumped in a follow-up if/when they emit warnings of their own.

## Test plan

- [ ] Merge — `ci.yml` + `extension-ci.yml` + `changeset-bot.yml` run on this PR itself, exercising checkout@v6 end-to-end before merge.
- [ ] After merge: trigger a publish-cluster-base dispatch (any ref) and confirm the Node 20 deprecation warning is gone from the run's annotations.
- [ ] Confirm a published image still has both `linux/amd64` + `linux/arm64` manifest entries (regression check against #734).

🤖 Generated with [Claude Code](https://claude.com/claude-code)