### PR TITLE
fix(scaffolder): share .claude volume + un-share worker workspace (wo…

### DIFF
--- a/.changeset/fix-scaffolder-share-claude-config-volume.md
+++ b/.changeset/fix-scaffolder-share-claude-config-volume.md
@@ -1,0 +1,18 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+Share the `.claude` directory volume between orchestrator and workers in scaffolded clusters.
+
+The generated compose mounted only `~/.claude.json` (a file) and no shared
+`/home/node/.claude` directory volume, so workers never inherited the
+orchestrator's Claude auth, speckit slash-commands, or conversation history.
+Every spec-kit phase launched an unauthenticated Claude CLI, exited "Not logged
+in" in <1s, and the phase runner committed an empty phase — producing PRs with
+phase commits but no real artifacts.
+
+Align the generated compose with the canonical cluster-base layout: add a shared
+`claude-config:/home/node/.claude` volume on both services, stop mounting
+`workspace` on the worker (per-job checkouts are container-local), and mount
+`shared-packages` read-only on the worker. Only the `.claude` directory is
+volume-mounted — never the `.claude.json` file path (preserving the #737 fix).

--- a/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
@@ -12,9 +12,10 @@ services:
     volumes:
       - workspace:/workspaces
       - ~/.claude.json:/home/node/.claude.json
-      - shared-packages:/shared-packages
+      - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy
+      - shared-packages:/shared-packages
       - /var/run/docker.sock:/var/run/docker-host.sock
       - vscode-cli-state:/home/node/.vscode/cli
       - generacy-app-config-data:/var/lib/generacy-app-config
@@ -55,11 +56,11 @@ services:
     deploy:
       replicas: \${WORKER_COUNT:-1}
     volumes:
-      - workspace:/workspaces
       - ~/.claude.json:/home/node/.claude.json
-      - shared-packages:/shared-packages
+      - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy
+      - shared-packages:/shared-packages:ro
       - generacy-app-config-data:/var/lib/generacy-app-config:ro
     tmpfs: *a1
     environment:
@@ -102,6 +103,7 @@ services:
       - cluster-network
 volumes:
   workspace: null
+  claude-config: null
   shared-packages: null
   npm-cache: null
   generacy-data: null

--- a/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
@@ -311,13 +311,23 @@ describe('scaffoldDockerCompose', () => {
     expect(parsed.services.worker).not.toHaveProperty('ports');
   });
 
-  it('bind mode uses ~/.claude.json bind mount (no claude-config volume)', () => {
+  it('bind mode binds ~/.claude.json and shares the claude-config dir volume', () => {
     scaffoldDockerCompose(dir, { ...baseInput, claudeConfigMode: 'bind' });
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     const orchVolumes = parsed.services.orchestrator.volumes as string[];
+    const workerVolumes = parsed.services.worker.volumes as string[];
+    // ~/.claude.json is bind-mounted (account metadata file).
     expect(orchVolumes).toContain('~/.claude.json:/home/node/.claude.json');
-    expect(parsed.volumes).not.toHaveProperty('claude-config');
+    // The .claude DIRECTORY is a shared named volume so workers inherit the
+    // orchestrator's Claude auth + speckit commands + conversations.
+    expect(orchVolumes).toContain('claude-config:/home/node/.claude');
+    expect(workerVolumes).toContain('claude-config:/home/node/.claude');
+    expect(parsed.volumes).toHaveProperty('claude-config');
+    // #737 guard: never mount the named volume onto the .claude.json FILE path
+    // (Docker rejects "is not directory").
+    expect(orchVolumes).not.toContain('claude-config:/home/node/.claude.json');
+    expect(workerVolumes).not.toContain('claude-config:/home/node/.claude.json');
   });
 
   // T001 [US2]: lock SC-002 — bind-mode YAML must be byte-identical after the
@@ -339,9 +349,13 @@ describe('scaffoldDockerCompose', () => {
 
     expect(orchVolumes).toContain('./claude.json:/home/node/.claude.json');
     expect(workerVolumes).toContain('./claude.json:/home/node/.claude.json');
+    // #737 guard: the named volume must never mount onto the .claude.json FILE.
     expect(orchVolumes).not.toContain('claude-config:/home/node/.claude.json');
     expect(workerVolumes).not.toContain('claude-config:/home/node/.claude.json');
-    expect(parsed.volumes).not.toHaveProperty('claude-config');
+    // …but the .claude DIRECTORY is still a shared named volume on both.
+    expect(orchVolumes).toContain('claude-config:/home/node/.claude');
+    expect(workerVolumes).toContain('claude-config:/home/node/.claude');
+    expect(parsed.volumes).toHaveProperty('claude-config');
   });
 
   // T003 [US1]: idempotency per contract Q6–Q8 / FR-002, FR-003.
@@ -451,12 +465,24 @@ describe('scaffoldDockerCompose', () => {
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     expect(parsed.volumes).toHaveProperty('workspace');
+    expect(parsed.volumes).toHaveProperty('claude-config');
     expect(parsed.volumes).toHaveProperty('shared-packages');
     expect(parsed.volumes).toHaveProperty('npm-cache');
     expect(parsed.volumes).toHaveProperty('generacy-data');
     expect(parsed.volumes).toHaveProperty('redis-data');
     expect(parsed.volumes).toHaveProperty('vscode-cli-state');
     expect(parsed.volumes).toHaveProperty('generacy-app-config-data');
+  });
+
+  it('mounts workspace on the orchestrator only — workers do not share it', () => {
+    // Workers must not share the orchestrator's working tree (concurrent
+    // checkouts would clobber it); their per-job checkouts are container-local.
+    scaffoldDockerCompose(dir, baseInput);
+    const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
+
+    expect(parsed.services.orchestrator.volumes).toContain('workspace:/workspaces');
+    const workerVolumes = parsed.services.worker.volumes as string[];
+    expect(workerVolumes.some((v) => v.startsWith('workspace:'))).toBe(false);
   });
 
   it('mounts shared-packages at /shared-packages (cluster-base entrypoint contract)', () => {
@@ -470,7 +496,8 @@ describe('scaffoldDockerCompose', () => {
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     expect(parsed.services.orchestrator.volumes).toContain('shared-packages:/shared-packages');
-    expect(parsed.services.worker.volumes).toContain('shared-packages:/shared-packages');
+    // Worker consumes the orchestrator's build output read-only.
+    expect(parsed.services.worker.volumes).toContain('shared-packages:/shared-packages:ro');
   });
 
   it('sanitizes project name', () => {

--- a/packages/generacy/src/cli/commands/cluster/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/cluster/scaffolder.ts
@@ -142,31 +142,45 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
       ? ['${ORCHESTRATOR_PORT:-3100}:3100']
       : ['${ORCHESTRATOR_PORT:-3100}'];
 
-  // Shared volumes for orchestrator and worker.
+  // Volumes mounted on both orchestrator and worker. Mirrors the canonical
+  // cluster-base devcontainer compose.
   //
-  // shared-packages MUST mount at /shared-packages — that's where the
-  // cluster-base entrypoint scripts (`entrypoint-orchestrator.sh`) run
-  // `npm install --prefix /shared-packages`, and the worker's entrypoint
-  // resolves `/shared-packages/node_modules/.bin/generacy` to spawn the
-  // worker process. Mounting it anywhere else means the orchestrator's
-  // install writes to its own overlay filesystem (not the volume), the
-  // worker's resolve looks at its own overlay (empty), and the worker
-  // exits with "Cannot find module '/shared-packages/node_modules/.bin/generacy'".
-  // Matches the canonical cluster-base devcontainer compose.
-  const sharedVolumes = [
-    'workspace:/workspaces',
+  // claude-config (/home/node/.claude) is a SHARED named volume so the
+  // orchestrator's post-activation Claude setup — auth (`.credentials.json`),
+  // speckit slash commands, and conversation history — is visible to every
+  // worker. Without it, workers spawn an unauthenticated Claude CLI with no
+  // speckit commands; each phase exits "Not logged in" in <1s and the phase
+  // runner commits an empty phase, producing PRs with commits but no artifacts.
+  // (~/.claude.json is the separate account-metadata file; both are mounted.)
+  const commonVolumes = [
     claudeConfigVolume,
-    'shared-packages:/shared-packages',
+    'claude-config:/home/node/.claude',
     'npm-cache:/home/node/.npm',
     'generacy-data:/var/lib/generacy',
   ];
 
-  // Orchestrator gets docker socket
+  // shared-packages MUST mount at /shared-packages — that's where the
+  // cluster-base entrypoint scripts (`entrypoint-orchestrator.sh`) run
+  // `npm install --prefix /shared-packages`, and the worker's entrypoint
+  // resolves `/shared-packages/node_modules/.bin/generacy` to spawn the
+  // worker process. Orchestrator builds here (RW); workers consume read-only.
+  //
+  // The orchestrator owns the `workspace` volume (RW). Workers do NOT mount it
+  // at all — their per-job checkouts are container-local — so concurrent
+  // workers and the orchestrator can't clobber a shared working tree.
   const orchestratorVolumes = [
-    ...sharedVolumes,
+    'workspace:/workspaces',
+    ...commonVolumes,
+    'shared-packages:/shared-packages',
     '/var/run/docker.sock:/var/run/docker-host.sock',
     'vscode-cli-state:/home/node/.vscode/cli',
     'generacy-app-config-data:/var/lib/generacy-app-config',
+  ];
+
+  const workerVolumes = [
+    ...commonVolumes,
+    'shared-packages:/shared-packages:ro',
+    'generacy-app-config-data:/var/lib/generacy-app-config:ro',
   ];
 
   const tmpfsMounts = [
@@ -219,7 +233,7 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
         deploy: {
           replicas: '${WORKER_COUNT:-1}',
         },
-        volumes: [...sharedVolumes, 'generacy-app-config-data:/var/lib/generacy-app-config:ro'],
+        volumes: workerVolumes,
         tmpfs: tmpfsMounts,
         environment: [
           'REDIS_URL=redis://redis:6379',
@@ -258,6 +272,7 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
     },
     volumes: {
       workspace: null,
+      'claude-config': null,
       'shared-packages': null,
       'npm-cache': null,
       'generacy-data': null,


### PR DESCRIPTION
…rkers can't run Claude) (#757)

* chore(speckit): complete specify phase for #750

* chore(speckit): complete clarify phase for #750

* chore(speckit): complete clarify phase for #750

* chore(speckit): complete plan phase for #750

* chore(speckit): complete tasks phase for #750

* chore(speckit): complete implement phase for #750

* chore: add changeset for #750 identity-split detector



* fix(scaffolder): share .claude volume so workers can run Claude

Generated cluster compose mounted only ~/.claude.json (a file) and no shared /home/node/.claude directory volume. The orchestrator's post-activation Claude setup — auth (.credentials.json), speckit slash commands, Agency MCP, and conversations — lives in its container-local ~/.claude, so workers (which actually spawn the Claude CLI for each spec-kit phase) got none of it. Every phase launched an unauthenticated Claude with no speckit commands, exited "Not logged in" in <1s, and the phase runner committed an empty phase and advanced — producing PRs with many phase commits but zero real artifacts (no plan.md/tasks.md/code).

Align the generated compose with the canonical cluster-base / cluster-microservices / tetrad-development composes:

  - Add a shared `claude-config:/home/node/.claude` named volume on BOTH orchestrator and worker (auth + commands + conversations).
  - Stop mounting `workspace` on the worker — workers must not share the orchestrator's working tree (concurrent checkouts clobber it); per-job checkouts are container-local.
  - Mount `shared-packages` read-only on the worker (orchestrator builds, workers consume).

This re-adds only the .claude DIRECTORY volume; it does NOT remount a named volume onto the .claude.json FILE path — the actual #737 bug — so that fix is preserved. Tests updated + snapshot regenerated accordingly.



* chore: add changeset for scaffolder .claude volume fix



---------