### PR TITLE
fix(control-plane): report actual VS Code tunnel name (fixes redeploy 'Timeout connecting to relay')

### DIFF
--- a/.changeset/fix-vscode-tunnel-actual-name.md
+++ b/.changeset/fix-vscode-tunnel-actual-name.md
@@ -1,0 +1,18 @@
+---
+"@generacy-ai/control-plane": patch
+---
+
+fix(control-plane): report the actual VS Code tunnel name, not the requested one
+
+The tunnel name is derived from the stable project id (#618), so deleting and
+redeploying a cluster for the same project makes the new Droplet request a name
+that's still registered to the (now-destroyed) previous Droplet. `code tunnel`
+reports "name already taken" and silently falls back to a random name — but the
+manager kept emitting the requested name, so the cloud persisted the wrong
+`vscodeTunnelName` and vscode.dev deep-linked to the dead tunnel ("Timeout
+connecting to relay").
+
+`VsCodeTunnelProcessManager` now parses the actual registered name from the
+`https://vscode.dev/tunnel/<name>/…` connection URL and reports that (falling
+back to the requested name only if no URL was seen), so the cloud/UI always
+points at the tunnel that's actually running.

--- a/packages/control-plane/__tests__/vscode-tunnel-manager.test.ts
+++ b/packages/control-plane/__tests__/vscode-tunnel-manager.test.ts
@@ -450,6 +450,37 @@ describe("VsCodeTunnelProcessManager", () => {
       });
     });
 
