### PR TITLE
fix(control-plane): defer post-activation sentinel until GitHub token is sealed (#739 repo-clone race)

### DIFF
--- a/.changeset/fix-739-post-activation-clone-race.md
+++ b/.changeset/fix-739-post-activation-clone-race.md
@@ -1,0 +1,15 @@
+---
+"@generacy-ai/control-plane": patch
+---
+
+fix(control-plane): defer the post-activation sentinel until the GitHub token is sealed
+
+`prepare-workspace` wrote the post-activation sentinel unconditionally, even
+when `writeWizardEnvFile` had not yet produced a `GH_TOKEN`. Because the
+post-activation watcher is one-shot, this fired the deferred repo clone before
+the GitHub token existed — the clone of a private repo authenticated with
+nothing, produced no workspace, and never re-ran when the token landed via
+`bootstrap-complete`. `writeWizardEnvFile` now reports `hasGitHubToken`, and
+`prepare-workspace` only writes the sentinel once the token is present
+(otherwise it defers to `bootstrap-complete`, which fires with the full
+credential set).

--- a/packages/control-plane/__tests__/routes/lifecycle.test.ts
+++ b/packages/control-plane/__tests__/routes/lifecycle.test.ts
@@ -20,7 +20,7 @@ vi.mock('../../src/util/read-body.js', () => ({
   readBody: vi.fn(async () => '{}'),
 }));
 vi.mock('../../src/services/wizard-env-writer.js', () => ({
-  writeWizardEnvFile: vi.fn(async () => ({ written: [], failed: [] })),
+  writeWizardEnvFile: vi.fn(async () => ({ written: [], failed: [], hasGitHubToken: false })),
 }));
 vi.mock('../../src/relay-events.js', () => ({
   getRelayPushEvent: vi.fn(() => undefined),
@@ -237,7 +237,7 @@ describe('handlePostLifecycle', () => {
       delete process.env.POST_ACTIVATION_TRIGGER;
       rmSync(tempDir, { recursive: true, force: true });
       vi.mocked(writeWizardEnvFile).mockReset();
-      vi.mocked(writeWizardEnvFile).mockResolvedValue({ written: [], failed: [] });
+      vi.mocked(writeWizardEnvFile).mockResolvedValue({ written: [], failed: [], hasGitHubToken: false });
     });
 
     it('returns 200 and writes sentinel file', async () => {
@@ -351,7 +351,11 @@ describe('handlePostLifecycle', () => {
       process.env.AGENCY_DIR = agencyDir;
       process.env.WIZARD_CREDS_PATH = envFilePath;
 
-      vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({ written: ['github-main-org'], failed: [] });
+      vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({
+        written: ['github-main-org'],
+        failed: [],
+        hasGitHubToken: false,
+      });
 
       const req = {} as IncomingMessage;
       const res = createMockResponse();
@@ -368,7 +372,7 @@ describe('handlePostLifecycle', () => {
       const sentinelPath = join(tempDir, 'bootstrap-no-creds');
       process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
 
-      vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({ written: [], failed: [] });
+      vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({ written: [], failed: [], hasGitHubToken: false });
 
       const req = {} as IncomingMessage;
       const res = createMockResponse();
@@ -402,6 +406,7 @@ describe('handlePostLifecycle', () => {
       vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({
         written: ['good-cred'],
         failed: ['bad-cred'],
+        hasGitHubToken: false,
       });
 
       const mockPushEvent = vi.fn();
@@ -440,12 +445,17 @@ describe('handlePostLifecycle', () => {
       delete process.env.WIZARD_CREDS_PATH;
       rmSync(tempDir, { recursive: true, force: true });
       vi.mocked(writeWizardEnvFile).mockReset();
-      vi.mocked(writeWizardEnvFile).mockResolvedValue({ written: [], failed: [] });
+      vi.mocked(writeWizardEnvFile).mockResolvedValue({ written: [], failed: [], hasGitHubToken: false });
     });
 
-    it('writes the same sentinel path bootstrap-complete uses', async () => {
+    it('writes the sentinel (same path bootstrap-complete uses) once the GitHub token is sealed', async () => {
       const sentinelPath = join(tempDir, 'prepare-workspace-sentinel');
       process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+      vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({
+        written: ['github-app'],
+        failed: [],
+        hasGitHubToken: true,
+      });
 
       const req = {} as IncomingMessage;
       const res = createMockResponse();
@@ -456,6 +466,23 @@ describe('handlePostLifecycle', () => {
       const body = JSON.parse(res._body);
       expect(body).toEqual({ accepted: true, action: 'prepare-workspace', sentinel: sentinelPath });
       expect(existsSync(sentinelPath)).toBe(true);
+    });
+
+    it('defers the sentinel until the GitHub token is sealed (no token → no clone yet)', async () => {
+      const sentinelPath = join(tempDir, 'prepare-workspace-deferred');
+      process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
+      // default mock: hasGitHubToken: false
+      const req = {} as IncomingMessage;
+      const res = createMockResponse();
+
+      await handlePostLifecycle(req, res, { userId: 'u-test' }, { action: 'prepare-workspace' });
+
+      expect(res.writeHead).toHaveBeenCalledWith(200);
+      const body = JSON.parse(res._body);
+      expect(body).toEqual({ accepted: true, action: 'prepare-workspace', sentinel: null });
+      // No early clone — the one-shot post-activation hook must not fire before
+      // GH_TOKEN exists; bootstrap-complete fires the sentinel later.
+      expect(existsSync(sentinelPath)).toBe(false);
     });
 
     it('unseals whatever credentials are currently stored (partial is fine)', async () => {
@@ -514,7 +541,7 @@ describe('handlePostLifecycle', () => {
       expect(existsSync(sentinelPath)).toBe(true);
     });
 
-    it('unseal failure is non-fatal (sentinel still written)', async () => {
+    it('unseal failure is non-fatal and defers the sentinel (no token → no clone yet)', async () => {
       const sentinelPath = join(tempDir, 'prepare-workspace-unseal-fail');
       process.env.POST_ACTIVATION_TRIGGER = sentinelPath;
 
@@ -525,8 +552,10 @@ describe('handlePostLifecycle', () => {
 
       await handlePostLifecycle(req, res, { userId: 'u-test' }, { action: 'prepare-workspace' });
 
-      expect(existsSync(sentinelPath)).toBe(true);
+      // Still responds 200 (non-fatal), but with no GH_TOKEN the early clone is
+      // deferred to bootstrap-complete rather than firing a token-less clone.
       expect(res.writeHead).toHaveBeenCalledWith(200);
+      expect(existsSync(sentinelPath)).toBe(false);
     });
 
     it('partial unseal emits the same cluster.bootstrap relay warning', async () => {
@@ -536,6 +565,7 @@ describe('handlePostLifecycle', () => {
       vi.mocked(writeWizardEnvFile).mockResolvedValueOnce({
         written: ['good-cred'],
         failed: ['bad-cred'],
+        hasGitHubToken: false,
       });
 
       const mockPushEvent = vi.fn();

--- a/packages/control-plane/__tests__/services/wizard-env-writer.test.ts
+++ b/packages/control-plane/__tests__/services/wizard-env-writer.test.ts
@@ -69,6 +69,7 @@ describe('writeWizardEnvFile', () => {
 
     expect(result.written).toEqual(['github-main-org', 'anthropic-api-key']);
     expect(result.failed).toEqual([]);
+    expect(result.hasGitHubToken).toBe(true);
 
     const envContent = await fs.readFile(envFilePath, 'utf8');
     expect(envContent).toContain('GH_TOKEN=ghp_abc123');
@@ -86,6 +87,7 @@ describe('writeWizardEnvFile', () => {
 
     expect(result.written).toEqual([]);
     expect(result.failed).toEqual([]);
+    expect(result.hasGitHubToken).toBe(false);
 
     const envContent = await fs.readFile(envFilePath, 'utf8');
     expect(envContent).toBe('');
@@ -96,6 +98,7 @@ describe('writeWizardEnvFile', () => {
 
     expect(result.written).toEqual([]);
     expect(result.failed).toEqual([]);
+    expect(result.hasGitHubToken).toBe(false);
 
     const envContent = await fs.readFile(envFilePath, 'utf8');
     expect(envContent).toBe('');

--- a/packages/control-plane/src/routes/lifecycle.ts
+++ b/packages/control-plane/src/routes/lifecycle.ts
@@ -107,14 +107,17 @@ export async function handlePostLifecycle(
     //
     // Idempotent w.r.t. bootstrap-complete: both use the same sentinel path
     // and the same writeWizardEnvFile call (which writes whatever is sealed
-    // at the moment), so calling bootstrap-complete after prepare-workspace
-    // re-writes the env file with the now-full credential set without
-    // disturbing the already-clone (the post-activation watcher only fires
-    // its hook on the first sentinel appearance).
+    // at the moment). The sentinel is only written once the GitHub token is
+    // actually sealed — otherwise the one-shot post-activation watcher fires
+    // the deferred clone before GH_TOKEN exists, clones nothing, and never
+    // re-runs when the token lands. When the token isn't ready yet we skip the
+    // sentinel; bootstrap-complete (end of wizard, full credentials) fires it.
     const agencyDir = process.env.AGENCY_DIR ?? '/workspaces/.agency';
     const envFilePath = process.env.WIZARD_CREDS_PATH ?? '/var/lib/generacy/wizard-credentials.env';
+    let hasGitHubToken = false;
     try {
       const envResult = await writeWizardEnvFile({ agencyDir, envFilePath });
+      hasGitHubToken = envResult.hasGitHubToken;
       if (envResult.failed.length > 0) {
         const pushEvent = getRelayPushEvent();
         pushEvent?.('cluster.bootstrap', {
@@ -128,10 +131,25 @@ export async function handlePostLifecycle(
     }
 
     const sentinel = process.env.POST_ACTIVATION_TRIGGER ?? '/tmp/generacy-bootstrap-complete';
-    await writeFile(sentinel, '', { flag: 'w' });
+    if (hasGitHubToken) {
+      await writeFile(sentinel, '', { flag: 'w' });
+    } else {
+      // GitHub token not sealed yet — defer the clone to bootstrap-complete so
+      // the one-shot post-activation hook runs with a usable GH_TOKEN.
+      getRelayPushEvent()?.('cluster.bootstrap', {
+        status: 'awaiting-credentials',
+        reason: 'github-token-not-sealed',
+      });
+    }
 
     res.writeHead(200);
-    res.end(JSON.stringify({ accepted: true, action: parsed.data, sentinel }));
+    res.end(
+      JSON.stringify({
+        accepted: true,
+        action: parsed.data,
+        sentinel: hasGitHubToken ? sentinel : null,
+      }),
+    );
     return;
   }
 

--- a/packages/control-plane/src/services/wizard-env-writer.ts
+++ b/packages/control-plane/src/services/wizard-env-writer.ts
@@ -16,6 +16,13 @@ export interface WriteWizardEnvFileResult {
   written: string[];
   /** Credential IDs that failed to unseal */
   failed: string[];
+  /**
+   * True when a usable `GH_TOKEN` was emitted to the env file. Callers gate the
+   * early post-activation clone on this — without a GitHub token the deferred
+   * clone of a private repo can't authenticate, so firing the (one-shot)
+   * post-activation sentinel before the token is sealed clones nothing.
+   */
+  hasGitHubToken: boolean;
 }
 
 interface EnvEntry {
@@ -82,7 +89,7 @@ export async function writeWizardEnvFile(
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
       // No credentials.yaml — write empty env file, no error
       await fs.writeFile(envFilePath, '', { mode: 0o600 });
-      return { written: [], failed: [] };
+      return { written: [], failed: [], hasGitHubToken: false };
     }
     throw err;
   }
@@ -90,7 +97,7 @@ export async function writeWizardEnvFile(
   const credentialIds = Object.keys(credentialsMap);
   if (credentialIds.length === 0) {
     await fs.writeFile(envFilePath, '', { mode: 0o600 });
-    return { written: [], failed: [] };
+    return { written: [], failed: [], hasGitHubToken: false };
   }
 
   const backend = getCredentialBackend();
@@ -119,5 +126,7 @@ export async function writeWizardEnvFile(
   // Write env file (mode 0600) — partial file on partial failure
   await fs.writeFile(envFilePath, formatEnvFile(entries), { mode: 0o600 });
 
-  return { written, failed };
+  const hasGitHubToken = entries.some((e) => e.key === 'GH_TOKEN' && e.value.length > 0);
+
+  return { written, failed, hasGitHubToken };
 }


### PR DESCRIPTION
Fixes #739.

## Problem

On a managed/cloud deploy the project repo was never cloned, even though activation, credentials, the tunnel, and vscode.dev all worked. Root cause: a **race between the post-activation sentinel and the GitHub token**.

The wizard calls `prepare-workspace` early (after the GitHub App step) to kick off the clone in parallel. That handler unsealed "whatever credentials are currently stored" and then wrote the post-activation sentinel **unconditionally**. The post-activation watcher is **one-shot** (its documented contract is "control-plane writes the sentinel *after* persisting credentials"). So when `prepare-workspace` fired before the GitHub token was sealed:

1. it wrote a token-less `wizard-credentials.env`,
2. the sentinel fired the deferred clone,
3. the private-repo clone had no `GH_TOKEN` → produced an empty `/workspaces` and still reported "complete",
4. the real credentials arrived ~3.5 min later via `bootstrap-complete`, but the one-shot watcher had already run and never re-cloned.

Observed on a staging droplet: clone ran 21:26 (no token), `wizard-credentials.env` written 21:30 (with token), `/workspaces` empty.

## Fix

- `writeWizardEnvFile` now returns **`hasGitHubToken`** (true when a non-empty `GH_TOKEN` was emitted).
- `prepare-workspace` writes the sentinel **only when `hasGitHubToken` is true**; otherwise it defers (emits a `cluster.bootstrap` `awaiting-credentials` event and returns `sentinel: null`). `bootstrap-complete` — the end-of-wizard step with the full credential set — fires the sentinel as before, so the one-shot clone runs with a usable token.

This keeps the early-clone optimization when the token is already sealed, and otherwise falls back to the (correct) end-of-wizard clone.

## Tests

- `wizard-env-writer`: `hasGitHubToken` true on github-app-with-token, false on empty/missing creds.
- `lifecycle`: sentinel written when token sealed; **deferred** (no sentinel, `sentinel: null`) when token absent or unseal fails.
- Full control-plane suite: 388/388 pass; `tsc --noEmit` clean.

## Follow-up (separate, defense-in-depth)

The cluster-base `entrypoint-post-activation.sh` still sources `wizard-credentials.env` only `if [ -f ]` and reports success even with no `GH_TOKEN`. Worth hardening it to require the token before cloning and fail (so `PostActivationRetryService` re-runs) — I'll file that in the cluster-base repo so the clone can't silently no-op even if some future caller fires the sentinel early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
