### PR TITLE
fix(scaffolder): share git-token-proxy socket volume (workers can't mint git tokens)

### DIFF
--- a/.changeset/fix-scaffolder-git-token-proxy-volume.md
+++ b/.changeset/fix-scaffolder-git-token-proxy-volume.md
@@ -1,0 +1,15 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+Share the `git-token-proxy` socket volume between orchestrator and workers in scaffolded clusters.
+
+cluster-base#61 introduced a git-token proxy: the orchestrator binds
+`/run/generacy-git-token/control.sock` and workers connect to it to mint JIT
+git installation tokens. The shared volume was added to the cluster-base
+devcontainer compose but not to the scaffolder, so generated local/cloud
+clusters left workers with their own empty `/run/generacy-git-token` —
+`CONTROL_SOCKET_UNREACHABLE`, and worker git operations (clone, commit, push)
+fail. Add `git-token-proxy:/run/generacy-git-token` (rw — Unix socket connect
+needs write) to both services and declare the named volume, mirroring the
+canonical cluster-base compose.

--- a/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
@@ -15,6 +15,7 @@ services:
       - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy
+      - git-token-proxy:/run/generacy-git-token
       - shared-packages:/shared-packages
       - /var/run/docker.sock:/var/run/docker-host.sock
       - vscode-cli-state:/home/node/.vscode/cli
@@ -60,6 +61,7 @@ services:
       - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy
+      - git-token-proxy:/run/generacy-git-token
       - shared-packages:/shared-packages:ro
       - generacy-app-config-data:/var/lib/generacy-app-config:ro
     tmpfs: *a1
@@ -104,6 +106,7 @@ services:
 volumes:
   workspace: null
   claude-config: null
+  git-token-proxy: null
   shared-packages: null
   npm-cache: null
   generacy-data: null

--- a/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
@@ -485,6 +485,20 @@ describe('scaffoldDockerCompose', () => {
     expect(workerVolumes.some((v) => v.startsWith('workspace:'))).toBe(false);
   });
 
+  it('shares the git-token-proxy socket volume on both orchestrator and worker', () => {
+    // The orchestrator binds /run/generacy-git-token/control.sock and workers
+    // connect to it for JIT git tokens (cluster-base#61). It must be a shared
+    // named volume on BOTH services (rw — Unix socket connect needs write) or
+    // workers get CONTROL_SOCKET_UNREACHABLE and can't authenticate git.
+    scaffoldDockerCompose(dir, baseInput);
+    const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
+
+    const mount = 'git-token-proxy:/run/generacy-git-token';
+    expect(parsed.services.orchestrator.volumes).toContain(mount);
+    expect(parsed.services.worker.volumes).toContain(mount);
+    expect(parsed.volumes).toHaveProperty('git-token-proxy');
+  });
+
   it('mounts shared-packages at /shared-packages (cluster-base entrypoint contract)', () => {
     // The cluster-base entrypoint scripts (`entrypoint-orchestrator.sh`,
     // `entrypoint-worker.sh`) run `npm install --prefix /shared-packages`

--- a/packages/generacy/src/cli/commands/cluster/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/cluster/scaffolder.ts
@@ -157,6 +157,12 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
     'claude-config:/home/node/.claude',
     'npm-cache:/home/node/.npm',
     'generacy-data:/var/lib/generacy',
+    // Shared socket dir for the git-token proxy: the orchestrator binds
+    // /run/generacy-git-token/control.sock and workers connect to it for JIT
+    // git tokens (generacy-ai/cluster-base#61). Must be a shared volume (not a
+    // per-container tmpfs) or workers get CONTROL_SOCKET_UNREACHABLE; rw on
+    // both — connecting to a Unix socket requires write access.
+    'git-token-proxy:/run/generacy-git-token',
   ];
 
   // shared-packages MUST mount at /shared-packages — that's where the
@@ -273,6 +279,7 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
     volumes: {
       workspace: null,
       'claude-config': null,
+      'git-token-proxy': null,
       'shared-packages': null,
       'npm-cache': null,
       'generacy-data': null,


### PR DESCRIPTION
## Problem

On a scaffolded cluster, **worker git operations fail** — clone/commit/push hit:
```
generacy-git-helper: CONTROL_SOCKET_UNREACHABLE: control socket at /run/generacy-git-token/control.sock unreachable (ENOENT)
fatal: could not read Username for 'https://github.com'
```

cluster-base#61's JIT git-token proxy runs on the orchestrator, binds `/run/generacy-git-token/control.sock`, and workers connect to it (their credential helper is wired to that socket). That socket must live on a **volume shared between the orchestrator and workers** — but the scaffolder never mounted one, so each container had its own empty image-baked `/run/generacy-git-token`. The orchestrator's socket is invisible to workers.

**Root cause:** the shared volume was added **only to the cluster-base devcontainer compose** (`git-token-proxy:/run/generacy-git-token`, both services + declared) — not to `scaffolder.ts`. Same generator-divergence class as the `.claude` volume fix.

## Fix

Add `git-token-proxy:/run/generacy-git-token` to **both** orchestrator and worker (rw — connecting to a Unix socket requires write access) and declare the named volume, mirroring the canonical cluster-base compose.

## Tests

Added a regression test asserting the mount on both services + the volume declaration; byte-identical snapshot regenerated. `61 passed`.

> Companion: same fix for cloud deploys in generacy-cloud `compose-template.ts`. Verified live: with the volume missing, a fresh cluster's worker clone returns `CONTROL_SOCKET_UNREACHABLE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)