### PR TITLE
fix(orchestrator): resolve cluster identity from GH_USERNAME so assignee filtering works on cloud clusters

### DIFF
--- a/.changeset/fix-cluster-identity-gh-username.md
+++ b/.changeset/fix-cluster-identity-gh-username.md
@@ -1,0 +1,17 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+fix(orchestrator): fall back to GH_USERNAME for cluster identity (assignee filtering)
+
+The label-monitor resolves the cluster's GitHub identity to filter issues by
+assignee. It checked `CLUSTER_GITHUB_USERNAME`, then `gh api /user`, then gave
+up ("filtering disabled, all issues processed"). On cloud/wizard clusters the
+credential is a GitHub App installation token (`<app>[bot]`), which can't call
+`/user`, so identity resolution failed and the cluster processed every issue
+instead of only those assigned to the selected account.
+
+`resolveClusterIdentity` now falls back to `GH_USERNAME` — the human account
+the installation belongs to, already delivered to the cluster by the wizard —
+between the explicit config var and the `gh api /user` attempt. `CLUSTER_GITHUB_USERNAME`
+still takes precedence.

--- a/packages/orchestrator/src/services/__tests__/identity.test.ts
+++ b/packages/orchestrator/src/services/__tests__/identity.test.ts
@@ -70,6 +70,13 @@ describe('resolveClusterIdentity', () => {
     vi.clearAllMocks();
     execFileChildListeners = {};
     logger = createMockLogger();
+    // The gh-api fallback tests assume no ambient GH_USERNAME (the new
+    // wizard-account fallback would otherwise short-circuit them).
+    delete process.env['GH_USERNAME'];
+  });
+
+  afterEach(() => {
+    delete process.env['GH_USERNAME'];
   });
 
   it('returns config username when set (no gh call made)', async () => {
@@ -80,6 +87,30 @@ describe('resolveClusterIdentity', () => {
       { username: 'my-user', source: 'config' },
       expect.stringContaining('my-user'),
     );
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('falls back to GH_USERNAME (wizard-delivered account) when config not set', async () => {
+    process.env['GH_USERNAME'] = 'christrudelpw';
+
+    const result = await resolveClusterIdentity(undefined, logger);
+
+    expect(result).toBe('christrudelpw');
+    expect(logger.info).toHaveBeenCalledWith(
+      { username: 'christrudelpw', source: 'gh-username-env' },
+      expect.stringContaining('christrudelpw'),
+    );
+    // GH_USERNAME short-circuits before the gh api /user call (which can't
+    // resolve an identity from a GitHub App installation token anyway).
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('prefers CLUSTER_GITHUB_USERNAME (config) over GH_USERNAME', async () => {
+    process.env['GH_USERNAME'] = 'wizard-account';
+
+    const result = await resolveClusterIdentity('explicit-config', logger);
+
+    expect(result).toBe('explicit-config');
     expect(mockExecFile).not.toHaveBeenCalled();
   });
 

--- a/packages/orchestrator/src/services/identity.ts
+++ b/packages/orchestrator/src/services/identity.ts
@@ -45,7 +45,23 @@ export async function resolveClusterIdentity(
     return configUsername;
   }
 
-  // 2. Fallback: gh api /user
+  // 2. Wizard-delivered GitHub account (GH_USERNAME). This is the human account
+  //    the GitHub App installation belongs to (e.g. the account selected during
+  //    cluster setup). The `gh api /user` fallback below can't resolve an
+  //    identity from a GitHub App installation token (`<app>[bot]` tokens can't
+  //    call /user), so without this, cloud/wizard clusters fall through to
+  //    "filtering disabled" and process every issue instead of only those
+  //    assigned to the selected account.
+  const ghUsername = process.env['GH_USERNAME'];
+  if (ghUsername) {
+    logger.info(
+      { username: ghUsername, source: 'gh-username-env' },
+      `Cluster identity resolved: ${ghUsername} (from GH_USERNAME)`,
+    );
+    return ghUsername;
+  }
+
+  // 3. Fallback: gh api /user
   try {
     const login = await ghApiUser();
     logger.info(
@@ -79,7 +95,7 @@ export async function resolveClusterIdentity(
     }
   }
 
-  // 3. Both failed — filtering disabled
+  // 4. All sources failed — filtering disabled
   logger.warn('Assignee filtering disabled: no cluster identity configured. All issues will be processed.');
   return undefined;
 }


### PR DESCRIPTION
## Problem

The label-monitor filters issues by the cluster's GitHub identity. `resolveClusterIdentity` ([orchestrator/identity.ts](packages/orchestrator/src/services/identity.ts)) resolves it as:

1. `CLUSTER_GITHUB_USERNAME` env var, else
2. `gh api /user`, else
3. **disabled → "All issues will be processed."**

On cloud/wizard clusters the delivered credential is a **GitHub App installation token** (`generacy-ai[bot]`, `ghs_…`). Installation tokens **can't call `/user`**, so step 2 fails and identity resolution falls through to *disabled* — the cluster then processes **every** issue in the repo instead of only those assigned to the account the operator selected during setup.

The selected account is already present in the cluster as **`GH_USERNAME`** (the App's `accountLogin`, delivered via the wizard and used by `setup-credentials.sh` for git config), but nothing fed it into the identity resolver.

## Fix

Add a `GH_USERNAME` fallback between the explicit config var and the `gh api /user` attempt:

1. `CLUSTER_GITHUB_USERNAME` (unchanged, still wins)
2. **`GH_USERNAME`** (new — the human account the installation belongs to)
3. `gh api /user`
4. disabled

Note: you can't assign a GitHub issue to a bot, so "issues assigned to the credential's account" has to mean the human account that owns the installation — which is exactly what `GH_USERNAME` holds.

## Tests

- New: falls back to `GH_USERNAME` (no `gh` call made); `CLUSTER_GITHUB_USERNAME` still takes precedence over `GH_USERNAME`.
- Existing gh-api fallback tests guarded with `delete process.env.GH_USERNAME`.
- 25/25 identity tests pass; `tsc --noEmit` clean; changeset added.

Context: discovered while testing cloud cluster deploys (the orchestrator logged "Assignee filtering disabled: no cluster identity configured"). Pairs with the cloud-deploy `REPO_URL` fix (generacy-ai/generacy-cloud#785).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