+    it("reports the ACTUAL tunnel name from the URL when the requested name was taken", async () => {
+      // Regression: when the requested --name is already taken (stale
+      // registration from a prior Droplet for the same project), `code tunnel`
+      // falls back to a random name. We must report that actual name (parsed
+      // from the connection URL) so the cloud/UI deep-links to the live tunnel,
+      // not the dead one.
+      const child = createMockChild();
+      spawnMock.mockReturnValue(child);
+
+      const mgr = new VsCodeTunnelProcessManager(defaultOpts());
+      const startResult = await mgr.start();
+      expect(startResult.tunnelName).toBe("test-cluster"); // requested name pre-connect
+
+      pushLine(
+        child,
+        "Open this link in your browser https://vscode.dev/tunnel/9ac46a6bef24/workspaces"
+      );
+
+      const connectedEvent = relayEvents.find(
+        (e) => e.payload.status === "connected"
+      );
+      expect(connectedEvent).toEqual({
+        channel: "cluster.vscode-tunnel",
+        payload: {
+          status: "connected",
+          tunnelName: "9ac46a6bef24",
+          tunnelUrl: "https://vscode.dev/tunnel/9ac46a6bef24/workspaces",
+        },
+      });
+    });
+
     it("emits disconnected event when connected process exits", async () => {
       const child = createMockChild();
       spawnMock.mockReturnValue(child);

--- a/packages/control-plane/src/services/vscode-tunnel-manager.ts
+++ b/packages/control-plane/src/services/vscode-tunnel-manager.ts
@@ -89,9 +89,21 @@ export class VsCodeTunnelProcessManager implements VsCodeTunnelManager {
   private deviceCode: string | null = null;
   private verificationUri: string | null = null;
   private tunnelUrl: string | null = null;
+  // The name `code tunnel` actually registered. It can differ from the
+  // requested `opts.tunnelName`: if that name is already taken (e.g. a stale
+  // registration left behind by a previously-deleted Droplet for the same
+  // project — the name is derived from the stable project id, see #618), the
+  // CLI silently falls back to a random name. We must report THIS name so the
+  // cloud/UI deep-links to the tunnel that's actually running, not the dead one.
+  private actualTunnelName: string | null = null;
   private stopping = false;
 
   constructor(private readonly opts: VsCodeTunnelManagerOptions) {}
+
+  /** Extract the registered tunnel name from a `https://vscode.dev/tunnel/<name>/…` URL. */
+  private tunnelNameFromUrl(url: string | null): string | null {
+    return url?.match(/vscode\.dev\/tunnel\/([\w-]+)/)?.[1] ?? null;
+  }
 
   getStatus(): VsCodeTunnelStatus {
     return this.status;
@@ -110,11 +122,14 @@ export class VsCodeTunnelProcessManager implements VsCodeTunnelManager {
       } else if (this.status === "connected") {
         emitTunnelEvent({
           status: "connected",
-          tunnelName: this.opts.tunnelName,
+          tunnelName: this.actualTunnelName ?? this.opts.tunnelName,
           tunnelUrl: this.tunnelUrl ?? undefined,
         });
       }
-      return { status: this.status, tunnelName: this.opts.tunnelName };
+      return {
+        status: this.status,
+        tunnelName: this.actualTunnelName ?? this.opts.tunnelName,
+      };
     }
 
     this.status = "starting";
@@ -144,6 +159,7 @@ export class VsCodeTunnelProcessManager implements VsCodeTunnelManager {
       this.deviceCode = null;
       this.verificationUri = null;
       this.tunnelUrl = null;
+      this.actualTunnelName = null;
 
       if (stopInitiated) {
         this.status = "stopped";
@@ -282,9 +298,12 @@ export class VsCodeTunnelProcessManager implements VsCodeTunnelManager {
       this.verificationUri = null;
       const urlMatch = line.match(TUNNEL_URL_PATTERN);
       this.tunnelUrl = urlMatch?.[1] ?? null;
+      // Prefer the name parsed from the actual tunnel URL — `code tunnel` may
+      // have fallen back to a random name when the requested name was taken.
+      this.actualTunnelName = this.tunnelNameFromUrl(this.tunnelUrl);
       emitTunnelEvent({
         status: "connected",
-        tunnelName: this.opts.tunnelName,
+        tunnelName: this.actualTunnelName ?? this.opts.tunnelName,
         tunnelUrl: this.tunnelUrl ?? undefined,
       });
     }


### PR DESCRIPTION
## Problem

After delete + redeploy of a cloud cluster, the VS Code tunnel never connects from vscode.dev — "The workbench failed to connect to the server (Error: Timeout connecting to relay)" — even though the cluster doc reports `vscodeTunnelStatus: connected`.

Root cause (confirmed on a live droplet by running `code tunnel` directly):

```
info g-xr7fxq61pf57u2loto is already taken, using a random name instead
info Creating tunnel with the name: 9ac46a6bef24
Open this link in your browser https://vscode.dev/tunnel/9ac46a6bef24/workspaces
```

The tunnel name is derived from the **stable project id** (`g-<projectId>`, #618). Destroying a droplet does **not** unregister its dev-tunnel, so on redeploy the new droplet requests a name that's still held by the dead droplet → `code tunnel` falls back to a **random** name (the container hostname). But `VsCodeTunnelProcessManager` kept emitting `this.opts.tunnelName` (the requested `g-<projectId>`), so the cloud persisted the wrong `vscodeTunnelName` and vscode.dev deep-linked to the **dead** tunnel → timeout. (This is why it worked on the *first* deploy but not after redeploys; version 1.95.3 and egress were ruled out.)

## Fix

The manager already parses the real connection URL (`TUNNEL_URL_PATTERN`); it just didn't use it for the name. Now it extracts the actual registered name from `https://vscode.dev/tunnel/<name>/…` and reports **that** in the `connected` event and `start()` result (falling back to the requested name only if no URL was parsed), and resets it on process exit. The cloud/UI then always deep-links to the tunnel that's actually running.

## Tests

- New regression test: a connected line with a different-named URL → emitted `tunnelName` is the actual name (`9ac46a6bef24`), not the requested `test-cluster`.
- Existing connected test (URL-less "is connected" line) still reports the requested name via fallback.
- 388/388 control-plane tests pass; `tsc --noEmit` clean; changeset added.

## Notes / follow-up

- Ships in the cluster-base image (control-plane) → needs an image rebuild to take effect.
- Side effect: each redeploy leaves an orphaned dev-tunnel registration on the account (eventually they accumulate). A good follow-up is unregistering the tunnel on teardown, or having the new droplet reclaim the stable name — but reporting the actual name is the correct, minimal fix that makes the tunnel work regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
