### PR TITLE
fix(scaffolder): share .claude volume + un-share worker workspace (workers can't run Claude)

### DIFF
--- a/.changeset/feat-750-identity-split-detector.md
+++ b/.changeset/feat-750-identity-split-detector.md
@@ -1,0 +1,16 @@
+---
+"@generacy-ai/orchestrator": minor
+---
+
+feat(orchestrator): detect cluster identity split and emit relay event (#750)
+
+Adds an identity-split detector that compares `process.env.GENERACY_CLUSTER_ID`
+against the persisted `cluster.json.cluster_id` during server startup. On
+mismatch it emits a single `cluster.identity-split` relay event per orchestrator
+process lifetime — surfacing clusters whose injected env identity has diverged
+from their persisted identity.
+
+The detector is best-effort and non-fatal: it never mutates env, `.env`, or
+`cluster.json`, and drops the event if no relay client is available. The new
+`cluster.identity-split` channel is added to the internal relay-events allowlist,
+and detection runs on both the existing-key and wizard-mode activation paths.

--- a/.changeset/fix-scaffolder-share-claude-config-volume.md
+++ b/.changeset/fix-scaffolder-share-claude-config-volume.md
@@ -1,0 +1,18 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+Share the `.claude` directory volume between orchestrator and workers in scaffolded clusters.
+
+The generated compose mounted only `~/.claude.json` (a file) and no shared
+`/home/node/.claude` directory volume, so workers never inherited the
+orchestrator's Claude auth, speckit slash-commands, or conversation history.
+Every spec-kit phase launched an unauthenticated Claude CLI, exited "Not logged
+in" in <1s, and the phase runner committed an empty phase — producing PRs with
+phase commits but no real artifacts.
+
+Align the generated compose with the canonical cluster-base layout: add a shared
+`claude-config:/home/node/.claude` volume on both services, stop mounting
+`workspace` on the worker (per-job checkouts are container-local), and mount
+`shared-packages` read-only on the worker. Only the `.claude` directory is
+volume-mounted — never the `.claude.json` file path (preserving the #737 fix).

--- a/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
@@ -12,9 +12,10 @@ services:
     volumes:
       - workspace:/workspaces
       - ~/.claude.json:/home/node/.claude.json
-      - shared-packages:/shared-packages
+      - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy
+      - shared-packages:/shared-packages
       - /var/run/docker.sock:/var/run/docker-host.sock
       - vscode-cli-state:/home/node/.vscode/cli
       - generacy-app-config-data:/var/lib/generacy-app-config
@@ -55,11 +56,11 @@ services:
     deploy:
       replicas: \${WORKER_COUNT:-1}
     volumes:
-      - workspace:/workspaces
       - ~/.claude.json:/home/node/.claude.json
-      - shared-packages:/shared-packages
+      - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy
+      - shared-packages:/shared-packages:ro
       - generacy-app-config-data:/var/lib/generacy-app-config:ro
     tmpfs: *a1
     environment:
@@ -102,6 +103,7 @@ services:
       - cluster-network
 volumes:
   workspace: null
+  claude-config: null
   shared-packages: null
   npm-cache: null
   generacy-data: null

--- a/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
@@ -311,13 +311,23 @@ describe('scaffoldDockerCompose', () => {
     expect(parsed.services.worker).not.toHaveProperty('ports');
   });
 
-  it('bind mode uses ~/.claude.json bind mount (no claude-config volume)', () => {
+  it('bind mode binds ~/.claude.json and shares the claude-config dir volume', () => {
     scaffoldDockerCompose(dir, { ...baseInput, claudeConfigMode: 'bind' });
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     const orchVolumes = parsed.services.orchestrator.volumes as string[];
+    const workerVolumes = parsed.services.worker.volumes as string[];
+    // ~/.claude.json is bind-mounted (account metadata file).
     expect(orchVolumes).toContain('~/.claude.json:/home/node/.claude.json');
-    expect(parsed.volumes).not.toHaveProperty('claude-config');
+    // The .claude DIRECTORY is a shared named volume so workers inherit the
+    // orchestrator's Claude auth + speckit commands + conversations.
+    expect(orchVolumes).toContain('claude-config:/home/node/.claude');
+    expect(workerVolumes).toContain('claude-config:/home/node/.claude');
+    expect(parsed.volumes).toHaveProperty('claude-config');
+    // #737 guard: never mount the named volume onto the .claude.json FILE path
+    // (Docker rejects "is not directory").
+    expect(orchVolumes).not.toContain('claude-config:/home/node/.claude.json');
+    expect(workerVolumes).not.toContain('claude-config:/home/node/.claude.json');
   });
 
   // T001 [US2]: lock SC-002 — bind-mode YAML must be byte-identical after the
@@ -339,9 +349,13 @@ describe('scaffoldDockerCompose', () => {
 
     expect(orchVolumes).toContain('./claude.json:/home/node/.claude.json');
     expect(workerVolumes).toContain('./claude.json:/home/node/.claude.json');
+    // #737 guard: the named volume must never mount onto the .claude.json FILE.
     expect(orchVolumes).not.toContain('claude-config:/home/node/.claude.json');
     expect(workerVolumes).not.toContain('claude-config:/home/node/.claude.json');
-    expect(parsed.volumes).not.toHaveProperty('claude-config');
+    // …but the .claude DIRECTORY is still a shared named volume on both.
+    expect(orchVolumes).toContain('claude-config:/home/node/.claude');
+    expect(workerVolumes).toContain('claude-config:/home/node/.claude');
+    expect(parsed.volumes).toHaveProperty('claude-config');
   });
 
   // T003 [US1]: idempotency per contract Q6–Q8 / FR-002, FR-003.
@@ -451,12 +465,24 @@ describe('scaffoldDockerCompose', () => {
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     expect(parsed.volumes).toHaveProperty('workspace');
+    expect(parsed.volumes).toHaveProperty('claude-config');
     expect(parsed.volumes).toHaveProperty('shared-packages');
     expect(parsed.volumes).toHaveProperty('npm-cache');
     expect(parsed.volumes).toHaveProperty('generacy-data');
     expect(parsed.volumes).toHaveProperty('redis-data');
     expect(parsed.volumes).toHaveProperty('vscode-cli-state');
     expect(parsed.volumes).toHaveProperty('generacy-app-config-data');
+  });
+
+  it('mounts workspace on the orchestrator only — workers do not share it', () => {
+    // Workers must not share the orchestrator's working tree (concurrent
+    // checkouts would clobber it); their per-job checkouts are container-local.
+    scaffoldDockerCompose(dir, baseInput);
+    const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
+
+    expect(parsed.services.orchestrator.volumes).toContain('workspace:/workspaces');
+    const workerVolumes = parsed.services.worker.volumes as string[];
+    expect(workerVolumes.some((v) => v.startsWith('workspace:'))).toBe(false);
   });
 
   it('mounts shared-packages at /shared-packages (cluster-base entrypoint contract)', () => {
@@ -470,7 +496,8 @@ describe('scaffoldDockerCompose', () => {
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     expect(parsed.services.orchestrator.volumes).toContain('shared-packages:/shared-packages');
-    expect(parsed.services.worker.volumes).toContain('shared-packages:/shared-packages');
+    // Worker consumes the orchestrator's build output read-only.
+    expect(parsed.services.worker.volumes).toContain('shared-packages:/shared-packages:ro');
   });
 
   it('sanitizes project name', () => {

--- a/packages/generacy/src/cli/commands/cluster/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/cluster/scaffolder.ts
@@ -142,31 +142,45 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
       ? ['${ORCHESTRATOR_PORT:-3100}:3100']
       : ['${ORCHESTRATOR_PORT:-3100}'];
 
-  // Shared volumes for orchestrator and worker.
+  // Volumes mounted on both orchestrator and worker. Mirrors the canonical
+  // cluster-base devcontainer compose.
   //
-  // shared-packages MUST mount at /shared-packages — that's where the
-  // cluster-base entrypoint scripts (`entrypoint-orchestrator.sh`) run
-  // `npm install --prefix /shared-packages`, and the worker's entrypoint
-  // resolves `/shared-packages/node_modules/.bin/generacy` to spawn the
-  // worker process. Mounting it anywhere else means the orchestrator's
-  // install writes to its own overlay filesystem (not the volume), the
-  // worker's resolve looks at its own overlay (empty), and the worker
-  // exits with "Cannot find module '/shared-packages/node_modules/.bin/generacy'".
-  // Matches the canonical cluster-base devcontainer compose.
-  const sharedVolumes = [
-    'workspace:/workspaces',
+  // claude-config (/home/node/.claude) is a SHARED named volume so the
+  // orchestrator's post-activation Claude setup — auth (`.credentials.json`),
+  // speckit slash commands, and conversation history — is visible to every
+  // worker. Without it, workers spawn an unauthenticated Claude CLI with no
+  // speckit commands; each phase exits "Not logged in" in <1s and the phase
+  // runner commits an empty phase, producing PRs with commits but no artifacts.
+  // (~/.claude.json is the separate account-metadata file; both are mounted.)
+  const commonVolumes = [
     claudeConfigVolume,
-    'shared-packages:/shared-packages',
+    'claude-config:/home/node/.claude',
     'npm-cache:/home/node/.npm',
     'generacy-data:/var/lib/generacy',
   ];
 
-  // Orchestrator gets docker socket
+  // shared-packages MUST mount at /shared-packages — that's where the
+  // cluster-base entrypoint scripts (`entrypoint-orchestrator.sh`) run
+  // `npm install --prefix /shared-packages`, and the worker's entrypoint
+  // resolves `/shared-packages/node_modules/.bin/generacy` to spawn the
+  // worker process. Orchestrator builds here (RW); workers consume read-only.
+  //
+  // The orchestrator owns the `workspace` volume (RW). Workers do NOT mount it
+  // at all — their per-job checkouts are container-local — so concurrent
+  // workers and the orchestrator can't clobber a shared working tree.
   const orchestratorVolumes = [
-    ...sharedVolumes,
+    'workspace:/workspaces',
+    ...commonVolumes,
+    'shared-packages:/shared-packages',
     '/var/run/docker.sock:/var/run/docker-host.sock',
     'vscode-cli-state:/home/node/.vscode/cli',
     'generacy-app-config-data:/var/lib/generacy-app-config',
+  ];
+
+  const workerVolumes = [
+    ...commonVolumes,
+    'shared-packages:/shared-packages:ro',
+    'generacy-app-config-data:/var/lib/generacy-app-config:ro',
   ];
 
   const tmpfsMounts = [
@@ -219,7 +233,7 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
         deploy: {
           replicas: '${WORKER_COUNT:-1}',
         },
-        volumes: [...sharedVolumes, 'generacy-app-config-data:/var/lib/generacy-app-config:ro'],
+        volumes: workerVolumes,
         tmpfs: tmpfsMounts,
         environment: [
           'REDIS_URL=redis://redis:6379',
@@ -258,6 +272,7 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
     },
     volumes: {
       workspace: null,
+      'claude-config': null,
       'shared-packages': null,
       'npm-cache': null,
       'generacy-data': null,

--- a/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
@@ -246,6 +246,29 @@ describe('scaffoldProject', () => {
   // .env file
   // -------------------------------------------------------------------------
 
+  // FR-001 verification gate (#750): the launch scaffolder MUST write the
+  // cloud-returned LaunchConfig.clusterId byte-for-byte to GENERACY_CLUSTER_ID.
+  // No client-side UUID minting or override. A regression to client-minted
+  // ids would resurrect the identity-split bug observed on staging.
+  it('writes GENERACY_CLUSTER_ID byte-for-byte from LaunchConfig.clusterId (FR-001)', () => {
+    const projectDir = join(tempDir, 'fr-001-gate');
+    const exactClusterId = 'a356d8f5-cca3-4f4a-9070-4fd8084b0468';
+    scaffoldProject(
+      projectDir,
+      { ...mockConfig, clusterId: exactClusterId },
+      1,
+    );
+
+    const content = readFileSync(
+      join(projectDir, '.generacy', '.env'),
+      'utf-8',
+    );
+
+    // Match the exact line, not a substring — ensures no transformation/wrapping.
+    const lines = content.split('\n');
+    expect(lines).toContain(`GENERACY_CLUSTER_ID=${exactClusterId}`);
+  });
+
   it('writes .env file with identity and project vars', () => {
     const projectDir = join(tempDir, 'new-project');
     scaffoldProject(projectDir, mockConfig, 1);

--- a/packages/orchestrator/src/__tests__/identity-split-detector.test.ts
+++ b/packages/orchestrator/src/__tests__/identity-split-detector.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { FastifyBaseLogger } from 'fastify';
+
+import {
+  detectIdentitySplit,
+  resetIdentitySplitDetectionState,
+  type IdentitySplitEvent,
+} from '../services/identity-split-detector.js';
+
+function createMockLogger(): FastifyBaseLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+    level: 'info',
+    silent: vi.fn(),
+  } as unknown as FastifyBaseLogger;
+}
+
+function writeValidClusterJson(path: string, clusterId: string): void {
+  writeFileSync(
+    path,
+    JSON.stringify({
+      cluster_id: clusterId,
+      project_id: 'proj_test',
+      org_id: 'org_test',
+      cloud_url: 'https://api.example.test',
+      activated_at: new Date().toISOString(),
+    }),
+  );
+}
+
+describe('detectIdentitySplit', () => {
+  let tempDir: string;
+  let clusterJsonPath: string;
+  let logger: FastifyBaseLogger;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'identity-split-test-'));
+    clusterJsonPath = join(tempDir, 'cluster.json');
+    logger = createMockLogger();
+    resetIdentitySplitDetectionState();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    resetIdentitySplitDetectionState();
+  });
+
+  it('returns match and does not emit when env id equals cluster.json id', async () => {
+    const id = 'cluster-aaa';
+    writeValidClusterJson(clusterJsonPath, id);
+    const sendRelayEvent = vi.fn();
+
+    const outcome = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: id },
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(outcome).toEqual({ kind: 'match', clusterId: id });
+    expect(sendRelayEvent).not.toHaveBeenCalled();
+  });
+
+  it('emits exactly one relay event with the correct payload shape on mismatch (first call)', async () => {
+    const envId = 'env-id-aaa';
+    const jsonId = 'json-id-bbb';
+    writeValidClusterJson(clusterJsonPath, jsonId);
+    const sendRelayEvent = vi.fn();
+
+    const outcome = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: envId },
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(outcome.kind).toBe('mismatch');
+    if (outcome.kind === 'mismatch') {
+      expect(outcome.envClusterId).toBe(envId);
+      expect(outcome.clusterJsonClusterId).toBe(jsonId);
+      expect(outcome.emitted).toBe(true);
+    }
+
+    expect(sendRelayEvent).toHaveBeenCalledTimes(1);
+    const [channel, payload] = sendRelayEvent.mock.calls[0] as [
+      string,
+      IdentitySplitEvent,
+    ];
+    expect(channel).toBe('cluster.identity-split');
+    expect(payload.env_cluster_id).toBe(envId);
+    expect(payload.cluster_json_cluster_id).toBe(jsonId);
+    expect(payload.detected_at).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/,
+    );
+  });
+
+  it('suppresses subsequent emissions across the same process lifetime (FR-005)', async () => {
+    const envId = 'env-id-aaa';
+    const jsonId = 'json-id-bbb';
+    writeValidClusterJson(clusterJsonPath, jsonId);
+    const sendRelayEvent = vi.fn();
+
+    const first = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: envId },
+      sendRelayEvent,
+      logger,
+    });
+    const second = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: envId },
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(first.kind).toBe('mismatch');
+    expect(second.kind).toBe('mismatch');
+    if (first.kind === 'mismatch') expect(first.emitted).toBe(true);
+    if (second.kind === 'mismatch') expect(second.emitted).toBe(false);
+
+    expect(sendRelayEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns no-env when GENERACY_CLUSTER_ID is unset (no event)', async () => {
+    writeValidClusterJson(clusterJsonPath, 'json-id-bbb');
+    const sendRelayEvent = vi.fn();
+
+    const outcome = await detectIdentitySplit({
+      clusterJsonPath,
+      env: {},
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(outcome).toEqual({ kind: 'no-env', envClusterId: undefined });
+    expect(sendRelayEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns no-env when GENERACY_CLUSTER_ID is empty string (no event)', async () => {
+    writeValidClusterJson(clusterJsonPath, 'json-id-bbb');
+    const sendRelayEvent = vi.fn();
+
+    const outcome = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: '' },
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(outcome.kind).toBe('no-env');
+    expect(sendRelayEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns no-cluster-json when cluster.json is missing (no event)', async () => {
+    const sendRelayEvent = vi.fn();
+
+    const outcome = await detectIdentitySplit({
+      clusterJsonPath: join(tempDir, 'does-not-exist.json'),
+      env: { GENERACY_CLUSTER_ID: 'env-id-aaa' },
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'no-cluster-json',
+      envClusterId: 'env-id-aaa',
+    });
+    expect(sendRelayEvent).not.toHaveBeenCalled();
+  });
+
+  it('returns no-cluster-json when cluster.json is corrupt (no event)', async () => {
+    writeFileSync(clusterJsonPath, '{ this is not json');
+    const sendRelayEvent = vi.fn();
+
+    const outcome = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: 'env-id-aaa' },
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(outcome.kind).toBe('no-cluster-json');
+    expect(sendRelayEvent).not.toHaveBeenCalled();
+  });
+
+  it('swallows sendRelayEvent throws, logs error, and still flips hasEmitted (single attempt counts)', async () => {
+    const envId = 'env-id-aaa';
+    const jsonId = 'json-id-bbb';
+    writeValidClusterJson(clusterJsonPath, jsonId);
+    const sendRelayEvent = vi.fn(() => {
+      throw new Error('relay client exploded');
+    });
+
+    const first = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: envId },
+      sendRelayEvent,
+      logger,
+    });
+
+    // First call: emission attempt counted, error logged & swallowed
+    expect(first.kind).toBe('mismatch');
+    if (first.kind === 'mismatch') expect(first.emitted).toBe(true);
+    expect(sendRelayEvent).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+
+    // Second call: suppressed (hasEmitted is true even though previous send threw)
+    const second = await detectIdentitySplit({
+      clusterJsonPath,
+      env: { GENERACY_CLUSTER_ID: envId },
+      sendRelayEvent,
+      logger,
+    });
+
+    expect(second.kind).toBe('mismatch');
+    if (second.kind === 'mismatch') expect(second.emitted).toBe(false);
+    expect(sendRelayEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/orchestrator/src/routes/internal-relay-events.ts
+++ b/packages/orchestrator/src/routes/internal-relay-events.ts
@@ -7,6 +7,7 @@ const ALLOWED_CHANNELS = [
   'cluster.audit',
   'cluster.credentials',
   'cluster.bootstrap',
+  'cluster.identity-split',
 ] as const;
 
 export const RelayEventRequestSchema = z.object({

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -49,6 +49,7 @@ import { SessionService } from './services/session-service.js';
 import { activate } from './activation/index.js';
 import { StatusReporter } from './services/status-reporter.js';
 import { PostActivationRetryService } from './services/post-activation-retry.js';
+import { detectIdentitySplit } from './services/identity-split-detector.js';
 import { TunnelHandler, getCodeServerManager, DockerEngineClient } from '@generacy-ai/control-plane';
 import { setupInternalRelayEventsRoute } from './routes/internal-relay-events.js';
 import { setupInternalRefreshMetadataRoute } from './routes/internal-refresh-metadata.js';
@@ -357,6 +358,23 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
     const result = await initializeRelayBridge(config, server, apiKeyStore, (client) => { relayClientRef = client; });
     relayBridge = result.relayBridge;
     relayBridgeRef = result.relayBridge;
+
+    // Detect identity split (env GENERACY_CLUSTER_ID vs persisted cluster.json.cluster_id).
+    // Best-effort: drops event if relay client unavailable. Once per process lifetime (#750).
+    detectIdentitySplit({
+      clusterJsonPath: config.activation.clusterJsonPath,
+      logger: server.log,
+      sendRelayEvent: relayClientRef
+        ? (channel, payload) => relayClientRef!.send({
+            type: 'event',
+            event: channel,
+            data: payload,
+            timestamp: new Date().toISOString(),
+          } as unknown as import('./types/relay.js').RelayMessage)
+        : undefined,
+    }).catch((err) => {
+      server.log.error({ err }, 'Identity-split detection failed (non-fatal)');
+    });
 
     // Check if post-activation needs to be retried (activated but completion flag absent)
     const retryService = new PostActivationRetryService({
@@ -723,6 +741,23 @@ async function activateInBackground(
   if (relayBridge) {
     await relayBridge.start();
   }
+
+  // Detect identity split after relay bridge has started (wizard-mode path, #750).
+  // Same call shape as the existing-key path; once-per-process guard lives in the detector.
+  detectIdentitySplit({
+    clusterJsonPath: config.activation.clusterJsonPath,
+    logger: server.log,
+    sendRelayEvent: localRelayClient
+      ? (channel, payload) => localRelayClient!.send({
+          type: 'event',
+          event: channel,
+          data: payload,
+          timestamp: new Date().toISOString(),
+        } as unknown as import('./types/relay.js').RelayMessage)
+      : undefined,
+  }).catch((err) => {
+    server.log.error({ err }, 'Identity-split detection failed (non-fatal)');
+  });
 
   // Check if post-activation needs to be retried (wizard-mode: activation just completed
   // but post-activation may have failed on a prior container lifecycle)

--- a/packages/orchestrator/src/services/identity-split-detector.ts
+++ b/packages/orchestrator/src/services/identity-split-detector.ts
@@ -1,0 +1,113 @@
+/**
+ * Identity-split detector.
+ *
+ * Compares `process.env.GENERACY_CLUSTER_ID` to the persisted
+ * `cluster.json.cluster_id`. On mismatch, emits a single
+ * `cluster.identity-split` relay event per orchestrator process lifetime.
+ *
+ * Never mutates env, .env, or cluster.json (FR-003).
+ */
+import type { FastifyBaseLogger } from 'fastify';
+import { readClusterJson } from '../activation/persistence.js';
+
+export interface IdentitySplitEvent {
+  env_cluster_id: string;
+  cluster_json_cluster_id: string;
+  detected_at: string;
+}
+
+export type DetectionOutcome =
+  | { kind: 'no-env'; envClusterId: undefined }
+  | { kind: 'no-cluster-json'; envClusterId: string }
+  | { kind: 'match'; clusterId: string }
+  | {
+      kind: 'mismatch';
+      envClusterId: string;
+      clusterJsonClusterId: string;
+      emitted: boolean;
+    };
+
+export interface DetectIdentitySplitOptions {
+  clusterJsonPath: string;
+  env?: NodeJS.ProcessEnv;
+  sendRelayEvent?: (
+    channel: 'cluster.identity-split',
+    payload: IdentitySplitEvent,
+  ) => void;
+  logger: Pick<FastifyBaseLogger, 'info' | 'warn' | 'error'>;
+}
+
+// Module-level once-guard. Container restart = fresh module = resets to false.
+let hasEmitted = false;
+
+/**
+ * Test helper: reset the once-emitted flag. Not for production use.
+ */
+export function resetIdentitySplitDetectionState(): void {
+  hasEmitted = false;
+}
+
+export async function detectIdentitySplit(
+  options: DetectIdentitySplitOptions,
+): Promise<DetectionOutcome> {
+  const env = options.env ?? process.env;
+  const envClusterId = env['GENERACY_CLUSTER_ID'];
+
+  if (!envClusterId || envClusterId.length === 0) {
+    return { kind: 'no-env', envClusterId: undefined };
+  }
+
+  const clusterJson = await readClusterJson(options.clusterJsonPath);
+  if (!clusterJson) {
+    return { kind: 'no-cluster-json', envClusterId };
+  }
+
+  if (envClusterId === clusterJson.cluster_id) {
+    return { kind: 'match', clusterId: envClusterId };
+  }
+
+  // Mismatch detected
+  if (hasEmitted) {
+    options.logger.info(
+      { envClusterId, clusterJsonClusterId: clusterJson.cluster_id },
+      'Identity-split detected (already emitted this process lifetime — suppressing)',
+    );
+    return {
+      kind: 'mismatch',
+      envClusterId,
+      clusterJsonClusterId: clusterJson.cluster_id,
+      emitted: false,
+    };
+  }
+
+  const payload: IdentitySplitEvent = {
+    env_cluster_id: envClusterId,
+    cluster_json_cluster_id: clusterJson.cluster_id,
+    detected_at: new Date().toISOString(),
+  };
+
+  // Flip the once-guard before attempting send: a single attempt counts,
+  // even if the send throws (quickstart.md: "single attempt counts").
+  hasEmitted = true;
+
+  options.logger.info(
+    { envClusterId, clusterJsonClusterId: clusterJson.cluster_id },
+    'Identity-split detected: emitting cluster.identity-split relay event',
+  );
+
+  try {
+    options.sendRelayEvent?.('cluster.identity-split', payload);
+  } catch (err) {
+    options.logger.error(
+      { err },
+      'Failed to send cluster.identity-split relay event (swallowed)',
+    );
+  }
+
+  return {
+    kind: 'mismatch',
+    envClusterId,
+    clusterJsonClusterId: clusterJson.cluster_id,
+    emitted: true,
+  };
+}

--- a/specs/750-summary-local-cluster-s/clarifications.md
+++ b/specs/750-summary-local-cluster-s/clarifications.md
@@ -11,7 +11,11 @@
 - C: Unknown / both — root-causing the exact mint site is part of this fix's deliverables.
 - D: Pre-activation volume contamination — a previously-activated cluster's `cluster.json` survives in a Docker volume and gets reused on the next launch (`clearStaleActivation` exists for this — possibly insufficient).
 
-**Answer**: *Pending*
+**Answer**: **A** — cloud-side; the two cloud endpoints disagree. Confirmed by inspection + the live ids:
+- `buildLaunchConfig` returns `claim.clusterId` (`services/api/src/services/launch-config.ts:121`) → this is what the scaffolder writes to `GENERACY_CLUSTER_ID` (observed `6c23c4c4-…`).
+- The device-code activation **mints a fresh `randomUUID()`** (`services/api/src/services/cluster-activation.ts:385-386`, "#792: generate fresh UUID (was hardcoded `clusterId = projectId`)") → this becomes the actual cluster doc + API key (observed `a356d8f5-…`, the only doc that exists; `clusters/6c23c4c4-…` is a 404 with no api_keys).
+
+The client is *not* at fault — the launch scaffolder correctly uses `config.clusterId`. So this is **(a)**: the claim/`buildLaunchConfig` id and the device-code `poll`-minted id diverge.
 
 ### Q2: Canonical id source when LaunchConfig.clusterId ≠ pollResult.cluster_id
 **Context**: The relay handshake authenticates with the API key, which is associated with `pollResult.cluster_id` on the cloud side. So `pollResult.cluster_id` is what cloud-side Firestore queries will resolve. But `LaunchConfig.clusterId` is what the user "added" via the web "Add cluster → local" flow. These should be the same — but if cloud returns different ids, which one becomes `GENERACY_CLUSTER_ID`?
@@ -21,7 +25,7 @@
 - B: `LaunchConfig.clusterId` wins. The cloud must guarantee `poll` returns the same id (cloud-side fix). The client treats divergence as an error.
 - C: Fail-fast. Orchestrator detects divergence and refuses to start, surfacing an actionable error message ("cloud returned mismatched ids — report this").
 
-**Answer**: *Pending*
+**Answer**: **B** — the claim / `LaunchConfig.clusterId` should be canonical, and the cloud must make device-code activation **use** it (mint the cluster id once at "Add cluster"/claim creation and have activation create the doc + API key under that id, instead of minting a fresh UUID). This keeps the already-scaffolded `GENERACY_CLUSTER_ID` correct with **no in-container `.env` rewrite** — which Q5 shows is unreliable across the host `.env` and already-spawned workers. The client treats any residual divergence as an error (Q4).
 
 ### Q3: Cloud-side coordination required?
 **Context**: Spec's Out-of-Scope explicitly lists "Cloud-side cluster-doc id minting strategy beyond ensuring it is returned to the launch path". FR-004 says "verify cloud `buildLaunchConfig` returns the doc id" — implying the cloud already does so, or this fix only verifies it. But if Q1=A (cloud is the source of the split), the fix can't be purely client-side.
@@ -31,7 +35,7 @@
 - B: Companion cloud PR required. File a separate cloud issue and treat this issue as blocked/dependent until cloud lands the fix. Note in spec.
 - C: Both sides. Client adds detection/reconciliation; cloud ensures id consistency. Document the cloud companion as a related issue but proceed with client work in parallel.
 
-**Answer**: *Pending*
+**Answer**: **C** — both sides, in parallel. The id-consistency fix is cloud-side (a `generacy-ai/generacy-cloud` companion: activation must reuse the claim/launch-config clusterId), while this issue (`packages/generacy` / `packages/orchestrator`) ships divergence **detection** (Q4) and verifies the launch path uses `config.clusterId`. Don't hard-block #750 on the cloud PR (B) — the detection work is independent and useful on its own.
 
 ### Q4: Existing mismatched clusters at orchestrator startup
 **Context**: FR-005 says "Existing local clusters with mismatched ids MUST NOT be silently rewritten. Reconciliation/migration is out of scope". But the orchestrator boots on every restart — it will repeatedly observe the mismatch. What should it do?
@@ -42,7 +46,7 @@
 - C: Refuse to start (`process.exit(1)`). Forces remediation but breaks existing mismatched clusters until manually destroyed/re-launched.
 - D: No detection at all — fix only ensures *fresh* launches scaffold correctly; existing clusters keep working as-is.
 
-**Answer**: *Pending*
+**Answer**: **B** — emit a relay error event (`cluster.identity-split`) at orchestrator startup when `process.env.GENERACY_CLUSTER_ID` ≠ persisted `cluster.json.cluster_id`, then continue. Surfacing it lets the cloud UI show a remediation banner ("destroy and re-launch this cluster") — the only real fix for an already-split cluster, since FR-005 forbids silent rewrite. A plain log (A) isn't user-visible; refusing to start (C) breaks existing mismatched clusters; no detection (D) wastes the signal. The orchestrator-side event emission is in scope here; the UI banner belongs to the cloud companion.
 
 ### Q5: Activation-time `.env` rewrite when ids diverge
 **Context**: If Q2=A (pollResult wins) and the cloud actually returns divergent ids, the orchestrator would need to update `GENERACY_CLUSTER_ID` to the right value. The orchestrator runs inside Docker, where `/var/lib/generacy/cluster.json` is in a named volume but `.env` is on the host (mounted as compose env-file). Mid-container env mutation doesn't propagate back to the host `.env` or to already-spawned worker processes without a container restart.
@@ -52,4 +56,4 @@
 - B: Write the corrected value into a runtime-state file (e.g. `/var/lib/generacy/runtime-identity.json`) that orchestrator + workers consult first, falling back to env. Host `.env` is left as-is; relay metadata reflects the runtime value.
 - C: This won't happen if cloud guarantees consistency (Q2=B/Q3=B/C) — defer reconciliation logic until/unless the divergence is actually observed in practice.
 
-**Answer**: *Pending*
+**Answer**: **C** — won't arise given Q2=B. Once the cloud guarantees a single consistent id (claim id == activation id == doc id), there is no divergence for the orchestrator to reconcile, so defer the in-container rewrite logic entirely (the question itself shows it can't reliably propagate to the host `.env` or to already-spawned workers). Detection (Q4) covers the legacy/already-split case.

--- a/specs/750-summary-local-cluster-s/clarifications.md
+++ b/specs/750-summary-local-cluster-s/clarifications.md
@@ -1,0 +1,55 @@
+# Clarifications
+
+## Batch 1 — 2026-06-04
+
+### Q1: Root cause location
+**Context**: The launch scaffolder already uses `config.clusterId` from the cloud `LaunchConfig` (see `packages/generacy/src/cli/commands/launch/scaffolder.ts:71-114`). The launch path writes that id into `.env` (`GENERACY_CLUSTER_ID`) and host-side `.generacy/cluster.json`. Separately, the orchestrator's activation flow writes `pollResult.cluster_id` into the container-side `/var/lib/generacy/cluster.json` (`packages/orchestrator/src/activation/index.ts:160-166`). So a split can only arise if (a) the cloud's `buildLaunchConfig` returns a different id than the device-code `poll` endpoint, OR (b) the CLI mints/overwrites the id somewhere we missed. The original bug report notes the exact mint site wasn't root-caused. Implementation direction depends on the answer.
+**Question**: Where is the id mismatch actually introduced?
+**Options**:
+- A: Cloud-side — `buildLaunchConfig` (or the web "Add cluster → local" flow) returns one cluster id, but the device-code `poll` endpoint mints/returns a different one. Both endpoints disagree.
+- B: Client-side — somewhere in the launch CLI a locally-minted UUID overrides `config.clusterId` before scaffolding (need to find the site).
+- C: Unknown / both — root-causing the exact mint site is part of this fix's deliverables.
+- D: Pre-activation volume contamination — a previously-activated cluster's `cluster.json` survives in a Docker volume and gets reused on the next launch (`clearStaleActivation` exists for this — possibly insufficient).
+
+**Answer**: *Pending*
+
+### Q2: Canonical id source when LaunchConfig.clusterId ≠ pollResult.cluster_id
+**Context**: The relay handshake authenticates with the API key, which is associated with `pollResult.cluster_id` on the cloud side. So `pollResult.cluster_id` is what cloud-side Firestore queries will resolve. But `LaunchConfig.clusterId` is what the user "added" via the web "Add cluster → local" flow. These should be the same — but if cloud returns different ids, which one becomes `GENERACY_CLUSTER_ID`?
+**Question**: When the two cloud-returned ids disagree, which one is the single source of truth?
+**Options**:
+- A: `pollResult.cluster_id` wins. The orchestrator rewrites `.env` (and the host-side `cluster.json`) post-activation to match the id the API key authenticates as. Tunnel/identity correctness over user intent.
+- B: `LaunchConfig.clusterId` wins. The cloud must guarantee `poll` returns the same id (cloud-side fix). The client treats divergence as an error.
+- C: Fail-fast. Orchestrator detects divergence and refuses to start, surfacing an actionable error message ("cloud returned mismatched ids — report this").
+
+**Answer**: *Pending*
+
+### Q3: Cloud-side coordination required?
+**Context**: Spec's Out-of-Scope explicitly lists "Cloud-side cluster-doc id minting strategy beyond ensuring it is returned to the launch path". FR-004 says "verify cloud `buildLaunchConfig` returns the doc id" — implying the cloud already does so, or this fix only verifies it. But if Q1=A (cloud is the source of the split), the fix can't be purely client-side.
+**Question**: Does this fix require a companion cloud-side PR (`generacy-ai/generacy-cloud`)?
+**Options**:
+- A: Strictly client-side. Cloud already returns the correct id; fix is only in `packages/generacy` and/or `packages/orchestrator`. Spec scope unchanged.
+- B: Companion cloud PR required. File a separate cloud issue and treat this issue as blocked/dependent until cloud lands the fix. Note in spec.
+- C: Both sides. Client adds detection/reconciliation; cloud ensures id consistency. Document the cloud companion as a related issue but proceed with client work in parallel.
+
+**Answer**: *Pending*
+
+### Q4: Existing mismatched clusters at orchestrator startup
+**Context**: FR-005 says "Existing local clusters with mismatched ids MUST NOT be silently rewritten. Reconciliation/migration is out of scope". But the orchestrator boots on every restart — it will repeatedly observe the mismatch. What should it do?
+**Question**: When the orchestrator starts and detects `process.env.GENERACY_CLUSTER_ID` ≠ persisted `cluster.json.cluster_id`, how should it behave?
+**Options**:
+- A: Log a single warning at startup (`cluster.identity-split-detected`), proceed normally. Visible in logs and metadata, but not surfaced as an error to the user.
+- B: Push a relay error event (`cluster.identity-split`) and continue. Cloud-side UI can surface a remediation banner ("destroy and re-launch this cluster").
+- C: Refuse to start (`process.exit(1)`). Forces remediation but breaks existing mismatched clusters until manually destroyed/re-launched.
+- D: No detection at all — fix only ensures *fresh* launches scaffold correctly; existing clusters keep working as-is.
+
+**Answer**: *Pending*
+
+### Q5: Activation-time `.env` rewrite when ids diverge
+**Context**: If Q2=A (pollResult wins) and the cloud actually returns divergent ids, the orchestrator would need to update `GENERACY_CLUSTER_ID` to the right value. The orchestrator runs inside Docker, where `/var/lib/generacy/cluster.json` is in a named volume but `.env` is on the host (mounted as compose env-file). Mid-container env mutation doesn't propagate back to the host `.env` or to already-spawned worker processes without a container restart.
+**Question**: If the orchestrator detects the split and Q2=A is the chosen behavior, how should it reconcile?
+**Options**:
+- A: Best-effort in-container only — orchestrator process uses `pollResult.cluster_id` internally (overrides `GENERACY_CLUSTER_ID`), but doesn't try to rewrite host `.env`. Workers re-read it from a control-plane endpoint or cluster.json instead of trusting env.
+- B: Write the corrected value into a runtime-state file (e.g. `/var/lib/generacy/runtime-identity.json`) that orchestrator + workers consult first, falling back to env. Host `.env` is left as-is; relay metadata reflects the runtime value.
+- C: This won't happen if cloud guarantees consistency (Q2=B/Q3=B/C) — defer reconciliation logic until/unless the divergence is actually observed in practice.
+
+**Answer**: *Pending*

--- a/specs/750-summary-local-cluster-s/contracts/cluster-identity-split-event.md
+++ b/specs/750-summary-local-cluster-s/contracts/cluster-identity-split-event.md
@@ -1,0 +1,90 @@
+# Contract: `cluster.identity-split` Relay Event
+
+## Channel
+`cluster.identity-split`
+
+## Direction
+Cluster (orchestrator) → Cloud (relay → UI consumer)
+
+## Emitter
+Orchestrator process, in-process (calls `ClusterRelayClient.send` directly). Emitted at most once per orchestrator process lifetime.
+
+## Trigger
+At orchestrator startup, after the relay bridge has started, when:
+- `process.env.GENERACY_CLUSTER_ID` is set AND
+- `/var/lib/generacy/cluster.json` exists and validates against `ClusterJsonSchema` AND
+- `process.env.GENERACY_CLUSTER_ID !== cluster.json.cluster_id`.
+
+## Payload Schema (JSON Schema-style)
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IdentitySplitEvent",
+  "description": "Emitted when an orchestrator detects that its env-sourced cluster id differs from the persisted cluster.json id.",
+  "type": "object",
+  "required": ["env_cluster_id", "cluster_json_cluster_id", "detected_at"],
+  "additionalProperties": false,
+  "properties": {
+    "env_cluster_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Value of process.env.GENERACY_CLUSTER_ID at detection time."
+    },
+    "cluster_json_cluster_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Value of /var/lib/generacy/cluster.json's cluster_id field at detection time."
+    },
+    "detected_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of when the detection occurred."
+    }
+  }
+}
+```
+
+### Example
+```json
+{
+  "env_cluster_id": "6c23c4c4-97d6-44ad-ac7a-b2302e9d7e9a",
+  "cluster_json_cluster_id": "a356d8f5-cca3-4f4a-9070-4fd8084b0468",
+  "detected_at": "2026-06-04T17:32:11.482Z"
+}
+```
+
+## Wire envelope
+
+Sent via the standard relay `EventMessage`:
+```json
+{
+  "type": "event",
+  "event": "cluster.identity-split",
+  "data": { /* IdentitySplitEvent payload above */ },
+  "timestamp": "2026-06-04T17:32:11.482Z"
+}
+```
+
+## Emission contract
+
+| Property | Value |
+|----------|-------|
+| **Frequency** | At most once per orchestrator process lifetime. |
+| **Reliability** | Best-effort. If the relay client is disconnected at emission time, the event is dropped (no buffering). The next orchestrator restart will re-detect and re-attempt. |
+| **Side effects** | NONE on local state. The detector MUST NOT write to `.env`, `cluster.json`, or mutate `process.env`. |
+| **Failure handling** | If `sendRelayEvent` throws, the error is logged and swallowed. Detection does not block orchestrator startup. |
+
+## Consumer expectations (out of scope for this issue — cloud companion)
+
+- Cloud SHOULD surface a UI banner ("Cluster identity mismatch — destroy and re-launch") on receipt.
+- Cloud MAY persist the event for diagnostics; not required.
+- Cloud MUST NOT mutate cluster state on receipt — remediation is user-driven.
+
+## Versioning
+
+V1. Additive fields permitted in future versions (consumers MUST tolerate unknown fields). Breaking changes require a new channel name.
+
+## Allowlist
+
+The channel `cluster.identity-split` is added to the orchestrator's `ALLOWED_CHANNELS` tuple in `packages/orchestrator/src/routes/internal-relay-events.ts` even though the orchestrator emits in-process. This keeps the allowlist authoritative for any future cross-process emitter (e.g. control-plane forwarding the same channel via the IPC route added in #594).

--- a/specs/750-summary-local-cluster-s/conversation-log.jsonl
+++ b/specs/750-summary-local-cluster-s/conversation-log.jsonl
@@ -8,3 +8,5 @@
 {"timestamp":"2026-06-04T16:35:05.383Z","phase":"plan","session_id":"","event_type":"phase_complete"}
 {"timestamp":"2026-06-04T16:35:16.237Z","phase":"tasks","session_id":"","event_type":"phase_start"}
 {"timestamp":"2026-06-04T16:36:39.430Z","phase":"tasks","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-04T16:36:51.977Z","phase":"implement","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-04T16:44:33.904Z","phase":"implement","session_id":"","event_type":"phase_complete"}

--- a/specs/750-summary-local-cluster-s/conversation-log.jsonl
+++ b/specs/750-summary-local-cluster-s/conversation-log.jsonl
@@ -1,2 +1,4 @@
 {"timestamp":"2026-06-04T15:31:06.862Z","phase":"specify","session_id":"","event_type":"phase_start"}
 {"timestamp":"2026-06-04T15:32:11.095Z","phase":"specify","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-04T15:32:26.245Z","phase":"clarify","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-04T15:35:55.409Z","phase":"clarify","session_id":"","event_type":"phase_complete"}

--- a/specs/750-summary-local-cluster-s/conversation-log.jsonl
+++ b/specs/750-summary-local-cluster-s/conversation-log.jsonl
@@ -2,3 +2,5 @@
 {"timestamp":"2026-06-04T15:32:11.095Z","phase":"specify","session_id":"","event_type":"phase_complete"}
 {"timestamp":"2026-06-04T15:32:26.245Z","phase":"clarify","session_id":"","event_type":"phase_start"}
 {"timestamp":"2026-06-04T15:35:55.409Z","phase":"clarify","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-04T16:27:54.712Z","phase":"clarify","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-04T16:30:24.394Z","phase":"clarify","session_id":"","event_type":"phase_complete"}

--- a/specs/750-summary-local-cluster-s/conversation-log.jsonl
+++ b/specs/750-summary-local-cluster-s/conversation-log.jsonl
@@ -4,3 +4,5 @@
 {"timestamp":"2026-06-04T15:35:55.409Z","phase":"clarify","session_id":"","event_type":"phase_complete"}
 {"timestamp":"2026-06-04T16:27:54.712Z","phase":"clarify","session_id":"","event_type":"phase_start"}
 {"timestamp":"2026-06-04T16:30:24.394Z","phase":"clarify","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-04T16:30:37.349Z","phase":"plan","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-04T16:35:05.383Z","phase":"plan","session_id":"","event_type":"phase_complete"}

--- a/specs/750-summary-local-cluster-s/conversation-log.jsonl
+++ b/specs/750-summary-local-cluster-s/conversation-log.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-06-04T15:31:06.862Z","phase":"specify","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-04T15:32:11.095Z","phase":"specify","session_id":"","event_type":"phase_complete"}

--- a/specs/750-summary-local-cluster-s/conversation-log.jsonl
+++ b/specs/750-summary-local-cluster-s/conversation-log.jsonl
@@ -6,3 +6,5 @@
 {"timestamp":"2026-06-04T16:30:24.394Z","phase":"clarify","session_id":"","event_type":"phase_complete"}
 {"timestamp":"2026-06-04T16:30:37.349Z","phase":"plan","session_id":"","event_type":"phase_start"}
 {"timestamp":"2026-06-04T16:35:05.383Z","phase":"plan","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-04T16:35:16.237Z","phase":"tasks","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-04T16:36:39.430Z","phase":"tasks","session_id":"","event_type":"phase_complete"}

--- a/specs/750-summary-local-cluster-s/data-model.md
+++ b/specs/750-summary-local-cluster-s/data-model.md
@@ -1,0 +1,133 @@
+# Data Model: Identity-Split Detection
+
+## Overview
+
+No new persisted entities. The detector reads two existing values, compares them, and (on mismatch) sends one relay event. The relay event payload is the only new shape introduced.
+
+## Inputs (existing data sources)
+
+### Environment Variable
+| Name | Type | Source | Required for detection? |
+|------|------|--------|-------------------------|
+| `GENERACY_CLUSTER_ID` | string (UUID) | `.generacy/.env` mounted into the orchestrator container at compose time | Yes — absent → skip detection silently |
+
+### Persisted File: `/var/lib/generacy/cluster.json`
+Schema already defined in `packages/orchestrator/src/activation/types.ts:17`:
+```ts
+const ClusterJsonSchema = z.object({
+  cluster_id: z.string().min(1),
+  project_id: z.string().min(1),
+  org_id: z.string().min(1),
+  cloud_url: z.string().url(),
+  activated_at: z.string().datetime(),
+});
+type ClusterJson = z.infer<typeof ClusterJsonSchema>;
+```
+- Written by `activate()` post-device-code-approval (`activation/index.ts:81,160`).
+- Read by the detector via existing `readClusterJson(path)` helper.
+- Missing or schema-invalid → `null` → skip detection silently.
+
+## Detector internals
+
+### `DetectionOutcome` (return type, internal — for testability)
+```ts
+export type DetectionOutcome =
+  | { kind: 'no-env'; envClusterId: undefined }
+  | { kind: 'no-cluster-json'; envClusterId: string }
+  | { kind: 'match'; clusterId: string }
+  | { kind: 'mismatch'; envClusterId: string; clusterJsonClusterId: string; emitted: boolean };
+```
+
+- `no-env`: `process.env.GENERACY_CLUSTER_ID` is unset or empty.
+- `no-cluster-json`: env is set but `readClusterJson` returned `null`.
+- `match`: both present and equal — happy path.
+- `mismatch`: both present and unequal. `emitted: true` means we sent the relay event this call; `emitted: false` means we suppressed because the module-level once-flag was already set.
+
+Used internally and by tests; not exposed on the relay wire.
+
+### Module-level state (in `identity-split-detector.ts`)
+```ts
+let hasEmitted = false;
+```
+- Set to `true` the first time the detector emits the relay event.
+- Reset only via `resetIdentitySplitDetectionState()` (test helper).
+- Container restart = module re-import = `hasEmitted` resets to `false`. By design.
+
+### Public function signature
+```ts
+export interface DetectIdentitySplitOptions {
+  clusterJsonPath: string;
+  env?: NodeJS.ProcessEnv;  // defaults to process.env, injectable for tests
+  sendRelayEvent?: (channel: 'cluster.identity-split', payload: IdentitySplitEvent) => void;
+  logger: Pick<FastifyBaseLogger, 'info' | 'warn' | 'error'>;
+}
+
+export async function detectIdentitySplit(
+  options: DetectIdentitySplitOptions
+): Promise<DetectionOutcome>;
+```
+
+## Output (new): Relay Event Payload
+
+### Event channel
+`cluster.identity-split`
+
+### Payload shape
+```ts
+export interface IdentitySplitEvent {
+  /** Cluster ID from process.env.GENERACY_CLUSTER_ID at detection time. */
+  env_cluster_id: string;
+  /** Cluster ID from /var/lib/generacy/cluster.json at detection time. */
+  cluster_json_cluster_id: string;
+  /** ISO-8601 timestamp of detection. */
+  detected_at: string;
+}
+```
+
+### Validation rules
+- Both id fields MUST be non-empty strings (validated at detection time before emission — both come from already-validated sources, but defense-in-depth).
+- `detected_at` MUST be a valid ISO-8601 timestamp (set via `new Date().toISOString()`).
+- The two id fields MUST be different (precondition of emission — match path never emits).
+
+### Naming conventions
+- Channel uses dot-separated `cluster.<noun>` (matches `cluster.bootstrap`, `cluster.credentials`, etc.).
+- Payload uses snake_case (matches `cluster.json` field names, the original source of one of the ids).
+
+## Relationships
+
+```
+.generacy/.env (host)
+       │
+       │ mounted as compose env-file
+       ▼
+process.env.GENERACY_CLUSTER_ID (orchestrator container)
+       │
+       │     ┌─────────────────────┐
+       └────►│ detectIdentitySplit │◄──── readClusterJson('/var/lib/generacy/cluster.json')
+             └──────────┬──────────┘
+                        │
+                        │ on mismatch + first call only
+                        ▼
+       sendRelayEvent('cluster.identity-split', payload)
+                        │
+                        ▼
+       ClusterRelayClient.send(EventMessage) ──► cloud
+                                                    │
+                                                    ▼
+                                  (cloud companion) UI banner
+```
+
+## State transitions
+
+```
+hasEmitted = false      ───────────►   hasEmitted = true
+       │                                       │
+       │ subsequent calls                      │ subsequent calls
+       │ (match or no-data)                    │ (any outcome)
+       │                                       │
+       ▼                                       ▼
+   no emission                          no emission
+   (per outcome)                        (suppressed)
+```
+
+There is no transition from `true` → `false` in production. Tests use `resetIdentitySplitDetectionState()` to reset.

--- a/specs/750-summary-local-cluster-s/plan.md
+++ b/specs/750-summary-local-cluster-s/plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Local Cluster Identity Split Detection
+
+**Feature**: Detect and surface mismatches between `process.env.GENERACY_CLUSTER_ID` and persisted `cluster.json.cluster_id` at orchestrator startup, without mutating local state. Verify the launch scaffolder is still the single client-side source for `GENERACY_CLUSTER_ID`.
+**Branch**: `750-summary-local-cluster-s`
+**Status**: Complete
+
+## Summary
+
+The local cluster launch path can produce an "identity split": the cluster's runtime `GENERACY_CLUSTER_ID` (from `.env`) is one UUID, but the cluster doc + API key it authenticates as on the cloud is a different UUID. Root cause is cloud-side (the device-code activation endpoint mints a fresh `randomUUID()` instead of reusing the claim's `clusterId`), and the fix for *fresh* clusters lands in a parallel `generacy-ai/generacy-cloud` companion issue.
+
+This issue ships the **client-side half**:
+1. **Detection** — at orchestrator startup, compare env id vs persisted `/var/lib/generacy/cluster.json.cluster_id`. On mismatch, emit a single `cluster.identity-split` relay event with both ids and continue running. No state mutation.
+2. **Verification gate** — confirm `packages/generacy/src/cli/commands/launch/scaffolder.ts` writes `LaunchConfig.clusterId` end-to-end (no client-side overrides).
+
+The event consumer (cloud UI banner offering "destroy and re-launch") is out of scope for this issue and tracked under the cloud companion.
+
+## Technical Context
+
+- **Language**: TypeScript (Node >= 22), ESM modules.
+- **Packages touched**:
+  - `packages/orchestrator/` — adds detector service, wires it into `server.ts` startup paths.
+  - `packages/generacy/src/cli/commands/launch/` — verification only (no code change expected; FR-001 already satisfied at `scaffolder.ts:71-114`).
+- **Dependencies**: No new deps. Uses existing `node:fs/promises`, `zod`, pino logger, and the established relay-event emission pattern.
+- **Relay channel**: New event channel `cluster.identity-split` joins the existing allowlist in `packages/orchestrator/src/routes/internal-relay-events.ts` (currently: `cluster.vscode-tunnel`, `cluster.audit`, `cluster.credentials`, `cluster.bootstrap`). Note: emission happens *in-process* in the orchestrator (it owns the relay client), so the IPC route may not need extension — but the channel name should still be a documented allowed value for cross-process emitters that follow.
+- **Persistence file**: `/var/lib/generacy/cluster.json` — already validated via `ClusterJsonSchema` (`packages/orchestrator/src/activation/types.ts:17`).
+- **Env source**: `process.env.GENERACY_CLUSTER_ID` set from `.generacy/.env` mounted into the orchestrator container.
+
+## Project Structure
+
+```
+packages/orchestrator/src/
+├── services/
+│   └── identity-split-detector.ts          # NEW: detector + once-per-process guard
+├── activation/
+│   ├── persistence.ts                       # EXISTING: readClusterJson() (reused)
+│   └── types.ts                             # EXISTING: ClusterJsonSchema
+├── routes/
+│   └── internal-relay-events.ts             # MODIFIED: add 'cluster.identity-split' to ALLOWED_CHANNELS allowlist
+└── server.ts                                # MODIFIED: invoke detector after relay bridge starts (both startup paths)
+
+packages/orchestrator/src/__tests__/
+└── identity-split-detector.test.ts          # NEW: unit tests for detector
+
+packages/generacy/src/cli/commands/launch/__tests__/
+└── scaffolder.test.ts                       # EXISTING: add (or confirm) assertion that scaffoldEnvFile writes config.clusterId verbatim
+
+specs/750-summary-local-cluster-s/
+├── plan.md                                  # this file
+├── research.md
+├── data-model.md
+├── contracts/
+│   └── cluster-identity-split-event.md
+└── quickstart.md
+```
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                        Orchestrator startup                    │
+│                                                                │
+│   createServer()                                               │
+│      │                                                         │
+│      ├─ register /internal/relay-events route (deferred)       │
+│      ├─ [activation path A: existing key]                      │
+│      │     initializeRelayBridge() ──► relayClientRef set      │
+│      │     detectIdentitySplit({clusterJsonPath, env, send})   │
+│      │                                                         │
+│      └─ [activation path B: wizard mode]                       │
+│            activateInBackground()                              │
+│              └─ on success ──► initializeRelayBridge()         │
+│                              detectIdentitySplit(...)          │
+│                                                                │
+│   detectIdentitySplit:                                         │
+│      1. read process.env.GENERACY_CLUSTER_ID                   │
+│      2. await readClusterJson(clusterJsonPath)                 │
+│      3. if both present AND ids differ:                        │
+│           if not alreadyEmitted (module-level guard):          │
+│             sendRelayEvent('cluster.identity-split', {         │
+│               env_cluster_id,                                  │
+│               cluster_json_cluster_id,                         │
+│               detected_at: ISO                                 │
+│             })                                                 │
+│             mark alreadyEmitted = true                         │
+│      4. NEVER mutate env, cluster.json, or .env                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+Key invariants:
+- **Detection is read-only**. The function reads two values, compares, optionally sends one relay event. No writes anywhere.
+- **One emission per process lifetime**. A module-level `hasEmitted` flag prevents flapping across reconnects, retries, or re-invocations within the same Node process. Container restart resets it (acceptable — that's a fresh process).
+- **Best-effort emission**. If the relay client is disconnected at detection time, the event is dropped (no buffering). Acceptable because the mismatch is persistent — the next orchestrator boot will detect again. Avoid building a queue.
+- **Missing files are non-events**. If `cluster.json` is absent (pre-activation) OR env id is unset, skip detection silently. Mismatch requires both sides to be present.
+
+## Constitution Check
+
+No `.specify/memory/constitution.md` exists in this repo — skipped.
+
+Adherence to project conventions:
+- ✅ Reuses existing relay-event pattern (`sendRelayEvent(channel, payload)` callback) — same shape as `PostActivationRetryService`.
+- ✅ Reuses existing `readClusterJson()` from `activation/persistence.ts` — no duplicated parsing.
+- ✅ Reuses existing relay channel naming convention `cluster.<noun>` (e.g. `cluster.bootstrap`, `cluster.credentials`).
+- ✅ No new packages, no new dependencies.
+- ✅ Fails closed on every side: missing inputs → no event; relay down → no event (next boot retries).
+- ✅ Defense against runaway emission via module-level once-flag (FR-005).
+
+## Implementation Steps (high level — `/tasks` will expand)
+
+1. Add `cluster.identity-split` to the `ALLOWED_CHANNELS` tuple in `packages/orchestrator/src/routes/internal-relay-events.ts` (documents the channel even though the orchestrator emits it directly).
+2. Create `packages/orchestrator/src/services/identity-split-detector.ts` exporting:
+   - `detectIdentitySplit(options): Promise<DetectionOutcome>` — the pure detector.
+   - `resetIdentitySplitDetectionState()` — test helper to clear the once-flag.
+3. Wire `detectIdentitySplit` into both startup paths in `packages/orchestrator/src/server.ts`:
+   - Existing-key path (~line 357, after `initializeRelayBridge` completes).
+   - Background-activation path (~line 720, after `relayBridge.start()` in `activateInBackground`).
+4. Unit tests in `packages/orchestrator/src/__tests__/identity-split-detector.test.ts` cover: match → no event; mismatch → one event; mismatch + repeat call → still one event; missing env → no event; missing cluster.json → no event; sendRelayEvent throw → swallowed and logged.
+5. Verification test in `packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts` asserting `scaffoldEnvFile` writes `config.clusterId` to `GENERACY_CLUSTER_ID` byte-for-byte (FR-001 gate).
+6. File the cloud companion issue (FR-006) — track as related issue, do not block this issue's merge on it.
+
+## Key Technical Decisions (full rationale in `research.md`)
+
+- **Detection only — no reconciliation** (FR-003, FR-004). Mid-process env mutation cannot reach already-spawned worker subprocesses, and the host `.env` is unreachable from inside the container. Reconciliation is unsafe; remediation is destroy + re-launch.
+- **Emit once per process** (FR-005). Module-level boolean flag. Container restart is a fresh module load → resets flag. Acceptable: identity split is persistent and one event per container boot is sufficient signal for the cloud UI.
+- **Best-effort emission**. No buffering, no retry. The mismatch persists across boots, so the next startup re-detects and re-emits. Buffering adds complexity for no real benefit.
+- **Reuse `readClusterJson`** (no new parsing). Already validated via `ClusterJsonSchema` in `activation/types.ts`.
+- **No host-side detection in CLI**. The CLI scaffolder already uses `config.clusterId` (`launch/scaffolder.ts:71-114`); FR-001 is a verification gate (unit-test assertion), not new behavior.
+- **Emit *after* relay bridge starts**, not before. The detector needs a working relay client; calling it pre-activation would silently drop the event. Calling post-bridge-start gives the best chance of in-flight delivery.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Detector runs before relay client has connected → event dropped | Acceptable: next orchestrator restart re-emits. Document as known behavior in event contract. |
+| `readClusterJson` throws on corrupt JSON | Existing implementation already returns `null` on parse failure (`activation/persistence.ts:47`). Detector treats `null` as "no detection possible" and returns. |
+| Race between `cluster.json` write (activation flow) and detector read | Detector runs *after* `initializeRelayBridge` which itself runs *after* `activate()` — so `cluster.json` is guaranteed to exist (or was already absent → no detection). |
+| Detection sends event on every relay reconnect | Module-level `hasEmitted` guard. Test covers this. |
+| Cloud UI not yet ready to consume the event | Out of scope; cloud companion tracks UI work. Event is forward-compatible (additive). |
+
+## Out of Scope (cross-referenced from spec)
+
+- Cloud-side cluster-doc id minting fix (separate `generacy-ai/generacy-cloud` issue per FR-006).
+- In-place migration / reconciliation of mismatched clusters (FR-003, FR-004).
+- Activation-time `.env` rewrite or mid-process env mutation (FR-003).
+- Cloud UI banner rendering (cloud companion).
+- Telemetry/metrics for split-cluster frequency.
+- `deploy` (SSH) path — already adopts `pollResult.cluster_id`; not affected.

--- a/specs/750-summary-local-cluster-s/quickstart.md
+++ b/specs/750-summary-local-cluster-s/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Identity-Split Detection
+
+## What this delivers
+
+After this change, an orchestrator that boots with a mismatched `GENERACY_CLUSTER_ID` (env) vs persisted `cluster.json.cluster_id` will:
+1. Emit one `cluster.identity-split` relay event on startup.
+2. Continue running normally.
+3. NOT mutate any local state.
+
+The cloud UI (delivered in the parallel cloud companion) will consume the event and prompt the user to destroy + re-launch the cluster.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `packages/orchestrator/src/services/identity-split-detector.ts` | NEW: `detectIdentitySplit()` + once-per-process guard + `resetIdentitySplitDetectionState()` test helper |
+| `packages/orchestrator/src/server.ts` | MODIFIED: invoke detector after relay bridge starts (both startup paths) |
+| `packages/orchestrator/src/routes/internal-relay-events.ts` | MODIFIED: add `'cluster.identity-split'` to `ALLOWED_CHANNELS` |
+| `packages/orchestrator/src/__tests__/identity-split-detector.test.ts` | NEW: unit tests covering all `DetectionOutcome` branches + once-only emission |
+| `packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts` | MODIFIED (verification gate for FR-001): assert `scaffoldEnvFile` writes `config.clusterId` to `GENERACY_CLUSTER_ID` verbatim |
+
+## Local manual verification
+
+### Setup (simulate a split)
+
+1. Launch a local cluster with the existing flow (`generacy launch --claim=...`).
+2. Wait for activation to complete.
+3. Tear down: `generacy stop`.
+4. Manually edit `~/Generacy/<project>/.generacy/.env` and set `GENERACY_CLUSTER_ID` to a different UUID than the value in `~/Generacy/<project>/.generacy/cluster.json` (or — simpler — leave them out of sync from an earlier mismatched session).
+5. Note: `cluster.json` in `.generacy/` is host-side; the orchestrator reads from `/var/lib/generacy/cluster.json` inside the container. Use whichever flow you have for surfacing a mismatch in the container's persisted file.
+6. Bring the cluster back up: `generacy up`.
+7. Tail the relay client side for the event.
+
+### Expected behavior
+
+- On orchestrator boot, the logs include a single `info` line documenting the detection (e.g. `Identity-split detected: env=<id1> cluster.json=<id2>`).
+- A single `cluster.identity-split` event traverses the relay.
+- Orchestrator stays up. `/health` returns 200.
+- `~/Generacy/<project>/.generacy/.env`, `~/Generacy/<project>/.generacy/cluster.json`, and the in-container `/var/lib/generacy/cluster.json` are byte-equal to their pre-boot state.
+
+### Tests
+
+Run the orchestrator unit tests:
+```bash
+pnpm --filter @generacy-ai/orchestrator test identity-split-detector
+```
+
+Run the launch verification gate:
+```bash
+pnpm --filter @generacy-ai/generacy test scaffolder
+```
+
+## Quick reference: when is detection skipped?
+
+| Condition | Behavior |
+|-----------|----------|
+| `process.env.GENERACY_CLUSTER_ID` is unset | Skip. Return `{ kind: 'no-env' }`. No event. |
+| `cluster.json` is missing or schema-invalid | Skip. Return `{ kind: 'no-cluster-json' }`. No event. |
+| Both present, ids equal | Skip. Return `{ kind: 'match' }`. No event. |
+| Both present, ids differ, first call | Emit event. Return `{ kind: 'mismatch', emitted: true }`. |
+| Both present, ids differ, subsequent calls | Skip emission (once-flag). Return `{ kind: 'mismatch', emitted: false }`. |
+| `sendRelayEvent` callback throws | Log error, swallow. Once-flag still flipped (single attempt counts). |
+
+## Cloud companion issue (must be filed)
+
+Per FR-006, before this lands, file a `generacy-ai/generacy-cloud` companion issue:
+- **Title**: "Device-code activation must reuse claim's clusterId instead of minting a fresh UUID"
+- **Body**: cross-reference this issue (#750), spec section "Root cause (clarified)", cite `services/api/src/services/cluster-activation.ts:385-386` as the mint site to fix.
+- **Linked**: this issue (#750), #744, generacy-cloud#792 / #796 / #801.
+
+## Troubleshooting
+
+### "I expect to see the event but the relay is silent"
+Check:
+1. The orchestrator's relay bridge has actually connected (look for `[relay] connected` log).
+2. `cluster.json` exists at `/var/lib/generacy/cluster.json` inside the container.
+3. `GENERACY_CLUSTER_ID` is actually set in the container's process env (not just on the host).
+4. The two ids genuinely differ (compare via `docker compose exec orchestrator env | grep GENERACY_CLUSTER_ID` and `docker compose exec orchestrator cat /var/lib/generacy/cluster.json`).
+
+### "Event fires every time the relay reconnects"
+Bug — file a regression issue. The module-level `hasEmitted` flag should prevent this. Check the call site in `server.ts` is not constructing a fresh module load per reconnect (it shouldn't, but if a future refactor moves detection into a reconnect callback, the once-guard would need to move with it or be persisted).
+
+### "Event fires every container restart"
+Expected. Container restart = fresh process = fresh module = flag reset. This is by design: one event per container boot is the right signal for the cloud UI.
+
+### "My fresh cluster shows identity-split immediately"
+The cloud companion has not yet landed. Verify your cloud is running a version that includes the device-code → claim-id reuse fix. Until then, every fresh local launch will trip the detector. (This is exactly why we ship detection in this issue — to surface the bug to users while the cloud companion lands.)

--- a/specs/750-summary-local-cluster-s/research.md
+++ b/specs/750-summary-local-cluster-s/research.md
@@ -1,0 +1,95 @@
+# Research: Identity-Split Detection
+
+## Goal
+
+Decide *how* and *where* the orchestrator should detect the identity-split condition without violating FR-003 (no state mutation) and FR-005 (no event spam).
+
+## Decisions
+
+### D1: Detection runs in-process inside the orchestrator (not control-plane)
+
+**Decision**: Implement the detector as an orchestrator service. Wire it into both startup paths in `server.ts`.
+
+**Rationale**:
+- The orchestrator owns the `ClusterRelay` WebSocket client — it can directly call `client.send({...})` with no IPC hop. The control-plane would need to use the existing `/internal/relay-events` IPC channel (added in #594/#598/#600), adding a code path that can fail (HTTP error, 503 if relay not yet initialized) for no benefit.
+- The data the detector needs (`process.env.GENERACY_CLUSTER_ID`, `/var/lib/generacy/cluster.json`) is equally available in either process. No control-plane-only state is involved.
+- Startup ordering is simpler: the orchestrator already has a clear "post-relay-bridge" hook point in both startup paths.
+
+**Alternatives considered**:
+- *Detection in control-plane, emit via IPC*: rejected — adds a network hop and a failure mode (orchestrator relay endpoint must be ready). The detector has no control-plane data dependency.
+- *Detection inside `activate()`*: rejected — `activate()` runs before the relay client is connected, so the event would always be dropped. Also conflates activation concerns with diagnostic detection.
+
+### D2: Emit one event per process lifetime via a module-level flag
+
+**Decision**: Use a `let hasEmitted = false;` module-level variable in `identity-split-detector.ts`. Export `resetIdentitySplitDetectionState()` for tests.
+
+**Rationale**:
+- FR-005 forbids spam. A module-level flag is the simplest enforcement and survives across all in-process callers (relay reconnects, retries).
+- Container restart = fresh Node process = fresh module load = flag resets. This is acceptable: a restarted container has the user observing a new boot cycle anyway, so one event per restart is the right granularity for the cloud UI.
+
+**Alternatives considered**:
+- *Persist the flag in a file (e.g. `/var/lib/generacy/identity-split-emitted`)*: rejected — the event is cheap to re-emit per boot; persistence adds I/O and a cleanup-on-resolution problem (when does the cluster get re-launched and the flag cleared? Manual remediation).
+- *Time-window debounce (e.g. emit at most once per hour)*: rejected — same persistence problem, also harder to test.
+
+### D3: Best-effort emission (no buffering, no retry)
+
+**Decision**: If the relay client is disconnected at detection time, log a warning and return. Do not buffer the event.
+
+**Rationale**:
+- Identity-split is persistent — the mismatch survives across reboots. The next orchestrator boot will detect and re-emit. Buffering optimizes for a non-existent scenario (one-shot mismatch that resolves before retry).
+- The relay client's send call already handles "disconnected" state by no-op'ing — the existing `internal-relay-events.ts:42` checks `client.isConnected` first. Mirror this pattern.
+
+**Alternatives considered**:
+- *Queue events until connected*: rejected — adds complexity for a self-healing scenario.
+
+### D4: Reuse `readClusterJson` from `activation/persistence.ts`
+
+**Decision**: Import `readClusterJson` directly. Do not reimplement parsing.
+
+**Rationale**:
+- `readClusterJson` already validates against `ClusterJsonSchema`, returns `null` on missing/corrupt — exactly the contract the detector wants ("no detection possible" → return).
+- Single source of truth for the cluster.json shape.
+
+### D5: Skip detection when either side is missing
+
+**Decision**: If `process.env.GENERACY_CLUSTER_ID` is unset OR `cluster.json` is missing/invalid, return without emitting.
+
+**Rationale**:
+- Pre-activation, `cluster.json` doesn't exist yet — that's not a split, just an unactivated cluster.
+- If env is unset, the cluster is misconfigured in a different way (no `.env` mounted) — out of scope for identity-split detection; would surface via different errors.
+- Mismatch requires *two present values that disagree* — anything else is noise.
+
+### D6: Call site is *after* `initializeRelayBridge` in both startup paths
+
+**Decision**: In `server.ts`:
+- Existing-key path (`if (config.relay.apiKey) { ... }`): call detector after `initializeRelayBridge` returns and the relayClientRef is set.
+- Background-activation path (`activateInBackground`): call detector after `await relayBridge.start()` succeeds.
+
+**Rationale**:
+- The relay client needs to be live (`isConnected: true`) for the event to actually be sent. Pre-bridge-start emission silently no-ops.
+- Both paths converge on "relay bridge has started → run detector once" — the same call site in both, just placed correctly relative to the bridge startup.
+
+### D7: Channel name `cluster.identity-split` joins ALLOWED_CHANNELS
+
+**Decision**: Add `'cluster.identity-split'` to the `ALLOWED_CHANNELS` tuple in `routes/internal-relay-events.ts`.
+
+**Rationale**:
+- Even though the orchestrator emits in-process (no IPC), the allowlist is the documented set of relay event channels. Adding the channel here keeps the allowlist authoritative and prepares for future emitters (e.g. if the control-plane ever needs to emit this).
+- Cheap, low risk — just a string addition to an enum.
+
+## Implementation Patterns Referenced
+
+- **Relay-event emission pattern**: `packages/orchestrator/src/services/post-activation-retry.ts:61` — `this.sendRelayEvent?.('cluster.bootstrap', { ... })` with optional callback DI. Mirror this signature.
+- **Background activation hook**: `packages/orchestrator/src/server.ts:666` — `activateInBackground()` is the post-activation hook in wizard mode.
+- **`readClusterJson` contract**: `packages/orchestrator/src/activation/persistence.ts:41` — returns `null` on missing/invalid, validated via Zod.
+- **Once-per-process pattern**: New for this issue, but module-level scoped state is consistent with the `module-level state store pattern` already used in control-plane (`POST /internal/status`, `setRelayPushEvent`).
+
+## Sources
+
+- Spec: `specs/750-summary-local-cluster-s/spec.md`
+- Clarifications: `specs/750-summary-local-cluster-s/clarifications.md`
+- Existing relay channel emission: `packages/orchestrator/src/services/post-activation-retry.ts`
+- Existing channel allowlist: `packages/orchestrator/src/routes/internal-relay-events.ts`
+- Cluster JSON schema: `packages/orchestrator/src/activation/types.ts`
+- Launch scaffolder verification target: `packages/generacy/src/cli/commands/launch/scaffolder.ts:71-114`
+- Related: #744 (cluster-id minting), generacy-cloud#792 / #796 / #801, #742 (cluster identity)

--- a/specs/750-summary-local-cluster-s/spec.md
+++ b/specs/750-summary-local-cluster-s/spec.md
@@ -1,14 +1,14 @@
-# Feature Specification: Local Cluster Identity Alignment with Cloud Cluster-Doc ID
+# Feature Specification: ## Summary
+
+A **local cluster's runtime identity (`GENERACY_CLUSTER_ID`) does not match its cloud cluster-doc id
 
 **Branch**: `750-summary-local-cluster-s` | **Date**: 2026-06-04 | **Status**: Draft
-**Issue**: [#750](https://github.com/generacy-ai/generacy/issues/750)
-**Type**: Bug fix
+
+## Summary
 
 ## Summary
 
 A **local cluster's runtime identity (`GENERACY_CLUSTER_ID`) does not match its cloud cluster-doc id.** The cluster relays/authenticates as the cloud doc id (via that doc's API key) but self-identifies as a *different* UUID for tunnel-name derivation, orchestrator identity, and worker enumeration — an identity split.
-
-The `generacy deploy` command already correctly adopts the cloud-returned `cluster_id` (see `cli/commands/deploy/activation.ts:85` and `cli/commands/deploy/scaffolder.ts:33`). The local launch path scaffolds with a locally-minted or pre-existing id and never reconciles it with the cloud-minted doc id. This fix brings the local launch path in line with the deploy path.
 
 ## Evidence (observed on staging)
 
@@ -19,81 +19,118 @@ Project `Xr7fxq61PF57U2lOtoKe`, local cluster `todo-list-example1-local-1`:
   - Relay log: `[relay] coexist: cluster=a356d8f5-… joining project=Xr7fxq61PF57U2lOtoKe`
 - No doc exists under `clusters/6c23c4c4-…` (404), and it has no `api_keys` — so this is an **identity split, not a duplicate doc**.
 
+## Why `deploy` is fine but this isn't
+
+`generacy deploy` already adopts the **cloud-returned** id:
+- `cli/commands/deploy/activation.ts:85` → `clusterId: pollResult.cluster_id`
+- `cli/commands/deploy/scaffolder.ts:33` → `cluster_id: activation.clusterId`
+
+So the remote/SSH path scaffolds with the cloud-minted `cluster_id`. The **local launch path** (web "Add cluster → local" → the launch command) appears to scaffold with a locally-minted / pre-existing id (`6c23c4c4`) and never reconcile it with the cloud-minted doc id (`a356d8f5`).
+
+(Couldn't fully root-cause the exact mint site — the local containers were torn down before I could read `.generacy/cluster.json` / the compose env source. Candidate sites: the launch command's clusterId generation, and/or the web "Add cluster → local" pre-creating a doc whose id isn't fed back into the scaffold.)
+
+## Impact
+
+- `deriveTunnelName` keys on `GENERACY_CLUSTER_ID` → the local cluster registers tunnel `g-6c23c4c4…`, persisted (via #743) onto the `a356d8f5` doc. Still unique, so **no tunnel-name collision** — but the doc id ≠ the tunnel-source id.
+- Anything correlating the cluster's self-reported identity (`6c23c4c4`) with its cloud doc id (`a356d8f5`) will mismatch — e.g. orchestrator identity / assignee filtering (#742), worker enumeration, future per-cluster reporting.
+- Confusing to debug (two ids for one cluster).
+
+## Root cause (clarified)
+
+The mismatch originates **cloud-side** — the two cloud endpoints disagree:
+
+- `buildLaunchConfig` returns `claim.clusterId` (`services/api/src/services/launch-config.ts:121`) → the scaffolder writes this to `GENERACY_CLUSTER_ID` (observed `6c23c4c4-…`).
+- Device-code activation mints a **fresh `randomUUID()`** (`services/api/src/services/cluster-activation.ts:385-386`, "#792: generate fresh UUID (was hardcoded `clusterId = projectId`)") → this becomes the actual cluster doc + API key (observed `a356d8f5-…`, the only doc that exists; `clusters/6c23c4c4-…` is a 404 with no api_keys).
+
+The client launch scaffolder is correct (it uses `config.clusterId` from `LaunchConfig`). The fix must align the two cloud endpoints.
+
+## Proposed fix
+
+**Two-track fix, ships in parallel:**
+
+1. **Cloud companion** (separate `generacy-ai/generacy-cloud` issue): Device-code activation must **reuse** the claim/`LaunchConfig.clusterId` instead of minting a fresh UUID. The claim's `clusterId` becomes canonical — that same id is used to create the cluster doc + API key during activation. Result: `LaunchConfig.clusterId == pollResult.cluster_id == cluster-doc id`.
+
+2. **This issue (client-side)**:
+   - Verify the launch path uses `config.clusterId` end-to-end (no client-side overrides).
+   - Ship divergence **detection** at orchestrator startup: when `process.env.GENERACY_CLUSTER_ID` ≠ persisted `/var/lib/generacy/cluster.json.cluster_id`, emit a relay event (`cluster.identity-split`) and continue. The cloud UI surfaces a remediation banner ("destroy and re-launch this cluster") for already-split clusters.
+   - **No in-container `.env` rewrite or activation-time reconciliation** — the host `.env` and already-spawned workers can't reliably be updated, and once the cloud companion lands, divergence won't arise on fresh launches.
+
+This aligns with #744 Q3 (cloud-minted clusterId).
+
+## Acceptance criteria
+
+- [ ] A freshly-launched local cluster's `GENERACY_CLUSTER_ID` equals its cloud cluster-doc id (post cloud companion landing).
+- [ ] `deriveTunnelName`, orchestrator identity, and worker enumeration all use the same id the cloud doc is keyed by.
+- [ ] No orphan id (no self-minted id that never becomes a doc).
+- [ ] Orchestrator startup emits `cluster.identity-split` relay event when `process.env.GENERACY_CLUSTER_ID` ≠ persisted `cluster.json.cluster_id`, then continues running.
+- [ ] No automatic rewrite of host `.env`, `cluster.json`, or in-process env at activation/startup.
+
+## Notes
+
+- Distinct from generacy-ai/generacy-cloud#801 (sibling stuck `connecting` due to projectId-keyed doc resolution) — that one is why this local cluster was stuck; this issue is the separate identity mismatch.
+- Lower urgency than #801, but worth closing before relying on per-cluster identity in production.
+
+Relates: #744 (cluster-id minting), generacy-ai/generacy-cloud#792 / #796 / #801, #742 (cluster identity).
+
+
 ## User Stories
 
-### US1: Operator debugging a local cluster sees one identity
+### US1: Local cluster has a single identity
 
-**As a** Generacy operator/developer investigating a misbehaving local cluster,
-**I want** the cluster's runtime `GENERACY_CLUSTER_ID` to match the cloud cluster-doc id,
-**So that** I can correlate logs, tunnel names, relay traffic, and Firestore docs by a single identifier without cross-referencing two UUIDs.
-
-**Acceptance Criteria**:
-- [ ] When inspecting a local cluster's orchestrator env, the `GENERACY_CLUSTER_ID` value matches the id used as the Firestore cluster-doc key.
-- [ ] The tunnel name registered with Microsoft (`g-<prefix>`) is derived from the same id present in the cloud doc.
-- [ ] Relay handshake logs (`cluster=<id>`) and orchestrator env id are identical.
-
-### US2: New local cluster scaffolds with cloud-minted id
-
-**As a** user running the web "Add cluster → local" flow (which invokes the launch command),
-**I want** the launch path to adopt the cloud-returned `cluster_id`,
-**So that** my freshly-created local cluster has a single, canonical identity from the moment it boots.
+**As a** Generacy operator/developer running a local cluster,
+**I want** my local cluster's `GENERACY_CLUSTER_ID` to equal the cloud cluster-doc id it relays as,
+**So that** tunnel-name derivation, orchestrator identity, worker enumeration, and per-cluster reporting all correlate to the same id without surprises when debugging.
 
 **Acceptance Criteria**:
-- [ ] After `generacy launch` completes, `.generacy/cluster.json` contains `cluster_id` equal to the cloud-minted id.
-- [ ] The `docker-compose.yml` (or `.env`) sets `GENERACY_CLUSTER_ID` to the same id.
-- [ ] No locally-generated UUID is persisted that does not correspond to a cloud cluster doc.
+- [ ] Freshly-launched local cluster shows the same UUID in `GENERACY_CLUSTER_ID`, `cluster.json.cluster_id`, the cloud cluster-doc path, and the relay handshake identity (post cloud companion).
+- [ ] No 404 cluster-doc lookups for the orchestrator's self-reported id.
 
-### US3: Worker enumeration and assignee filtering work end-to-end on local clusters
+### US2: Existing mismatched clusters surface a clear remediation path
 
-**As a** developer relying on per-cluster features (orchestrator assignee filtering #742, worker enumeration, per-cluster reporting),
-**I want** the local cluster's self-reported identity to match the doc id those features key on,
-**So that** these features work correctly on local clusters, not just `deploy`-provisioned remote clusters.
+**As a** Generacy operator with a pre-existing local cluster that was launched before the fix,
+**I want** the orchestrator to detect the identity split and surface it,
+**So that** I receive a UI prompt to destroy and re-launch the cluster rather than discovering the mismatch through obscure correlation failures.
 
 **Acceptance Criteria**:
-- [ ] Assignee filtering by cluster id (#742) succeeds on local clusters.
-- [ ] Any feature querying Firestore by `clusters/<GENERACY_CLUSTER_ID>` resolves correctly.
+- [ ] Orchestrator startup emits `cluster.identity-split` relay event when env id ≠ persisted cluster.json id.
+- [ ] Orchestrator continues running (does not exit) after emitting the event.
+- [ ] No automatic mutation of host `.env`, `cluster.json`, or process env.
 
 ## Functional Requirements
 
 | ID | Requirement | Priority | Notes |
 |----|-------------|----------|-------|
-| FR-001 | The local launch path MUST persist the cloud-returned `cluster_id` (not a locally-minted UUID) into `.generacy/cluster.json`. | P1 | Mirrors deploy: `cli/commands/deploy/activation.ts:85`, `cli/commands/deploy/scaffolder.ts:33`. |
-| FR-002 | The generated `docker-compose.yml` and/or `.env` MUST export `GENERACY_CLUSTER_ID` set to the cloud-returned `cluster_id`. | P1 | Consumed by orchestrator, tunnel-name derivation, relay metadata. |
-| FR-003 | The cloud-returned `cluster_id` MUST be the single source of truth for the local launch path — no shadow/orphan id may be minted client-side. | P1 | Prevents identity split. |
-| FR-004 | If the web "Add cluster → local" flow pre-creates a cluster doc, that doc's id MUST be fed into the launch command (e.g. via claim code → `LaunchConfig.clusterId`). | P1 | Verify cloud `buildLaunchConfig` returns the doc id. |
-| FR-005 | Existing local clusters with mismatched ids MUST NOT be silently rewritten. Reconciliation/migration is out of scope for this fix. | P2 | Fresh clusters only. |
-| FR-006 | The fix MUST NOT regress the `generacy deploy` path, which already adopts the cloud-returned id correctly. | P1 | Regression check. |
+| FR-001 | The launch CLI scaffolder MUST write `LaunchConfig.clusterId` (cloud-returned claim id) to `.env`'s `GENERACY_CLUSTER_ID` and `.generacy/cluster.json.cluster_id`. No client-side UUID minting or override. | P1 | Already implemented at `packages/generacy/src/cli/commands/launch/scaffolder.ts:71-114`; this FR is a verification gate. |
+| FR-002 | The orchestrator at startup MUST compare `process.env.GENERACY_CLUSTER_ID` against the persisted `/var/lib/generacy/cluster.json.cluster_id`. On mismatch, emit a relay event on channel `cluster.identity-split` with both ids and continue running. | P1 | Detection only — no remediation. Event consumed by cloud UI. |
+| FR-003 | The orchestrator MUST NOT rewrite host `.env`, the host-side `cluster.json`, or in-process `GENERACY_CLUSTER_ID` to reconcile an identity split. | P1 | Host `.env` is unreachable from inside the container; mid-process env mutation does not propagate to already-spawned workers. Reconciliation is unsafe. |
+| FR-004 | The fix MUST NOT silently overwrite mismatched ids on existing local clusters. Remediation is destroy + re-launch (user-driven via cloud UI banner). | P1 | FR-005 from original spec retained. |
+| FR-005 | The orchestrator's `cluster.identity-split` event MUST be emitted at most once per orchestrator process lifetime (not on every restart loop iteration / not flapping). | P2 | Prevent log/event spam; one event per boot. |
+| FR-006 | A companion `generacy-ai/generacy-cloud` issue MUST be filed to make device-code activation reuse the claim's `clusterId` (canonical source) instead of minting a fresh `randomUUID()`. | P1 | This issue ships detection independently; the cloud companion delivers prevention. Tracked as a related/dependent issue, not a blocker. |
 
 ## Success Criteria
 
 | ID | Metric | Target | Measurement |
 |----|--------|--------|-------------|
-| SC-001 | Identity match on fresh local cluster | 100% | After `generacy launch`, `GENERACY_CLUSTER_ID` from orchestrator env equals Firestore cluster-doc id. |
-| SC-002 | No orphan ids | 0 | No client-minted UUIDs exist that lack a corresponding cloud cluster doc. |
-| SC-003 | Tunnel-name source id matches doc id | 100% | `deriveTunnelName(GENERACY_CLUSTER_ID)` uses the same id keying the cluster doc. |
-| SC-004 | Deploy path regression | 0 regressions | `generacy deploy` continues to scaffold with cloud-returned id (unchanged behavior). |
+| SC-001 | Identity consistency on fresh launch | 100% | Launch a new local cluster post-fix (with cloud companion landed); verify `GENERACY_CLUSTER_ID` matches the cloud cluster-doc id and relay handshake identity. |
+| SC-002 | Mismatch detection on existing split cluster | Event emitted within 5s of orchestrator start | Boot an orchestrator with a deliberately-mismatched env id; observe one `cluster.identity-split` event on the relay; confirm orchestrator stays up. |
+| SC-003 | No silent state mutation | Zero writes | After mismatch detection, `.env`, `cluster.json`, and `process.env.GENERACY_CLUSTER_ID` byte-equal their pre-detection values. |
+| SC-004 | No event spam | ≤1 event per orchestrator process | Run orchestrator for ≥5 minutes with persistent mismatch; only one `cluster.identity-split` event observed. |
 
 ## Assumptions
 
-- The cloud-side `buildLaunchConfig` (or equivalent) already returns the canonical `cluster_id` from the cloud cluster doc — or can be made to do so as part of this fix.
-- The web "Add cluster → local" flow that pre-creates the cluster doc passes the resulting id forward (via claim code or `LaunchConfig`) to the launch command.
-- The fix is scoped to the launch path scaffolder; orchestrator-side identity reading from `GENERACY_CLUSTER_ID` env var stays unchanged.
-- generacy-cloud#801 (sibling stuck `connecting`) is being handled separately and does not block this work.
+- Cloud-side `buildLaunchConfig` already returns `claim.clusterId` correctly (verified at `services/api/src/services/launch-config.ts:121`). This issue does not introduce that behavior; it relies on it.
+- The orchestrator's relay client is available at startup (post-activation) to emit the `cluster.identity-split` event. If activation has not yet completed, detection may run after activation.
+- Cloud UI consumes `cluster.identity-split` and renders a remediation banner (tracked via the cloud companion issue).
+- "Destroy and re-launch" is an acceptable user-facing remediation for already-split clusters (no in-place migration is offered).
 
 ## Out of Scope
 
-- Migration/reconciliation of existing mismatched local clusters (fresh clusters only).
-- Changes to `generacy deploy` (already correct).
-- The sibling-cluster `connecting` issue (generacy-cloud#801).
-- Cloud-side cluster-doc id minting strategy beyond ensuring it is returned to the launch path.
-- Tunnel-name collision handling (#743 already covers the actual-vs-requested name reporting).
-
-## Related Issues
-
-- **#744** — Cluster-id minting (Q3: cloud-minted clusterId). This fix aligns with that direction.
-- **#742** — Orchestrator identity / assignee filtering (broken by the identity split).
-- **#743** — Tunnel name actual-vs-requested reporting (independent, but adjacent).
-- **generacy-cloud#792 / #796 / #801** — Related cloud-side cluster identity/connection issues.
+- Cloud-side cluster-doc id minting strategy beyond requiring that activation reuse the claim's `clusterId` (the cloud companion issue covers implementation).
+- In-place migration / reconciliation of existing mismatched clusters (FR-004).
+- Activation-time `.env` rewrite or mid-process env mutation (FR-003).
+- UI rendering of the identity-split banner (cloud-side).
+- Telemetry/metrics for split-cluster frequency (could be a follow-up).
+- Lifecycle of the `deploy` (SSH) path — it already adopts `pollResult.cluster_id` and is not affected.
 
 ---
 

--- a/specs/750-summary-local-cluster-s/spec.md
+++ b/specs/750-summary-local-cluster-s/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Local Cluster Identity Alignment with Cloud Cluster-Doc ID
+
+**Branch**: `750-summary-local-cluster-s` | **Date**: 2026-06-04 | **Status**: Draft
+**Issue**: [#750](https://github.com/generacy-ai/generacy/issues/750)
+**Type**: Bug fix
+
+## Summary
+
+A **local cluster's runtime identity (`GENERACY_CLUSTER_ID`) does not match its cloud cluster-doc id.** The cluster relays/authenticates as the cloud doc id (via that doc's API key) but self-identifies as a *different* UUID for tunnel-name derivation, orchestrator identity, and worker enumeration — an identity split.
+
+The `generacy deploy` command already correctly adopts the cloud-returned `cluster_id` (see `cli/commands/deploy/activation.ts:85` and `cli/commands/deploy/scaffolder.ts:33`). The local launch path scaffolds with a locally-minted or pre-existing id and never reconciles it with the cloud-minted doc id. This fix brings the local launch path in line with the deploy path.
+
+## Evidence (observed on staging)
+
+Project `Xr7fxq61PF57U2lOtoKe`, local cluster `todo-list-example1-local-1`:
+- Orchestrator process env: **`GENERACY_CLUSTER_ID=6c23c4c4-97d6-44ad-ac7a-b2302e9d7e9a`**
+- Cloud cluster-doc id (and relay identity): **`a356d8f5-cca3-4f4a-9070-4fd8084b0468`**
+  - Firestore doc `organizations/vnVZ…/clusters/a356d8f5-…` exists (`name: todo-list-example1-local-1`, `mode: local`), with one `api_keys/*`.
+  - Relay log: `[relay] coexist: cluster=a356d8f5-… joining project=Xr7fxq61PF57U2lOtoKe`
+- No doc exists under `clusters/6c23c4c4-…` (404), and it has no `api_keys` — so this is an **identity split, not a duplicate doc**.
+
+## User Stories
+
+### US1: Operator debugging a local cluster sees one identity
+
+**As a** Generacy operator/developer investigating a misbehaving local cluster,
+**I want** the cluster's runtime `GENERACY_CLUSTER_ID` to match the cloud cluster-doc id,
+**So that** I can correlate logs, tunnel names, relay traffic, and Firestore docs by a single identifier without cross-referencing two UUIDs.
+
+**Acceptance Criteria**:
+- [ ] When inspecting a local cluster's orchestrator env, the `GENERACY_CLUSTER_ID` value matches the id used as the Firestore cluster-doc key.
+- [ ] The tunnel name registered with Microsoft (`g-<prefix>`) is derived from the same id present in the cloud doc.
+- [ ] Relay handshake logs (`cluster=<id>`) and orchestrator env id are identical.
+
+### US2: New local cluster scaffolds with cloud-minted id
+
+**As a** user running the web "Add cluster → local" flow (which invokes the launch command),
+**I want** the launch path to adopt the cloud-returned `cluster_id`,
+**So that** my freshly-created local cluster has a single, canonical identity from the moment it boots.
+
+**Acceptance Criteria**:
+- [ ] After `generacy launch` completes, `.generacy/cluster.json` contains `cluster_id` equal to the cloud-minted id.
+- [ ] The `docker-compose.yml` (or `.env`) sets `GENERACY_CLUSTER_ID` to the same id.
+- [ ] No locally-generated UUID is persisted that does not correspond to a cloud cluster doc.
+
+### US3: Worker enumeration and assignee filtering work end-to-end on local clusters
+
+**As a** developer relying on per-cluster features (orchestrator assignee filtering #742, worker enumeration, per-cluster reporting),
+**I want** the local cluster's self-reported identity to match the doc id those features key on,
+**So that** these features work correctly on local clusters, not just `deploy`-provisioned remote clusters.
+
+**Acceptance Criteria**:
+- [ ] Assignee filtering by cluster id (#742) succeeds on local clusters.
+- [ ] Any feature querying Firestore by `clusters/<GENERACY_CLUSTER_ID>` resolves correctly.
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR-001 | The local launch path MUST persist the cloud-returned `cluster_id` (not a locally-minted UUID) into `.generacy/cluster.json`. | P1 | Mirrors deploy: `cli/commands/deploy/activation.ts:85`, `cli/commands/deploy/scaffolder.ts:33`. |
+| FR-002 | The generated `docker-compose.yml` and/or `.env` MUST export `GENERACY_CLUSTER_ID` set to the cloud-returned `cluster_id`. | P1 | Consumed by orchestrator, tunnel-name derivation, relay metadata. |
+| FR-003 | The cloud-returned `cluster_id` MUST be the single source of truth for the local launch path — no shadow/orphan id may be minted client-side. | P1 | Prevents identity split. |
+| FR-004 | If the web "Add cluster → local" flow pre-creates a cluster doc, that doc's id MUST be fed into the launch command (e.g. via claim code → `LaunchConfig.clusterId`). | P1 | Verify cloud `buildLaunchConfig` returns the doc id. |
+| FR-005 | Existing local clusters with mismatched ids MUST NOT be silently rewritten. Reconciliation/migration is out of scope for this fix. | P2 | Fresh clusters only. |
+| FR-006 | The fix MUST NOT regress the `generacy deploy` path, which already adopts the cloud-returned id correctly. | P1 | Regression check. |
+
+## Success Criteria
+
+| ID | Metric | Target | Measurement |
+|----|--------|--------|-------------|
+| SC-001 | Identity match on fresh local cluster | 100% | After `generacy launch`, `GENERACY_CLUSTER_ID` from orchestrator env equals Firestore cluster-doc id. |
+| SC-002 | No orphan ids | 0 | No client-minted UUIDs exist that lack a corresponding cloud cluster doc. |
+| SC-003 | Tunnel-name source id matches doc id | 100% | `deriveTunnelName(GENERACY_CLUSTER_ID)` uses the same id keying the cluster doc. |
+| SC-004 | Deploy path regression | 0 regressions | `generacy deploy` continues to scaffold with cloud-returned id (unchanged behavior). |
+
+## Assumptions
+
+- The cloud-side `buildLaunchConfig` (or equivalent) already returns the canonical `cluster_id` from the cloud cluster doc — or can be made to do so as part of this fix.
+- The web "Add cluster → local" flow that pre-creates the cluster doc passes the resulting id forward (via claim code or `LaunchConfig`) to the launch command.
+- The fix is scoped to the launch path scaffolder; orchestrator-side identity reading from `GENERACY_CLUSTER_ID` env var stays unchanged.
+- generacy-cloud#801 (sibling stuck `connecting`) is being handled separately and does not block this work.
+
+## Out of Scope
+
+- Migration/reconciliation of existing mismatched local clusters (fresh clusters only).
+- Changes to `generacy deploy` (already correct).
+- The sibling-cluster `connecting` issue (generacy-cloud#801).
+- Cloud-side cluster-doc id minting strategy beyond ensuring it is returned to the launch path.
+- Tunnel-name collision handling (#743 already covers the actual-vs-requested name reporting).
+
+## Related Issues
+
+- **#744** — Cluster-id minting (Q3: cloud-minted clusterId). This fix aligns with that direction.
+- **#742** — Orchestrator identity / assignee filtering (broken by the identity split).
+- **#743** — Tunnel name actual-vs-requested reporting (independent, but adjacent).
+- **generacy-cloud#792 / #796 / #801** — Related cloud-side cluster identity/connection issues.
+
+---
+
+*Generated by speckit*

--- a/specs/750-summary-local-cluster-s/tasks.md
+++ b/specs/750-summary-local-cluster-s/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: Local Cluster Identity Split Detection
+
+**Input**: Design documents from `/specs/750-summary-local-cluster-s/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/cluster-identity-split-event.md, quickstart.md
+**Status**: Complete
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1 = single identity / verification gate; US2 = mismatch detection + relay event)
+
+## Phase 1: Setup
+
+- [ ] T001 [P] [US2] Add `'cluster.identity-split'` to the `ALLOWED_CHANNELS` tuple in `packages/orchestrator/src/routes/internal-relay-events.ts` (documents the channel even though emission is in-process; keeps the allowlist authoritative for future cross-process emitters).
+
+## Phase 2: Core Implementation
+
+- [ ] T002 [US2] Create `packages/orchestrator/src/services/identity-split-detector.ts` with:
+  - `IdentitySplitEvent` interface — `{ env_cluster_id, cluster_json_cluster_id, detected_at }` (snake_case, matches data-model.md §Output).
+  - `DetectionOutcome` discriminated union — `no-env | no-cluster-json | match | mismatch` (per data-model.md §DetectionOutcome).
+  - `DetectIdentitySplitOptions` interface — `{ clusterJsonPath, env?, sendRelayEvent?, logger }`.
+  - Module-level `let hasEmitted = false` once-guard.
+  - `export async function detectIdentitySplit(options)`: reads `env.GENERACY_CLUSTER_ID`, calls `readClusterJson(clusterJsonPath)` (import from `../activation/persistence.ts`), branches on the four outcomes, and on `mismatch` calls `sendRelayEvent('cluster.identity-split', payload)` exactly once across the process lifetime. Swallow + log any `sendRelayEvent` throw (FR-005, contracts/cluster-identity-split-event.md §Failure handling).
+  - `export function resetIdentitySplitDetectionState()` test helper (resets `hasEmitted` to `false`).
+  - NEVER mutate `process.env`, `.env`, or `cluster.json` (FR-003).
+
+- [ ] T003 [US2] Wire `detectIdentitySplit` into the existing-key startup path in `packages/orchestrator/src/server.ts` (~line 357, after `initializeRelayBridge()` returns and `relayClientRef` is set). Pass `clusterJsonPath` (use the same `/var/lib/generacy/cluster.json` path constant used by `activate()`), `logger`, and a `sendRelayEvent` closure that calls `relayClientRef.send({ type: 'event', event: 'cluster.identity-split', data: payload, timestamp: new Date().toISOString() })` — mirror the wire envelope from `routes/internal-relay-events.ts` (#600 fix shape).
+
+- [ ] T004 [US2] Wire `detectIdentitySplit` into the background-activation (wizard-mode) startup path in `packages/orchestrator/src/server.ts` (~line 720, inside `activateInBackground` after `await relayBridge.start()` succeeds). Same call shape as T003. Both call sites converge on "relay bridge has started → run detector once" (research.md §D6).
+
+## Phase 3: Tests
+
+- [ ] T005 [US2] Create `packages/orchestrator/src/__tests__/identity-split-detector.test.ts` covering each `DetectionOutcome` branch:
+  - `match` → outcome `match`, no `sendRelayEvent` call.
+  - `mismatch`, first call → outcome `mismatch` with `emitted: true`, exactly one `sendRelayEvent` call with payload shape per contracts/cluster-identity-split-event.md.
+  - `mismatch`, second call after `resetIdentitySplitDetectionState()` NOT called → outcome `mismatch` with `emitted: false`, still only one total `sendRelayEvent` call (FR-005).
+  - Missing env (`env.GENERACY_CLUSTER_ID` unset) → outcome `no-env`, no event.
+  - Missing `cluster.json` (mock `readClusterJson` returning `null`) → outcome `no-cluster-json`, no event.
+  - `sendRelayEvent` throws → swallowed; no exception propagates; logger.error called; `hasEmitted` still flipped (single attempt counts, per quickstart.md table).
+  - Use `resetIdentitySplitDetectionState()` in `beforeEach` for test isolation.
+
+- [ ] T006 [P] [US1] In `packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts`, add (or confirm) an assertion that `scaffoldEnvFile` writes the input `config.clusterId` byte-for-byte to the `GENERACY_CLUSTER_ID` line of the generated `.env` (FR-001 verification gate). No new behavior — this test locks in the current correct behavior at `packages/generacy/src/cli/commands/launch/scaffolder.ts:71-114` so a future regression to client-side UUID minting fails fast.
+
+## Phase 4: Follow-up
+
+- [ ] T007 [P] [US1] File the cloud companion issue in `generacy-ai/generacy-cloud` per FR-006 and quickstart.md §"Cloud companion issue":
+  - **Title**: "Device-code activation must reuse claim's clusterId instead of minting a fresh UUID"
+  - **Body**: cross-reference this issue (#750), cite root cause at `services/api/src/services/cluster-activation.ts:385-386`, link #744, generacy-cloud#792 / #796 / #801.
+  - Track as related issue; do NOT block this issue's merge on it.
+
+## Dependencies & Execution Order
+
+**Sequential dependencies**:
+- T002 must complete before T003 and T004 (server.ts wires the detector — needs it to exist).
+- T002 must complete before T005 (tests import the detector).
+- T003 and T004 can be done in the same edit pass (same file, `server.ts`) but are listed separately because they touch distinct call sites with distinct conditions.
+
+**Parallel opportunities**:
+- T001 [P] is independent (channel allowlist string addition — touches only `internal-relay-events.ts`).
+- T006 [P] is independent (touches only the launch scaffolder test file, different package).
+- T007 [P] is administrative (file an external issue — no code).
+- After T002 lands, T005 can run in parallel with the T003/T004 wiring edits (different files).
+
+**Suggested order**:
+1. T001 + T006 + T007 in parallel (independent setup / verification gate / follow-up filing).
+2. T002 (core detector module).
+3. T003 + T004 (server.ts wiring, same file — do in one edit pass).
+4. T005 (detector unit tests).
+
+## Notes
+
+- Two user stories map cleanly: **US1 = T006 + T007** (single-identity verification gate + cloud companion that delivers prevention); **US2 = T001 + T002 + T003 + T004 + T005** (detection + relay event).
+- No new dependencies, no new packages.
+- No state mutation anywhere (FR-003 is the load-bearing invariant — every task must respect it).
+- Detector emits at most once per process (FR-005). Module-level `hasEmitted` flag enforces this; T005 covers it.

--- a/specs/750-summary-local-cluster-s/tasks.md
+++ b/specs/750-summary-local-cluster-s/tasks.md
@@ -10,11 +10,11 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 [P] [US2] Add `'cluster.identity-split'` to the `ALLOWED_CHANNELS` tuple in `packages/orchestrator/src/routes/internal-relay-events.ts` (documents the channel even though emission is in-process; keeps the allowlist authoritative for future cross-process emitters).
+- [X] T001 [P] [US2] Add `'cluster.identity-split'` to the `ALLOWED_CHANNELS` tuple in `packages/orchestrator/src/routes/internal-relay-events.ts` (documents the channel even though emission is in-process; keeps the allowlist authoritative for future cross-process emitters).
 
 ## Phase 2: Core Implementation
 
-- [ ] T002 [US2] Create `packages/orchestrator/src/services/identity-split-detector.ts` with:
+- [X] T002 [US2] Create `packages/orchestrator/src/services/identity-split-detector.ts` with:
   - `IdentitySplitEvent` interface — `{ env_cluster_id, cluster_json_cluster_id, detected_at }` (snake_case, matches data-model.md §Output).
   - `DetectionOutcome` discriminated union — `no-env | no-cluster-json | match | mismatch` (per data-model.md §DetectionOutcome).
   - `DetectIdentitySplitOptions` interface — `{ clusterJsonPath, env?, sendRelayEvent?, logger }`.
@@ -23,13 +23,13 @@
   - `export function resetIdentitySplitDetectionState()` test helper (resets `hasEmitted` to `false`).
   - NEVER mutate `process.env`, `.env`, or `cluster.json` (FR-003).
 
-- [ ] T003 [US2] Wire `detectIdentitySplit` into the existing-key startup path in `packages/orchestrator/src/server.ts` (~line 357, after `initializeRelayBridge()` returns and `relayClientRef` is set). Pass `clusterJsonPath` (use the same `/var/lib/generacy/cluster.json` path constant used by `activate()`), `logger`, and a `sendRelayEvent` closure that calls `relayClientRef.send({ type: 'event', event: 'cluster.identity-split', data: payload, timestamp: new Date().toISOString() })` — mirror the wire envelope from `routes/internal-relay-events.ts` (#600 fix shape).
+- [X] T003 [US2] Wire `detectIdentitySplit` into the existing-key startup path in `packages/orchestrator/src/server.ts` (~line 357, after `initializeRelayBridge()` returns and `relayClientRef` is set). Pass `clusterJsonPath` (use the same `/var/lib/generacy/cluster.json` path constant used by `activate()`), `logger`, and a `sendRelayEvent` closure that calls `relayClientRef.send({ type: 'event', event: 'cluster.identity-split', data: payload, timestamp: new Date().toISOString() })` — mirror the wire envelope from `routes/internal-relay-events.ts` (#600 fix shape).
 
-- [ ] T004 [US2] Wire `detectIdentitySplit` into the background-activation (wizard-mode) startup path in `packages/orchestrator/src/server.ts` (~line 720, inside `activateInBackground` after `await relayBridge.start()` succeeds). Same call shape as T003. Both call sites converge on "relay bridge has started → run detector once" (research.md §D6).
+- [X] T004 [US2] Wire `detectIdentitySplit` into the background-activation (wizard-mode) startup path in `packages/orchestrator/src/server.ts` (~line 720, inside `activateInBackground` after `await relayBridge.start()` succeeds). Same call shape as T003. Both call sites converge on "relay bridge has started → run detector once" (research.md §D6).
 
 ## Phase 3: Tests
 
-- [ ] T005 [US2] Create `packages/orchestrator/src/__tests__/identity-split-detector.test.ts` covering each `DetectionOutcome` branch:
+- [X] T005 [US2] Create `packages/orchestrator/src/__tests__/identity-split-detector.test.ts` covering each `DetectionOutcome` branch:
   - `match` → outcome `match`, no `sendRelayEvent` call.
   - `mismatch`, first call → outcome `mismatch` with `emitted: true`, exactly one `sendRelayEvent` call with payload shape per contracts/cluster-identity-split-event.md.
   - `mismatch`, second call after `resetIdentitySplitDetectionState()` NOT called → outcome `mismatch` with `emitted: false`, still only one total `sendRelayEvent` call (FR-005).
@@ -38,7 +38,7 @@
   - `sendRelayEvent` throws → swallowed; no exception propagates; logger.error called; `hasEmitted` still flipped (single attempt counts, per quickstart.md table).
   - Use `resetIdentitySplitDetectionState()` in `beforeEach` for test isolation.
 
-- [ ] T006 [P] [US1] In `packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts`, add (or confirm) an assertion that `scaffoldEnvFile` writes the input `config.clusterId` byte-for-byte to the `GENERACY_CLUSTER_ID` line of the generated `.env` (FR-001 verification gate). No new behavior — this test locks in the current correct behavior at `packages/generacy/src/cli/commands/launch/scaffolder.ts:71-114` so a future regression to client-side UUID minting fails fast.
+- [X] T006 [P] [US1] In `packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts`, add (or confirm) an assertion that `scaffoldEnvFile` writes the input `config.clusterId` byte-for-byte to the `GENERACY_CLUSTER_ID` line of the generated `.env` (FR-001 verification gate). No new behavior — this test locks in the current correct behavior at `packages/generacy/src/cli/commands/launch/scaffolder.ts:71-114` so a future regression to client-side UUID minting fails fast.
 
 ## Phase 4: Follow-up
 


### PR DESCRIPTION
## Problem

On a scaffolded cluster, **workers can't run Claude**, so spec-kit issues produce a draft PR with many phase commits (`chore(speckit): complete specify/plan/tasks/implement…`) but **zero real artifacts** — only a templated `spec.md` + conversation-log; no `plan.md`, `tasks.md`, or implementation code.

**Root cause:** the generated compose mounted only `~/.claude.json` (a file) and **no shared `/home/node/.claude` directory volume**. The orchestrator's post-activation Claude setup — auth (`.credentials.json`), speckit slash-commands, Agency MCP, conversations — lives in its **container-local** `~/.claude`. Workers (which actually spawn the Claude CLI for each phase) get none of it. Verified on a live cluster:

```
$ docker exec <worker> claude -p "ping"
Not logged in · Please run /login      # exits ~900ms — matches every phase duration
$ ls ~/.claude/commands                 # absent on workers; present on orchestrator
```

Each phase launches an unauthenticated Claude with no speckit commands, exits in <1s, and the phase runner treats the quick exit as success — commits an empty phase and advances. Proven fix: copying the orchestrator's `~/.claude` onto a worker makes `claude -p` return a real response and the speckit commands appear.

## Why the generator drifted

The canonical cluster composes — `cluster-base`, `cluster-microservices`, and the `tetrad-development` dev stack — **already** share `claude-config:/home/node/.claude` on both services and use `shared-packages:ro` on workers. Only the hand-rolled generators (`scaffolder.ts` here, and `generacy-cloud`'s `compose-template.ts`) diverged.

## Fix

Align the generated compose with the canonical cluster-base layout:

- **Add shared `claude-config:/home/node/.claude`** named volume on both orchestrator and worker → workers inherit the orchestrator's Claude auth + speckit commands + conversation history.
- **Stop mounting `workspace` on the worker** → workers no longer share the orchestrator's working tree (concurrent checkouts would clobber it); per-job checkouts are container-local.
- **`shared-packages` read-only on the worker.**

## #737 is preserved

This re-adds only the `.claude` **directory** volume. It does **not** remount a named volume onto the `.claude.json` **file** path — the actual #737 bug ("source …/.claude.json is not directory"). The #737 file-path guard remains asserted in the tests; the prior tests/snapshot that asserted *no* `claude-config` volume at all were over-corrected and are updated here.

## Tests

`scaffolder.test.ts` updated (bind + volume modes now assert the dir volume exists while keeping the file-path guard; added a test that the worker doesn't share `workspace`); snapshot regenerated. `60 passed`.

> Companion: the same fix for cloud deploys is in generacy-cloud (`compose-template.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)