### PR TITLE
feat: #777 777-severity-high-773-not (#778)

### DIFF
--- a/.changeset/fix-777-jit-gh-token-credentialless.md
+++ b/.changeset/fix-777-jit-gh-token-credentialless.md
@@ -1,0 +1,14 @@
+---
+"@generacy-ai/orchestrator": patch
+"@generacy-ai/workflow-engine": patch
+---
+
+Fix JIT gh-token provider on wizard-bootstrapped clusters (#777).
+
+The gh JIT token provider was gated on a `github-app` credential descriptor
+that wizard-bootstrapped clusters never have, so it was always `undefined` and
+every `gh` call fell back to the expired ambient `GH_TOKEN`. The provider is now
+built whenever the control-plane `/git-token` path is available and fetches
+credential-less (passing `credentialId` only when a descriptor exists). When a
+provider is present, `GH_TOKEN` is always set on the `gh` subprocess (never
+`undefined`), so it can no longer inherit the stale ambient token.

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -31,6 +31,7 @@ import {
   createJitGithubTokenProvider,
   resolveSocketPath,
 } from './services/jit-github-token-provider.js';
+import { clusterApiKeyExists } from './services/cluster-api-key-probe.js';
 import { GitHubAuthHealthService } from './services/github-auth-health.js';
 import {
   CredentialExpiryWatcher,
@@ -211,10 +212,16 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
   // JIT GitHub token provider — replaces the static wizard-creds-token-provider.
   // Resolves a fresh installation token per `gh` invocation via the control-plane
   // /git-token route. Constructed in both orchestrator and worker modes because
-  // ClaudeCliWorker (worker mode) also needs it. When no github-app credential is
-  // configured, leaves the provider undefined so callers fall through to ambient
-  // `GH_TOKEN` (existing behavior for unconfigured clusters).
-  const githubTokenProvider = githubAppCredentialId
+  // ClaudeCliWorker (worker mode) also needs it.
+  //
+  // Gating: built when the cluster-api-key file exists — same precondition the
+  // working `git-credential-generacy` path relies on. Wizard-bootstrapped clusters
+  // (no `github-app` descriptor in `.agency/credentials.yaml`) still get a
+  // credential-less provider; `client.fetch()` is called with no argument and the
+  // control-plane resolves the installation server-side from cluster identity.
+  // Truly-unconfigured / offline clusters (no api-key file) keep the legacy
+  // fallback — provider stays `undefined` and callers inherit ambient `GH_TOKEN`.
+  const githubTokenProvider = clusterApiKeyExists()
     ? createJitGithubTokenProvider({
         client: createJitGitTokenClient({ socketPath: resolveSocketPath() }),
         credentialId: githubAppCredentialId,

--- a/packages/orchestrator/src/services/cluster-api-key-probe.ts
+++ b/packages/orchestrator/src/services/cluster-api-key-probe.ts
@@ -1,0 +1,27 @@
+import { existsSync } from 'node:fs';
+
+/**
+ * Path to the cluster API key file. Must match
+ * `packages/control-plane/src/services/cluster-api-key.ts:4` — drift between
+ * the two paths reintroduces the gating mismatch.
+ */
+export const DEFAULT_KEY_PATH = '/var/lib/generacy/cluster-api-key';
+
+/**
+ * Returns true iff the cluster API key file exists at the resolved path.
+ * Used at orchestrator startup to gate JIT gh provider construction.
+ *
+ * Resolution order:
+ *   1. explicit `keyPath` argument
+ *   2. `CLUSTER_API_KEY_PATH` env var (test override)
+ *   3. `DEFAULT_KEY_PATH`
+ *
+ * Pure `existsSync` — does NOT read the file's contents. The control-plane
+ * reads contents on every `/git-token` request via its own async
+ * `ClusterApiKeyReader`; this helper is intentionally separate so the
+ * orchestrator can gate provider construction synchronously at startup
+ * without booting the control-plane file reader.
+ */
+export function clusterApiKeyExists(keyPath?: string): boolean {
+  return existsSync(keyPath ?? process.env['CLUSTER_API_KEY_PATH'] ?? DEFAULT_KEY_PATH);
+}

--- a/packages/orchestrator/src/services/jit-github-token-provider.ts
+++ b/packages/orchestrator/src/services/jit-github-token-provider.ts
@@ -13,7 +13,13 @@ interface Logger {
 
 export interface JitGithubTokenProviderOptions {
   client: JitGitTokenClient;
-  credentialId: string;
+  /**
+   * GitHub-app credentialId from `.agency/credentials.yaml`. When omitted,
+   * the provider operates credential-less: it calls `client.fetch()` (the
+   * control-plane resolves the installation from cluster identity) and
+   * uses the `WIZARD_SENTINEL_KEY` for cache + authHealth keying.
+   */
+  credentialId?: string;
   authHealth?: AuthHealthSink;
   refreshWindowMs?: number;
   now?: () => Date;
@@ -28,6 +34,22 @@ interface TokenCacheEntry {
 
 const DEFAULT_REFRESH_WINDOW_MS = 5 * 60_000;
 const DEFAULT_SOCKET_PATH = '/run/generacy-control-plane/control.sock';
+
+/**
+ * Reserved-prefix sentinel used as the cache and AuthHealth key when the
+ * JIT gh provider is built credential-less (no `github-app` descriptor in
+ * `.agency/credentials.yaml`). Cannot collide with real descriptor ids,
+ * which are GitHub installation/credential identifiers.
+ *
+ * Visible in:
+ *   - structured logs from `createJitGithubTokenProvider` and `GitHubAuthHealthService`
+ *   - `cluster.credentials` relay payloads (`refresh-requested` / `auth-failed` /
+ *     `auth-recovered`) emitted on the credential-less path
+ *
+ * Cloud-side: no consumer today. Future consumers should treat any
+ * credentialId starting with `__` as synthetic.
+ */
+export const WIZARD_SENTINEL_KEY = '__wizard__';
 
 export function resolveSocketPath(env: NodeJS.ProcessEnv = process.env): string {
   return (
@@ -49,24 +71,26 @@ export function createJitGithubTokenProvider(
     logger,
   } = options;
 
+  const effectiveKey = credentialId ?? WIZARD_SENTINEL_KEY;
   const cache = new Map<string, TokenCacheEntry>();
 
   return async () => {
     const currentTime = now();
-    const cached = cache.get(credentialId);
+    const cached = cache.get(effectiveKey);
 
     if (cached && cached.expiresAt.getTime() - currentTime.getTime() > refreshWindowMs) {
       return cached.token;
     }
 
     try {
+      // Pass-through: undefined → client sends '{}'; defined → client sends { credentialId }.
       const response = await client.fetch(credentialId);
       const entry: TokenCacheEntry = {
         token: response.token,
         expiresAt: response.expiresAt,
         fetchedAt: now(),
       };
-      cache.set(credentialId, entry);
+      cache.set(effectiveKey, entry);
       return entry.token;
     } catch (rawErr) {
       const err =
@@ -78,16 +102,16 @@ export function createJitGithubTokenProvider(
             );
 
       // Discard any stale cached entry — never serve a token after a refresh failure.
-      cache.delete(credentialId);
+      cache.delete(effectiveKey);
 
       try {
-        authHealth?.recordResult(credentialId, { ok: false, statusCode: 503 });
+        authHealth?.recordResult(effectiveKey, { ok: false, statusCode: 503 });
       } catch {
         // Sink errors must not mask the original failure.
       }
 
       logger.warn(
-        { code: err.code, message: err.message, credentialId },
+        { code: err.code, message: err.message, credentialId: effectiveKey },
         'JIT GitHub token refresh failed',
       );
 

--- a/packages/orchestrator/src/services/label-monitor-service.ts
+++ b/packages/orchestrator/src/services/label-monitor-service.ts
@@ -1,4 +1,5 @@
 import { WORKFLOW_LABELS, GhAuthError, type GitHubClientFactory } from '@generacy-ai/workflow-engine';
+import { JitTokenError } from '@generacy-ai/control-plane';
 import type {
   LabelEvent,
   MonitorState,
@@ -508,6 +509,17 @@ export class LabelMonitorService {
         this.authHealth.recordResult(this.githubAppCredentialId, { ok: true });
       }
     } catch (error) {
+      if (error instanceof JitTokenError) {
+        // JIT token fetch failed (control-plane unreachable / cloud-pull error).
+        // The provider has already evicted the cache and recorded the failure;
+        // here we skip the rest of this poll cycle so we never spawn `gh` with
+        // an empty/ambient token. The next cycle will retry.
+        this.logger.warn(
+          { code: error.code, message: error.message, owner, repo },
+          'JIT GitHub token refresh failed — skipping label monitor cycle',
+        );
+        return;
+      }
       if (error instanceof GhAuthError) {
         const credentialId = this.githubAppCredentialId;
         if (credentialId) {

--- a/packages/orchestrator/src/services/pr-feedback-monitor-service.ts
+++ b/packages/orchestrator/src/services/pr-feedback-monitor-service.ts
@@ -1,4 +1,5 @@
 import { GhAuthError, type GitHubClientFactory } from '@generacy-ai/workflow-engine';
+import { JitTokenError } from '@generacy-ai/control-plane';
 import type {
   MonitorState,
   QueueAdapter,
@@ -326,6 +327,16 @@ export class PrFeedbackMonitorService {
         this.authHealth.recordResult(this.githubAppCredentialId, { ok: true });
       }
     } catch (error) {
+      if (error instanceof JitTokenError) {
+        // JIT token fetch failed — provider already evicted cache and recorded
+        // the failure. Skip this poll cycle so we never spawn `gh` with an
+        // empty/ambient token. The next cycle will retry.
+        this.logger.warn(
+          { code: error.code, message: error.message, owner, repo },
+          'JIT GitHub token refresh failed — skipping PR-feedback monitor cycle',
+        );
+        return;
+      }
       if (error instanceof GhAuthError) {
         const credentialId = this.githubAppCredentialId;
         if (credentialId) {
@@ -369,6 +380,13 @@ export class PrFeedbackMonitorService {
       try {
         await this.processPrReviewEvent(event);
       } catch (error) {
+        if (error instanceof JitTokenError) {
+          this.logger.warn(
+            { code: error.code, message: error.message, owner, repo, prNumber: pr.number },
+            'JIT GitHub token refresh failed — stopping PR-feedback monitor cycle',
+          );
+          return;
+        }
         if (error instanceof GhAuthError) {
           const credentialId = this.githubAppCredentialId;
           if (credentialId) {

--- a/packages/orchestrator/src/services/webhook-setup-service.ts
+++ b/packages/orchestrator/src/services/webhook-setup-service.ts
@@ -9,6 +9,7 @@
  * detection via Smee instead of relying on 15-minute polling fallback.
  */
 import { executeCommand } from '@generacy-ai/workflow-engine';
+import { JitTokenError } from '@generacy-ai/control-plane';
 
 /**
  * Logger interface matching Pino/Fastify logger shape.
@@ -144,10 +145,18 @@ export class WebhookSetupService {
     this._tokenProvider = tokenProvider;
   }
 
+  /**
+   * Invariant: when a tokenProvider is configured, the env override ALWAYS
+   * carries a `GH_TOKEN` key — never `undefined`. Prevents the `gh` subprocess
+   * from inheriting the orchestrator's ambient `GH_TOKEN`. If the provider
+   * throws (e.g., `JitTokenError`), the throw propagates to the per-repo
+   * try/catch in `_ensureWebhookForRepo`, which logs and continues.
+   * See `specs/777-severity-high-773-not/contracts/gh-cli-env-override.md`.
+   */
   private async resolveTokenEnv(): Promise<Record<string, string> | undefined> {
     if (!this._tokenProvider) return undefined;
     const token = await this._tokenProvider();
-    return token ? { GH_TOKEN: token } : undefined;
+    return { GH_TOKEN: token ?? '' };
   }
 
   /**
@@ -364,7 +373,12 @@ export class WebhookSetupService {
       const errorMessage = String(error);
 
       // Determine appropriate log level and message based on error type
-      if (errorMessage.includes('403') || errorMessage.includes('404')) {
+      if (error instanceof JitTokenError) {
+        this._logger.warn(
+          { owner, repo, code: error.code, message: error.message },
+          'JIT GitHub token refresh failed — skipping webhook setup for repository'
+        );
+      } else if (errorMessage.includes('403') || errorMessage.includes('404')) {
         this._logger.warn(
           { owner, repo, error: errorMessage },
           'Insufficient permissions to manage webhooks (admin:repo_hook required)'
@@ -469,6 +483,13 @@ export class WebhookSetupService {
       // Return as GitHubWebhook array (minimal validation - trust GitHub API)
       return parsed as GitHubWebhook[];
     } catch (error) {
+      if (error instanceof JitTokenError) {
+        this._logger.warn(
+          { owner, repo, code: error.code, message: error.message },
+          'JIT GitHub token refresh failed — skipping webhook listing for repository'
+        );
+        return [];
+      }
       // Handle parse errors and other exceptions gracefully
       this._logger.warn(
         { owner, repo, error: String(error) },

--- a/packages/orchestrator/src/worker/claude-cli-worker.ts
+++ b/packages/orchestrator/src/worker/claude-cli-worker.ts
@@ -27,6 +27,7 @@ import { createAgentLauncher } from '../launcher/launcher-setup.js';
 import type { AgentLauncher } from '../launcher/agent-launcher.js';
 import { CredhelperHttpClient } from '../launcher/credhelper-client.js';
 import { CredhelperUnavailableError } from '../launcher/credhelper-errors.js';
+import { JitTokenError } from '@generacy-ai/control-plane';
 import { conversationProcessFactory } from '../conversation/process-factory.js';
 
 /**
@@ -608,10 +609,17 @@ export class ClaudeCliWorker {
         // work (e.g. markReadyForReview, SSE emission). Log at warn level and
         // do NOT re-throw, so WorkerDispatcher calls queue.complete() instead
         // of queue.release().
-        workerLogger.warn(
-          { error: String(error) },
-          'Post-completion step failed (all phases completed successfully)',
-        );
+        if (error instanceof JitTokenError) {
+          workerLogger.warn(
+            { code: error.code, message: error.message },
+            'JIT GitHub token refresh failed during post-completion step (all phases completed successfully)',
+          );
+        } else {
+          workerLogger.warn(
+            { error: String(error) },
+            'Post-completion step failed (all phases completed successfully)',
+          );
+        }
       } else {
         workerLogger.error(
           { error: String(error) },

--- a/packages/orchestrator/tests/unit/services/cluster-api-key-probe.test.ts
+++ b/packages/orchestrator/tests/unit/services/cluster-api-key-probe.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  clusterApiKeyExists,
+  DEFAULT_KEY_PATH,
+} from '../../../src/services/cluster-api-key-probe.js';
+
+describe('clusterApiKeyExists (#777)', () => {
+  let tempDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'cluster-api-key-probe-'));
+    originalEnv = process.env['CLUSTER_API_KEY_PATH'];
+    delete process.env['CLUSTER_API_KEY_PATH'];
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env['CLUSTER_API_KEY_PATH'] = originalEnv;
+    } else {
+      delete process.env['CLUSTER_API_KEY_PATH'];
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns true when key file exists at the explicit path', () => {
+    const keyPath = path.join(tempDir, 'cluster-api-key');
+    writeFileSync(keyPath, 'secret');
+    expect(clusterApiKeyExists(keyPath)).toBe(true);
+  });
+
+  it('returns false when key file missing at the explicit path', () => {
+    const keyPath = path.join(tempDir, 'does-not-exist');
+    expect(clusterApiKeyExists(keyPath)).toBe(false);
+  });
+
+  it('honors explicit keyPath argument over CLUSTER_API_KEY_PATH env var', () => {
+    const present = path.join(tempDir, 'present');
+    const absent = path.join(tempDir, 'absent');
+    writeFileSync(present, 'k');
+
+    // Env points at a missing file, but explicit arg points at an existing one
+    process.env['CLUSTER_API_KEY_PATH'] = absent;
+    expect(clusterApiKeyExists(present)).toBe(true);
+
+    // Inverse: env points at an existing file, but explicit arg points at a missing one
+    process.env['CLUSTER_API_KEY_PATH'] = present;
+    expect(clusterApiKeyExists(absent)).toBe(false);
+  });
+
+  it('honors CLUSTER_API_KEY_PATH env var when no explicit keyPath given', () => {
+    const keyPath = path.join(tempDir, 'env-key');
+    writeFileSync(keyPath, 'k');
+    process.env['CLUSTER_API_KEY_PATH'] = keyPath;
+    expect(clusterApiKeyExists()).toBe(true);
+  });
+
+  it('returns false when env var path is missing and no explicit keyPath given', () => {
+    process.env['CLUSTER_API_KEY_PATH'] = path.join(tempDir, 'nope');
+    expect(clusterApiKeyExists()).toBe(false);
+  });
+
+  it('DEFAULT_KEY_PATH matches the control-plane reader path', () => {
+    // Must match `packages/control-plane/src/services/cluster-api-key.ts:4`.
+    expect(DEFAULT_KEY_PATH).toBe('/var/lib/generacy/cluster-api-key');
+  });
+});

--- a/packages/orchestrator/tests/unit/services/jit-github-token-provider.test.ts
+++ b/packages/orchestrator/tests/unit/services/jit-github-token-provider.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   createJitGithubTokenProvider,
   resolveSocketPath,
+  WIZARD_SENTINEL_KEY,
 } from '../../../src/services/jit-github-token-provider.js';
 
 function makeLogger() {
@@ -336,6 +337,128 @@ describe('createJitGithubTokenProvider', () => {
     expect(value).toBeDefined();
     expect(typeof value).toBe('string');
     expect(value.length).toBeGreaterThan(0);
+  });
+
+  // ---------------------------------------------------------------
+  // Credential-less path (wizard-bootstrapped clusters) — #777
+  // ---------------------------------------------------------------
+
+  it('creates provider when credentialId omitted', () => {
+    const client = makeMockClient();
+    const provider = createJitGithubTokenProvider({
+      client,
+      logger: makeLogger(),
+    });
+    expect(typeof provider).toBe('function');
+  });
+
+  it('uses WIZARD_SENTINEL_KEY as cache key when credentialId omitted', async () => {
+    const client = makeMockClient();
+    const provider = createJitGithubTokenProvider({
+      client,
+      logger: makeLogger(),
+    });
+
+    await provider();
+    await provider();
+
+    // Second call within the cache window should hit the cache (sentinel key
+    // used consistently for set+get).
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls client.fetch() with no argument when credentialId omitted', async () => {
+    const client = makeMockClient();
+    const provider = createJitGithubTokenProvider({
+      client,
+      logger: makeLogger(),
+    });
+
+    await provider();
+
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+    expect(client.fetch).toHaveBeenCalledWith(undefined);
+  });
+
+  it('records authHealth under WIZARD_SENTINEL_KEY on failure', async () => {
+    const client = makeMockClient({
+      fetchImpl: async () => {
+        throw new JitTokenError('CLOUD_AUTH_REJECTED', 'rejected');
+      },
+    });
+    const authHealth = makeAuthHealth();
+    const provider = createJitGithubTokenProvider({
+      client,
+      authHealth,
+      logger: makeLogger(),
+    });
+
+    await expect(provider()).rejects.toBeInstanceOf(JitTokenError);
+    expect(authHealth.recordResult).toHaveBeenCalledTimes(1);
+    expect(authHealth.recordResult).toHaveBeenCalledWith(WIZARD_SENTINEL_KEY, {
+      ok: false,
+      statusCode: 503,
+    });
+  });
+
+  it('propagates JitTokenError unchanged in credential-less path', async () => {
+    const client = makeMockClient({
+      fetchImpl: async () => {
+        throw new JitTokenError('CLOUD_UNREACHABLE', 'down');
+      },
+    });
+    const provider = createJitGithubTokenProvider({
+      client,
+      logger: makeLogger(),
+    });
+
+    await expect(provider()).rejects.toMatchObject({
+      name: 'JitTokenError',
+      code: 'CLOUD_UNREACHABLE',
+      message: 'down',
+    });
+  });
+
+  it('passes credentialId to client.fetch when defined', async () => {
+    const client = makeMockClient();
+    const provider = createJitGithubTokenProvider({
+      client,
+      credentialId: 'foo',
+      logger: makeLogger(),
+    });
+
+    await provider();
+
+    expect(client.fetch).toHaveBeenCalledWith('foo');
+  });
+
+  it('uses descriptor credentialId as cache key when defined (sentinel not used)', async () => {
+    const client = makeMockClient({
+      fetchImpl: async () => {
+        throw new JitTokenError('CLOUD_AUTH_REJECTED', 'rejected');
+      },
+    });
+    const authHealth = makeAuthHealth();
+    const provider = createJitGithubTokenProvider({
+      client,
+      credentialId: 'foo',
+      authHealth,
+      logger: makeLogger(),
+    });
+
+    await expect(provider()).rejects.toBeInstanceOf(JitTokenError);
+    expect(authHealth.recordResult).toHaveBeenCalledWith('foo', {
+      ok: false,
+      statusCode: 503,
+    });
+    expect(authHealth.recordResult).not.toHaveBeenCalledWith(
+      WIZARD_SENTINEL_KEY,
+      expect.anything(),
+    );
+  });
+
+  it('WIZARD_SENTINEL_KEY constant is "__wizard__"', () => {
+    expect(WIZARD_SENTINEL_KEY).toBe('__wizard__');
   });
 });
 

--- a/packages/orchestrator/tests/unit/services/jit-provider-gating.test.ts
+++ b/packages/orchestrator/tests/unit/services/jit-provider-gating.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  JitTokenError,
+  type JitGitTokenClient,
+  type JitGitTokenResponse,
+} from '@generacy-ai/control-plane';
+import {
+  createJitGithubTokenProvider,
+  WIZARD_SENTINEL_KEY,
+} from '../../../src/services/jit-github-token-provider.js';
+import { clusterApiKeyExists } from '../../../src/services/cluster-api-key-probe.js';
+
+/**
+ * #777 — Integration-style test for the three gating outcomes that server.ts
+ * implements via `clusterApiKeyExists() ? createJitGithubTokenProvider(...) : undefined`.
+ *
+ * The full server is too heavy to boot in unit tests, so this exercises the
+ * composed gating logic directly. The server.ts wiring is a one-line ternary
+ * over these primitives.
+ */
+describe('JIT GitHub token provider gating (#777)', () => {
+  let tempDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'jit-gating-'));
+    originalEnv = process.env['CLUSTER_API_KEY_PATH'];
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env['CLUSTER_API_KEY_PATH'] = originalEnv;
+    } else {
+      delete process.env['CLUSTER_API_KEY_PATH'];
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makeLogger() {
+    return { info: vi.fn(), warn: vi.fn() };
+  }
+
+  function makeAuthHealth() {
+    return { recordResult: vi.fn() };
+  }
+
+  function makeClient(): JitGitTokenClient & {
+    fetch: ReturnType<typeof vi.fn>;
+  } {
+    return {
+      fetch: vi.fn(
+        async (): Promise<JitGitTokenResponse> => ({
+          token: 'ghs_token',
+          expiresAt: new Date(Date.now() + 60 * 60_000),
+        }),
+      ),
+    } as JitGitTokenClient & { fetch: ReturnType<typeof vi.fn> };
+  }
+
+  /**
+   * Mirror the gating logic from `packages/orchestrator/src/server.ts`:
+   *   clusterApiKeyExists() ? createJitGithubTokenProvider({...}) : undefined
+   */
+  function buildProvider(opts: {
+    client: JitGitTokenClient;
+    credentialId?: string;
+    authHealth?: { recordResult: ReturnType<typeof vi.fn> };
+  }) {
+    if (!clusterApiKeyExists()) return undefined;
+    return createJitGithubTokenProvider({
+      client: opts.client,
+      credentialId: opts.credentialId,
+      authHealth: opts.authHealth,
+      logger: makeLogger(),
+    });
+  }
+
+  // -------------------------------------------------------------
+  // Case 1: descriptor present + api-key present
+  // -------------------------------------------------------------
+  it('descriptor present + api-key present → provider constructed, descriptor credentialId used (sentinel NOT used)', async () => {
+    const keyPath = path.join(tempDir, 'cluster-api-key');
+    writeFileSync(keyPath, 'k');
+    process.env['CLUSTER_API_KEY_PATH'] = keyPath;
+
+    const client = makeClient();
+    const authHealth = makeAuthHealth();
+
+    // Force the provider to fail so authHealth is called and we can inspect the key.
+    client.fetch.mockImplementationOnce(async () => {
+      throw new JitTokenError('CLOUD_AUTH_REJECTED', 'rejected');
+    });
+
+    const provider = buildProvider({
+      client,
+      credentialId: 'cred-real',
+      authHealth,
+    });
+
+    expect(provider).toBeDefined();
+    await expect(provider!()).rejects.toBeInstanceOf(JitTokenError);
+
+    // client.fetch was called with the real credentialId (not undefined)
+    expect(client.fetch).toHaveBeenCalledWith('cred-real');
+    // authHealth keyed by the real id, not the sentinel
+    expect(authHealth.recordResult).toHaveBeenCalledWith('cred-real', {
+      ok: false,
+      statusCode: 503,
+    });
+    expect(authHealth.recordResult).not.toHaveBeenCalledWith(
+      WIZARD_SENTINEL_KEY,
+      expect.anything(),
+    );
+  });
+
+  // -------------------------------------------------------------
+  // Case 2: no descriptor + api-key present (wizard-bootstrapped cluster)
+  // -------------------------------------------------------------
+  it('no descriptor + api-key present → provider constructed credential-less, sentinel used', async () => {
+    const keyPath = path.join(tempDir, 'cluster-api-key');
+    writeFileSync(keyPath, 'k');
+    process.env['CLUSTER_API_KEY_PATH'] = keyPath;
+
+    const client = makeClient();
+    const authHealth = makeAuthHealth();
+
+    // Force the provider to fail so authHealth is called and we can inspect the key.
+    client.fetch.mockImplementationOnce(async () => {
+      throw new JitTokenError('CLOUD_UNREACHABLE', 'down');
+    });
+
+    const provider = buildProvider({
+      client,
+      credentialId: undefined,
+      authHealth,
+    });
+
+    expect(provider).toBeDefined();
+    await expect(provider!()).rejects.toBeInstanceOf(JitTokenError);
+
+    // client.fetch called credential-less
+    expect(client.fetch).toHaveBeenCalledWith(undefined);
+    // authHealth keyed by the sentinel
+    expect(authHealth.recordResult).toHaveBeenCalledWith(WIZARD_SENTINEL_KEY, {
+      ok: false,
+      statusCode: 503,
+    });
+  });
+
+  // Cache + sentinel keying coherence
+  it('no descriptor + api-key present → cache keyed by sentinel (second call hits cache)', async () => {
+    const keyPath = path.join(tempDir, 'cluster-api-key');
+    writeFileSync(keyPath, 'k');
+    process.env['CLUSTER_API_KEY_PATH'] = keyPath;
+
+    const client = makeClient();
+    const provider = buildProvider({ client, credentialId: undefined });
+
+    expect(provider).toBeDefined();
+    await provider!();
+    await provider!();
+
+    // Cache hit on the second call — sentinel-keyed set/get are consistent.
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------
+  // Case 3: no api-key (truly-unconfigured / offline cluster)
+  // -------------------------------------------------------------
+  it('no api-key → provider is undefined (legacy fallback)', () => {
+    // Point CLUSTER_API_KEY_PATH at a non-existent file
+    process.env['CLUSTER_API_KEY_PATH'] = path.join(tempDir, 'absent');
+
+    const client = makeClient();
+    const provider = buildProvider({ client, credentialId: 'cred-real' });
+
+    expect(provider).toBeUndefined();
+    expect(client.fetch).not.toHaveBeenCalled();
+  });
+
+  it('no api-key + no descriptor → provider is undefined (legacy fallback)', () => {
+    process.env['CLUSTER_API_KEY_PATH'] = path.join(tempDir, 'absent');
+
+    const client = makeClient();
+    const provider = buildProvider({ client, credentialId: undefined });
+
+    expect(provider).toBeUndefined();
+  });
+});

--- a/packages/workflow-engine/src/actions/github/client/gh-cli.ts
+++ b/packages/workflow-engine/src/actions/github/client/gh-cli.ts
@@ -64,10 +64,24 @@ export class GhCliGitHubClient implements GitHubClient {
     this.tokenProvider = tokenProvider;
   }
 
+  /**
+   * Resolve the env override passed to the `gh` subprocess.
+   *
+   * Invariant: provider present ⇒ `GH_TOKEN` is always set, never `undefined`.
+   * This prevents the `gh` subprocess from inheriting the orchestrator's
+   * ambient `GH_TOKEN` (which, on wizard clusters, is the expired static
+   * token from `wizard-credentials.env`). When the provider throws
+   * `JitTokenError`, the throw propagates and the caller's loop-boundary
+   * catch records the failure and skips the gh call — no subprocess is
+   * spawned. See `specs/777-severity-high-773-not/contracts/gh-cli-env-override.md`.
+   *
+   * No provider ⇒ returns `undefined` so the subprocess inherits ambient env
+   * (legacy behavior for truly-unconfigured clusters).
+   */
   private async resolveTokenEnv(): Promise<Record<string, string> | undefined> {
     if (!this.tokenProvider) return undefined;
     const token = await this.tokenProvider();
-    return token ? { GH_TOKEN: token } : undefined;
+    return { GH_TOKEN: token ?? '' };
   }
 
   private async executeGh(args: string[]) {

--- a/packages/workflow-engine/tests/actions/github/client-token-injection.test.ts
+++ b/packages/workflow-engine/tests/actions/github/client-token-injection.test.ts
@@ -166,7 +166,7 @@ describe('GhCliGitHubClient token injection', () => {
   });
 
   describe('when tokenProvider returns undefined (resolution failed)', () => {
-    it('passes env: undefined to executeCommand', async () => {
+    it('passes env: { GH_TOKEN: "" } to executeCommand', async () => {
       const tokenProvider = vi.fn().mockResolvedValue(undefined);
       const client = new GhCliGitHubClient('/test/workdir', tokenProvider);
 
@@ -175,17 +175,19 @@ describe('GhCliGitHubClient token injection', () => {
       await client.getRepoInfo();
 
       expect(tokenProvider).toHaveBeenCalledOnce();
+      // Invariant: provider present ⇒ GH_TOKEN is always set (never undefined),
+      // so the gh subprocess can't inherit the expired ambient GH_TOKEN.
       expect(mockExecuteCommand).toHaveBeenCalledWith(
         'gh',
         expect.any(Array),
         expect.objectContaining({
           cwd: '/test/workdir',
-          env: undefined,
+          env: { GH_TOKEN: '' },
         }),
       );
     });
 
-    it('passes env: undefined for PR listing when token resolution fails', async () => {
+    it('passes env: { GH_TOKEN: "" } for PR listing when token resolution fails', async () => {
       const tokenProvider = vi.fn().mockResolvedValue(undefined);
       const client = new GhCliGitHubClient('/test/workdir', tokenProvider);
 
@@ -198,7 +200,7 @@ describe('GhCliGitHubClient token injection', () => {
         'gh',
         expect.any(Array),
         expect.objectContaining({
-          env: undefined,
+          env: { GH_TOKEN: '' },
         }),
       );
     });

--- a/packages/workflow-engine/tests/actions/github/gh-cli.token-env.test.ts
+++ b/packages/workflow-engine/tests/actions/github/gh-cli.token-env.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../src/actions/cli-utils.js', () => ({
+  executeCommand: vi.fn(),
+  parseJSONSafe: vi.fn((input: string) => {
+    try { return JSON.parse(input); } catch { return null; }
+  }),
+}));
+
+import { executeCommand } from '../../../src/actions/cli-utils.js';
+import { GhCliGitHubClient } from '../../../src/actions/github/client/gh-cli.js';
+
+const mockExecuteCommand = vi.mocked(executeCommand);
+
+/**
+ * #777 — Tests for the resolveTokenEnv invariant:
+ *   - provider present ⇒ GH_TOKEN is ALWAYS set in env override (never undefined)
+ *   - provider throws ⇒ env-override never constructed (no `gh` spawn)
+ *   - no provider ⇒ env override is undefined (legacy ambient inheritance)
+ *
+ * Note: `resolveTokenEnv` is private — we exercise it via `executeGh` (any
+ * public method works; we use `getRepoInfo` since it makes a single gh call)
+ * and inspect the `env` option passed to `executeCommand`.
+ */
+describe('GhCliGitHubClient resolveTokenEnv invariant (#777)', () => {
+  beforeEach(() => {
+    mockExecuteCommand.mockReset();
+  });
+
+  function mockGhSuccess() {
+    mockExecuteCommand.mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({ owner: { login: 'o' }, name: 'r', defaultBranchRef: { name: 'main' } }),
+      stderr: '',
+    });
+  }
+
+  it('resolveTokenEnv returns { GH_TOKEN } when provider returns a token', async () => {
+    mockGhSuccess();
+    const tokenProvider = vi.fn(async () => 'ghs_fresh');
+    const client = new GhCliGitHubClient('/tmp', tokenProvider);
+
+    await client.getRepoInfo();
+
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+    const callArgs = mockExecuteCommand.mock.calls[0]!;
+    const opts = callArgs[2] as { env?: Record<string, string> };
+    expect(opts.env).toEqual({ GH_TOKEN: 'ghs_fresh' });
+  });
+
+  it('resolveTokenEnv returns { GH_TOKEN: "" } when provider returns undefined', async () => {
+    mockGhSuccess();
+    const tokenProvider = vi.fn(async () => undefined);
+    const client = new GhCliGitHubClient('/tmp', tokenProvider);
+
+    await client.getRepoInfo();
+
+    const callArgs = mockExecuteCommand.mock.calls[0]!;
+    const opts = callArgs[2] as { env?: Record<string, string> };
+    expect(opts.env).toEqual({ GH_TOKEN: '' });
+    // Explicit: NOT undefined — the whole point of the invariant is to defeat
+    // ambient inheritance of process.env.GH_TOKEN.
+    expect(opts.env).not.toBeUndefined();
+  });
+
+  it('resolveTokenEnv returns { GH_TOKEN: "" } when provider returns empty string', async () => {
+    mockGhSuccess();
+    const tokenProvider = vi.fn(async () => '');
+    const client = new GhCliGitHubClient('/tmp', tokenProvider);
+
+    await client.getRepoInfo();
+
+    const callArgs = mockExecuteCommand.mock.calls[0]!;
+    const opts = callArgs[2] as { env?: Record<string, string> };
+    expect(opts.env).toEqual({ GH_TOKEN: '' });
+  });
+
+  it('resolveTokenEnv returns undefined when no provider configured (legacy behavior)', async () => {
+    mockGhSuccess();
+    const client = new GhCliGitHubClient('/tmp');
+
+    await client.getRepoInfo();
+
+    const callArgs = mockExecuteCommand.mock.calls[0]!;
+    const opts = callArgs[2] as { env?: Record<string, string> };
+    expect(opts.env).toBeUndefined();
+  });
+
+  it('executeGh propagates errors thrown by the tokenProvider; no gh subprocess spawned', async () => {
+    const thrown = new Error('JIT token fetch failed');
+    const tokenProvider = vi.fn(async () => {
+      throw thrown;
+    });
+    const client = new GhCliGitHubClient('/tmp', tokenProvider);
+
+    await expect(client.getRepoInfo()).rejects.toBe(thrown);
+    expect(mockExecuteCommand).not.toHaveBeenCalled();
+  });
+});

--- a/specs/777-severity-high-773-not/clarifications.md
+++ b/specs/777-severity-high-773-not/clarifications.md
@@ -1,0 +1,68 @@
+# Clarifications: JIT gh token provider must work without a `github-app` credential descriptor
+
+**Issue**: [#777](https://github.com/generacy-ai/generacy/issues/777)
+**Branch**: `777-severity-high-773-not`
+
+---
+
+## Batch 1 — 2026-06-06
+
+### Q1: Synthetic key value
+**Context**: FR-003 says "use a stable synthetic constant (e.g. `'default'`)" for the cache key and `authHealth.recordResult(...)` keying in the credential-less path. The issue body hedges with "`'default'`/the repo owner". The exact string becomes part of the wire contract for `cluster.credentials` relay events (`refresh-requested`/`auth-failed`/`auth-recovered`) when no descriptor exists, so the cloud will see it. Picking the wrong value can leak repo identifiers into telemetry or collide with a real descriptor id.
+**Question**: What MUST the synthetic key be when no `github-app` descriptor is present?
+**Options**:
+- A: Literal string `'default'` (matches the FR-003 example exactly; never collides because real descriptor ids are GitHub installation/credential identifiers, not the word "default")
+- B: A reserved-prefix string such as `'__wizard__'` or `'__synthetic__'` (clearly distinguishes the credential-less path from any real descriptor id at a glance in logs/relay payloads)
+- C: Repo owner / cluster id derived (e.g. `clusterId` from `cluster.json`) — gives per-cluster cardinality but introduces variability and possible PII in relay events
+
+**Answer**: **B** — Reserved-prefix sentinel (e.g. `'__wizard__'`). Both A and B avoid the two stated risks (no PII, no collision — real ids are GitHub installation/credential identifiers). The tiebreaker is observability: a reserved sentinel is self-documenting in logs and relay payloads ("this is the credential-less path") and is trivially recognizable if the cloud ever special-cases synthetic ids (see Q3). `'default'` (A) is acceptable and matches the FR example, but reads like it could be a real fallback value; prefer the explicit sentinel. Use the *same* constant for both the cache key and `authHealth.recordResult(...)` keying.
+
+---
+
+### Q2: Provider construction precondition
+**Context**: FR-002 says "build the JIT gh provider whenever `createJitGitTokenClient` can be constructed (the control-plane socket precondition)". `createJitGitTokenClient({ socketPath })` is a constructor that doesn't probe the socket — it just builds an HTTP client wrapper. So the actual gate is ambiguous: do we always construct (and let `fetch()` fail loudly at first call), or do we probe the socket at startup and skip the provider if unreachable (matching today's `undefined` semantics for callers)? This determines whether wizard clusters whose control-plane is briefly slow to bind get a working provider on first attempt or a permanently-`undefined` one.
+**Question**: When no `github-app` descriptor exists, what precondition gates provider construction?
+**Options**:
+- A: Always construct — `createJitGitTokenClient` is unconditional; first `fetch()` call is the failure point (matches "fail at call time" of US3; provider is never `undefined` for callers)
+- B: Probe the control-plane socket at startup (`fs.existsSync(socketPath)` or a TCP-style connect) and only construct if reachable; if unreachable, leave provider `undefined` (preserves today's "no provider → ambient fallback" only for the unrechable case, which the assumption section says is rare)
+- C: Gate on the presence of `/var/lib/generacy/cluster-api-key` (the precondition `git-credential-generacy` actually relies on), without probing the socket
+
+**Answer**: **C** — Gate on `/var/lib/generacy/cluster-api-key` presence. This is the precondition `git-credential-generacy` actually relies on, and it correctly distinguishes the two cases: a cloud-connected cluster (api-key present → use JIT, even with no `github-app` descriptor — the bug case) vs a genuinely unconfigured/offline cluster (no api-key → `/git-token` has nothing to pull from → keep the ambient `GH_TOKEN` fallback). Avoid **B** (socket `existsSync` probe): the control-plane socket can bind *after* the orchestrator resolves descriptors, so a probe risks a permanently-`undefined` provider on a startup race — i.e. it reintroduces the exact silent-fallback bug we're fixing (this is the #59 startup-race class). Avoid **A** (always construct): it breaks truly-unconfigured clusters by making every `gh` call throw. With C, when the api-key is present the provider is always built; a not-yet-ready socket just makes the first `fetch()` throw (fail-loud, retried next poll) — never a silent fallback.
+
+---
+
+### Q3: Cloud-side compatibility of synthetic credential id in relay events
+**Context**: The Assumptions section explicitly flags this: "The `GitHubAuthHealthService` is tolerant of a synthetic credential id (`'default'`) as a key — it does not validate the key against `.agency/credentials.yaml`. (To be re-verified during /clarify or /plan.)" `GitHubAuthHealthService.maybeRequestRefresh` emits `refresh-requested` on `cluster.credentials` keyed by `credentialId`. If we send `{ credentialId: 'default' }` to the cloud, the cloud may have no row to refresh and may either no-op silently, log a warning, or treat it as an error. This affects whether the existing `refresh-requested`/`auth-failed`/`auth-recovered` flow actually does anything useful for wizard clusters or is just noise.
+**Question**: What is the expected cloud-side behavior when an `auth-failed` / `refresh-requested` relay event arrives with a synthetic credential id that has no matching descriptor row?
+**Options**:
+- A: Cloud already silently no-ops unknown credential ids — relay events for the credential-less path are fire-and-forget telemetry only; this fix does NOT need a cloud-side change to be effective
+- B: Suppress relay event emission entirely in the credential-less path (don't call `authHealth.recordResult` / `maybeRequestRefresh` at all when there is no descriptor) — accept that wizard clusters get no GitHub-auth health relay signal until a descriptor is synthesized
+- C: Emit events but document this as a known cloud-side gap to be addressed by a separate follow-up issue; do not block #777 on the cloud-side change
+
+**Answer**: **A** — Cloud no-ops unknown ids; no cloud-side change needed (verified). generacy-cloud currently has **no consumer** for `refresh-requested`/`auth-failed` (the #762 cloud-side refresh handler was deferred per #762 Q2=B), so these events are fire-and-forget telemetry today regardless of the key. More importantly, the credential-less path **does not depend** on a cloud push-refresh: the JIT provider re-fetches inline via `/git-token` (which re-pulls from cloud) on its own. And the token endpoint resolves the installation from cluster identity (cluster-api-key), not the `credentialId` — proven by the working credential-less `git` path. So the synthetic id never needs a matching row. Keep emitting (local `AuthHealthSink`/`/health` signal stays useful); do **not** suppress (B) and do **not** block #777 on any cloud change. If a future cloud consumer is added, the reserved-prefix sentinel from Q1 makes it trivial to recognize-and-ignore.
+
+---
+
+### Q4: Worker-mode provider construction
+**Context**: FR-004 says the same provider MUST be threaded to `ClaudeCliWorker` via the existing `tokenProvider` plumbing. But `ClaudeCliWorker` runs in a separate worker process (forked or spawned). In today's code, `githubAppCredentialId` is passed positionally into worker-construction sites (see `server.ts` lines 355–388). The provider itself is a closure over a `JitGitTokenClient` and a cache `Map`, so it can't literally cross a process boundary. Either worker mode constructs its own equivalent provider at worker startup (and its cache is independent of orchestrator's), or there is shared in-process plumbing that the spec is assuming.
+**Question**: How does the worker-mode `ClaudeCliWorker` receive the credential-less provider?
+**Options**:
+- A: Worker process constructs its own `createJitGithubTokenProvider({ client, /* no credentialId */, logger })` at worker startup, with an independent cache; orchestrator and worker have separate caches but identical fetch behavior (matches `ClaudeCliWorker`'s existing pattern of building its own deps)
+- B: Worker mode is in-process (same Node process as orchestrator) and literally shares the orchestrator's provider instance — confirm by inspecting `ClaudeCliWorker` lifecycle
+- C: Worker mode is out of scope for this fix; only orchestrator-mode `gh` callers are addressed, and a follow-up issue covers worker mode
+
+**Answer**: **A** — Worker process builds its own provider; independent cache. Confirmed by inspection: workers run as separate processes (`server.ts` `if (isWorkerMode)` constructs `ClaudeCliWorker` in the worker process), and `githubTokenProvider` is built at the same site in both modes. A provider is a closure over a `JitGitTokenClient` + cache `Map` — it cannot cross a process boundary, so **B is factually impossible** here. Each worker constructs its own credential-less provider with an independent cache but identical fetch/cache/fail-loud behavior. **C (worker out of scope) is wrong** — workers are the *primary* failure surface (they run the speckit phases); leaving them out would not fix the reported breakage.
+
+---
+
+### Q5: Behavior when JIT fetch fails AND ambient `GH_TOKEN` exists
+**Context**: US3 wants fail-loud ("clear, observable failures … instead of a silent fallback to a static expired token"). FR-008 says the fix MUST NOT add any read of `GH_TOKEN` from `wizard-credentials.env` *for `gh` purposes*. But today's `gh` callers (`GhCliGitHubClient.getEnv()`) inherit ambient `GH_TOKEN` from `process.env` automatically when `tokenProvider` returns nothing — meaning: even if we make the provider throw, a caller that catches the throw and proceeds will spawn `gh` with the ambient (likely expired) token unless we actively scrub it. So "fail-loud" requires more than just the provider throwing.
+**Question**: When the JIT provider throws `JitTokenError`, what MUST happen to the ambient `GH_TOKEN` for `gh` calls?
+**Options**:
+- A: Callers MUST propagate the throw (not catch) — `gh` is never spawned at all. Ambient `GH_TOKEN` is irrelevant because we never reach an `executeCommand('gh', ...)` call. (Most fail-loud; matches US3.)
+- B: Callers catch the throw, log, and skip the `gh` call (do not spawn) — same observable outcome as A but with localized error handling so one credential failure doesn't crash unrelated monitors.
+- C: Callers spawn `gh` with `GH_TOKEN` explicitly unset in the env override (e.g. `{ GH_TOKEN: '' }`) so the ambient value can't leak through — `gh` fails loudly with its own "no auth" error rather than a delayed 401.
+
+**Answer**: **B** — Provider throws; callers catch + log + skip the `gh` call (never spawn `gh` with the ambient token). The decisive requirement (FR-008): a token-fetch failure must never silently fall through to the ambient/expired `GH_TOKEN`. Since post-fix there is always a `tokenProvider` (per Q2, when api-key present), `GhCliGitHubClient.getEnv()` either returns `{ GH_TOKEN: fresh }` (overriding ambient) or throws — so on the success path ambient is overridden and on the failure path `gh` is never spawned. Prefer **B** over pure-propagate **A** because the label monitor, PR-feedback monitor, and worker share this provider; one credential blip should not crash an entire monitor poll loop — catch at the loop boundary, log, and skip the cycle (the `AuthHealthSink.recordResult({ ok:false, 503 })` from #773 already supplies the loud signal). Recommend **also** adopting C's hardening as defense-in-depth: when the provider is present, set `GH_TOKEN: ''` in the `gh` env override so an ambient value can never leak even through an unforeseen caller path. Net: fail-loud, observable, no silent static-token fallback, and resilient monitors.
+
+---

--- a/specs/777-severity-high-773-not/contracts/gh-cli-env-override.md
+++ b/specs/777-severity-high-773-not/contracts/gh-cli-env-override.md
@@ -1,0 +1,62 @@
+# Contract: `GhCliGitHubClient.resolveTokenEnv` env-override invariant
+
+**File**: `packages/workflow-engine/src/actions/github/client/gh-cli.ts`
+**Change kind**: tighten an existing invariant; backwards-compatible for the no-provider case.
+
+## Before
+
+```ts
+private async resolveTokenEnv(): Promise<Record<string, string> | undefined> {
+  if (!this.tokenProvider) return undefined;
+  const token = await this.tokenProvider();
+  return token ? { GH_TOKEN: token } : undefined;
+}
+```
+
+Failure mode: if `this.tokenProvider` is set but returns `''`, the method returns `undefined`, `executeCommand('gh', …)` is spawned with no env override, and the subprocess inherits the orchestrator's ambient `GH_TOKEN` (the static expired wizard token). Silent fallback.
+
+## After
+
+```ts
+private async resolveTokenEnv(): Promise<Record<string, string> | undefined> {
+  if (!this.tokenProvider) return undefined;
+  // Invariant: when a tokenProvider is configured, the env override ALWAYS
+  // carries a GH_TOKEN key — never undefined. This prevents the gh subprocess
+  // from inheriting the orchestrator's ambient GH_TOKEN (which, on wizard
+  // clusters, is the expired static token from wizard-credentials.env).
+  // If the provider throws JitTokenError, the throw propagates and the caller's
+  // loop-boundary catch records the failure and skips the gh call (see
+  // LabelMonitorService/PrFeedbackMonitorService catch branches).
+  const token = await this.tokenProvider();
+  return { GH_TOKEN: token ?? '' };
+}
+```
+
+## Invariants
+
+1. **Provider present ⇒ `GH_TOKEN` always set in env override**. The env-override object is returned with a `GH_TOKEN` key whenever `this.tokenProvider` is configured. Ambient inheritance from `process.env.GH_TOKEN` is structurally impossible on this code path.
+2. **Provider throws ⇒ env-override never constructed**. The throw propagates to `executeGh`, which propagates to the caller. No `executeCommand('gh', …)` call occurs on the failure path.
+3. **No provider ⇒ behavior unchanged**. Returns `undefined`; the gh subprocess inherits ambient env (legacy behavior for truly-unconfigured clusters).
+4. **Empty token ⇒ `GH_TOKEN: ''`** rather than falling through. `gh` will fail loudly with a "no auth" error rather than silently using ambient. Defense-in-depth — the provider should never return an empty string in practice (it either returns a non-empty token or throws), but if it ever does the failure is loud, not silent.
+
+## Caller obligations (loop-boundary catch)
+
+Callers that already catch `GhAuthError` at their poll loop boundary (per #762) MUST also catch `JitTokenError` at the same boundary, log, and skip the cycle. The affected callers:
+
+- `packages/orchestrator/src/services/label-monitor-service.ts` — `pollRepo` catch chain.
+- `packages/orchestrator/src/services/pr-feedback-monitor-service.ts` — `pollRepo` catch chain.
+- `packages/orchestrator/src/services/webhook-setup-service.ts` — wraps `gh` calls; catch on a per-call basis (best-effort registration).
+- `packages/orchestrator/src/worker/claude-cli-worker.ts` — sibling fan-out call site; the existing error handler around the `gh pr ready` loop captures any throw and continues with the next sibling.
+
+The `LabelSyncService.syncAll()` already runs inside a try/catch in `server.ts:237–241` so a thrown `JitTokenError` there logs and continues.
+
+(The catch additions in the caller files are tracked under task generation, not under this contract.)
+
+## Tests (added)
+
+In `packages/workflow-engine/__tests__/actions/github/client/gh-cli.test.ts`:
+
+- `resolveTokenEnv returns { GH_TOKEN } when provider returns a token` — value matches provider output.
+- `resolveTokenEnv returns { GH_TOKEN: '' } when provider returns falsy` — explicit empty string; no `undefined`.
+- `resolveTokenEnv returns undefined when no provider configured` — legacy behavior preserved.
+- `executeGh propagates JitTokenError when provider throws` — no `gh` spawn observed (mock `executeCommand` not called); error rethrown unchanged.

--- a/specs/777-severity-high-773-not/contracts/jit-github-token-provider.ts.md
+++ b/specs/777-severity-high-773-not/contracts/jit-github-token-provider.ts.md
@@ -1,0 +1,110 @@
+# Contract: `createJitGithubTokenProvider`
+
+**File**: `packages/orchestrator/src/services/jit-github-token-provider.ts`
+**Change kind**: backwards-compatible signature widening + new exported constant.
+
+## Exports
+
+### `WIZARD_SENTINEL_KEY` (new)
+
+```ts
+export const WIZARD_SENTINEL_KEY = '__wizard__';
+```
+
+### `JitGithubTokenProviderOptions` (modified)
+
+```ts
+export interface JitGithubTokenProviderOptions {
+  client: JitGitTokenClient;
+  credentialId?: string;             // ← was `credentialId: string`
+  authHealth?: AuthHealthSink;
+  refreshWindowMs?: number;
+  now?: () => Date;
+  logger: Logger;
+}
+```
+
+### `createJitGithubTokenProvider` (modified body, same signature shape)
+
+```ts
+export function createJitGithubTokenProvider(
+  options: JitGithubTokenProviderOptions,
+): JitGithubTokenProvider {
+  const {
+    client,
+    credentialId,                              // may be undefined
+    authHealth,
+    refreshWindowMs = DEFAULT_REFRESH_WINDOW_MS,
+    now = () => new Date(),
+    logger,
+  } = options;
+
+  const effectiveKey = credentialId ?? WIZARD_SENTINEL_KEY;
+  const cache = new Map<string, TokenCacheEntry>();
+
+  return async () => {
+    const currentTime = now();
+    const cached = cache.get(effectiveKey);
+
+    if (cached && cached.expiresAt.getTime() - currentTime.getTime() > refreshWindowMs) {
+      return cached.token;
+    }
+
+    try {
+      // Pass-through: undefined → client sends '{}'; defined → client sends { credentialId }.
+      const response = await client.fetch(credentialId);
+      const entry: TokenCacheEntry = {
+        token: response.token,
+        expiresAt: response.expiresAt,
+        fetchedAt: now(),
+      };
+      cache.set(effectiveKey, entry);
+      return entry.token;
+    } catch (rawErr) {
+      const err =
+        rawErr instanceof JitTokenError
+          ? rawErr
+          : new JitTokenError(
+              'CONTROL_SOCKET_UNREACHABLE',
+              rawErr instanceof Error ? rawErr.message : String(rawErr),
+            );
+
+      cache.delete(effectiveKey);
+
+      try {
+        authHealth?.recordResult(effectiveKey, { ok: false, statusCode: 503 });
+      } catch {
+        /* sink errors must not mask the original failure */
+      }
+
+      logger.warn(
+        { code: err.code, message: err.message, credentialId: effectiveKey },
+        'JIT GitHub token refresh failed',
+      );
+
+      throw err;
+    }
+  };
+}
+```
+
+## Invariants
+
+1. **Sentinel substitution is internal**: the `effectiveKey` variable is the only place the sentinel is materialized; callers never pass `'__wizard__'` themselves.
+2. **One key for cache + authHealth**: the same `effectiveKey` is used for `cache.get/set/delete` and for `authHealth.recordResult`. They cannot drift.
+3. **`client.fetch(credentialId)` preserves undefined**: passing `undefined` reaches the control-plane as `'{}'` (existing branch in `JitGitTokenClient.fetch`). Do not wrap or default-collapse this argument inside the provider.
+4. **Failure semantics unchanged**: cache eviction, authHealth recording, warn-logging, and `JitTokenError` propagation are identical to #773; only the key value differs in the credential-less branch.
+
+## Backwards compatibility
+
+Existing call sites that pass `credentialId: <string>` continue to work unchanged — the field is widened from required to optional, not narrowed. The `effectiveKey` derivation returns the original `credentialId` when present.
+
+## Tests (added)
+
+- `creates provider when credentialId omitted` — constructs successfully; provider is a function.
+- `uses WIZARD_SENTINEL_KEY when credentialId omitted` — after one successful `fetch`, `cache.get(WIZARD_SENTINEL_KEY)` (probed indirectly via second `fetch` returning the cached token without re-calling the client).
+- `calls client.fetch() with no argument when credentialId omitted` — verified via spy on the `JitGitTokenClient`.
+- `records authHealth under WIZARD_SENTINEL_KEY on failure` — spy on `AuthHealthSink.recordResult`; first arg is the sentinel.
+- `propagates JitTokenError unchanged in credential-less path` — error code, message preserved.
+- `passes credentialId to client.fetch when defined` — no regression on the descriptor path.
+- `uses descriptor credentialId as cache key when defined` — sentinel not used in the defined path.

--- a/specs/777-severity-high-773-not/conversation-log.jsonl
+++ b/specs/777-severity-high-773-not/conversation-log.jsonl
@@ -1,0 +1,14 @@
+{"timestamp":"2026-06-06T03:38:15.916Z","phase":"specify","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-06T03:40:01.166Z","phase":"specify","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-06T03:40:13.417Z","phase":"clarify","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-06T03:43:19.800Z","phase":"clarify","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-06T03:47:23.641Z","phase":"clarify","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-06T03:50:11.188Z","phase":"clarify","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-06T03:50:22.983Z","phase":"plan","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-06T03:57:25.289Z","phase":"plan","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-06T03:57:35.348Z","phase":"tasks","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-06T04:00:13.740Z","phase":"tasks","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-06T04:00:25.667Z","phase":"implement","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-06T04:10:25.990Z","phase":"implement","session_id":"","event_type":"phase_complete"}
+{"timestamp":"2026-06-06T04:10:32.525Z","phase":"implement","session_id":"","event_type":"phase_start"}
+{"timestamp":"2026-06-06T04:11:20.363Z","phase":"implement","session_id":"","event_type":"phase_complete"}

--- a/specs/777-severity-high-773-not/data-model.md
+++ b/specs/777-severity-high-773-not/data-model.md
@@ -1,0 +1,148 @@
+# Data Model: #777
+
+This is a behavioral fix, not a data-structure change. The "model" here is the shape of the in-memory types touched by the fix and the contract they expose.
+
+## Constants
+
+### `WIZARD_SENTINEL_KEY`
+
+```ts
+/**
+ * Reserved-prefix sentinel used as the cache and AuthHealth key when the
+ * JIT gh provider is built credential-less (no `github-app` descriptor in
+ * `.agency/credentials.yaml`). Cannot collide with real descriptor ids,
+ * which are GitHub installation/credential identifiers.
+ *
+ * Visible in:
+ *   - structured logs from `createJitGithubTokenProvider` and `GitHubAuthHealthService`
+ *   - `cluster.credentials` relay payloads (`refresh-requested` / `auth-failed` /
+ *     `auth-recovered`) emitted on the credential-less path
+ *
+ * Cloud-side: no consumer today (per Q3). Future consumers should treat any
+ * credentialId starting with `__` as synthetic.
+ */
+export const WIZARD_SENTINEL_KEY = '__wizard__';
+```
+
+Defined in `packages/orchestrator/src/services/jit-github-token-provider.ts`. Exported for test access and future cross-package use.
+
+## Modified types
+
+### `JitGithubTokenProviderOptions`
+
+**Before** (`packages/orchestrator/src/services/jit-github-token-provider.ts:14–21`):
+
+```ts
+export interface JitGithubTokenProviderOptions {
+  client: JitGitTokenClient;
+  credentialId: string;          // ← required
+  authHealth?: AuthHealthSink;
+  refreshWindowMs?: number;
+  now?: () => Date;
+  logger: Logger;
+}
+```
+
+**After**:
+
+```ts
+export interface JitGithubTokenProviderOptions {
+  client: JitGitTokenClient;
+  /**
+   * GitHub-app credentialId from `.agency/credentials.yaml`. When omitted,
+   * the provider operates credential-less: it calls `client.fetch()` (the
+   * control-plane resolves the installation from cluster identity) and
+   * uses the `WIZARD_SENTINEL_KEY` for cache + authHealth keying.
+   */
+  credentialId?: string;
+  authHealth?: AuthHealthSink;
+  refreshWindowMs?: number;
+  now?: () => Date;
+  logger: Logger;
+}
+```
+
+### `JitGithubTokenProvider` (return type — unchanged shape, unchanged behavior)
+
+```ts
+export type JitGithubTokenProvider = () => Promise<string>;
+```
+
+Provider semantics:
+
+| Provider state | Returns | On `client.fetch` failure |
+|---|---|---|
+| Cache hit (`expiresAt - now > refreshWindowMs`) | cached token | n/a — fetch not called |
+| Cache miss or expiring | new token from `client.fetch(credentialId)` (or `client.fetch()` if `credentialId === undefined`) | throws `JitTokenError`; cache entry deleted; `authHealth.recordResult(effectiveKey, { ok: false, statusCode: 503 })` recorded; warn-logged |
+
+Where `effectiveKey = credentialId ?? WIZARD_SENTINEL_KEY`.
+
+## New types
+
+### `ClusterApiKeyExistsFn` (informal — internal helper)
+
+```ts
+// packages/orchestrator/src/services/cluster-api-key-probe.ts
+const DEFAULT_KEY_PATH = '/var/lib/generacy/cluster-api-key';
+
+/**
+ * Returns true iff `/var/lib/generacy/cluster-api-key` exists. Used at
+ * orchestrator startup to gate JIT gh provider construction. Honors the
+ * `CLUSTER_API_KEY_PATH` env var override for tests.
+ *
+ * Pure existsSync — does NOT read the file. The control-plane reads contents
+ * on every `/git-token` request via its own `ClusterApiKeyReader`.
+ */
+export function clusterApiKeyExists(
+  keyPath: string = process.env.CLUSTER_API_KEY_PATH ?? DEFAULT_KEY_PATH,
+): boolean;
+```
+
+Standalone helper (not a class) because it has one job, no state, and a 1-LOC body. Located in `packages/orchestrator/src/services/` next to the provider it gates.
+
+## Validation rules
+
+- `WIZARD_SENTINEL_KEY` MUST be the literal string `'__wizard__'`. No template, no env-derived value, no runtime computation. Wire-compatibility with future cloud consumers depends on stability.
+- `credentialId`, when provided, MUST be a non-empty string. (Existing behavior — `readCredentialDescriptors` skips entries with non-string ids.)
+- The api-key path constant MUST be `/var/lib/generacy/cluster-api-key` to match `packages/control-plane/src/services/cluster-api-key.ts:4`. Drift between the two paths reintroduces the gating mismatch.
+
+## Relationships
+
+```text
+.agency/credentials.yaml              /var/lib/generacy/cluster-api-key
+        │                                         │
+        ▼                                         ▼
+readCredentialDescriptors()              clusterApiKeyExists()
+        │                                         │
+        │ (optional)                              │ (required for JIT)
+        ▼                                         ▼
+        ┌─────────────────────────────────────────┐
+        │  server.ts provider-construction gate   │
+        │                                         │
+        │  if (!clusterApiKeyExists()) → undef    │
+        │  else → createJitGithubTokenProvider({  │
+        │           credentialId: ghapp?.credId,  │ ← may be undefined
+        │           …                             │
+        │         })                              │
+        └─────────────────────────────────────────┘
+                              │
+                              ▼
+                 JitGithubTokenProvider closure
+                              │
+              ┌───────────────┴───────────────┐
+              │                               │
+              ▼                               ▼
+        cache: Map<string,        authHealth.recordResult(
+          TokenCacheEntry>          credentialId ?? WIZARD_SENTINEL_KEY,
+          keyed by                  …
+          credentialId ??         )
+          WIZARD_SENTINEL_KEY
+```
+
+## Unchanged types (referenced for completeness)
+
+- `JitGitTokenClient.fetch(credentialId?: string): Promise<JitGitTokenResponse>` — already supports `undefined`; no change.
+- `JitTokenError` (from `@generacy-ai/control-plane`) — thrown unchanged.
+- `AuthHealthSink.recordResult(credentialId: string, result): void` — signature unchanged; receives sentinel string in the credential-less path.
+- `GitHubAuthHealthService.maybeRequestRefresh(credentialId, reason)` — accepts any string; sentinel passes through.
+- `GhCliGitHubClient` constructor — `tokenProvider` parameter unchanged.

--- a/specs/777-severity-high-773-not/plan.md
+++ b/specs/777-severity-high-773-not/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: JIT gh token provider works without `github-app` descriptor
+
+**Feature**: #773 silent fallback on wizard-bootstrapped clusters — build the JIT gh token provider credential-less when only the cluster API key is available.
+**Branch**: `777-severity-high-773-not`
+**Status**: Complete
+**Date**: 2026-06-06
+**Spec**: [spec.md](spec.md) · [clarifications.md](clarifications.md)
+
+## Summary
+
+#773 introduced a just-in-time GitHub token provider that fetches fresh installation tokens via `/git-token` on every `gh` invocation, retiring the static `wizard-credentials.env` `GH_TOKEN`. The provider is gated on the presence of a `github-app` credential descriptor in `.agency/credentials.yaml`. Wizard-bootstrapped clusters (every cluster in production today) never have that descriptor — they store a raw `GH_TOKEN`/`GH_USERNAME`/`GH_EMAIL` triple — so `githubAppCredentialId` is `undefined`, the provider is never constructed, and `GhCliGitHubClient` falls through to the ambient (expired) `GH_TOKEN` inherited from the orchestrator's `process.env`. Symptom: every `gh` call (label sync, label monitor, PR-feedback monitor, workers) 401s about an hour after activation.
+
+The fix removes the descriptor gate. When `/var/lib/generacy/cluster-api-key` exists (the same precondition the working `git-credential-generacy` path relies on), the orchestrator builds a credential-less provider that calls `client.fetch()` with no `credentialId` — the control-plane resolves the GitHub installation server-side from cluster identity. Cache key and `authHealth` keying use the reserved sentinel `'__wizard__'`. Worker mode does the same in its own process. Defense-in-depth: when the provider is present, the `gh` env override always carries `GH_TOKEN` (never `undefined`), so ambient leakage is structurally impossible.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js >= 22
+**Primary Dependencies**: `@generacy-ai/control-plane` (`JitGitTokenClient`, `JitTokenError`), `pino` (logging), `node:fs` (api-key presence probe). No new runtime deps.
+**Storage**: file-presence probe of `/var/lib/generacy/cluster-api-key` (existsSync, contents never read in orchestrator); `.agency/credentials.yaml` read unchanged (existing `readCredentialDescriptors`).
+**Testing**: `vitest` (existing). Unit coverage in `packages/orchestrator/__tests__/services/` and `packages/workflow-engine/__tests__/actions/github/client/`.
+**Target Platform**: Linux orchestrator container; ClaudeCliWorker subprocess in the same container.
+**Project Type**: TypeScript monorepo (single tree, multiple workspace packages).
+**Performance Goals**: behavior unchanged from #773 — token cached until `expiresAt - now <= 5 min`, single in-flight refresh per cache key, `JitGitTokenClient` already coalesces concurrent fetches.
+**Constraints**:
+- Backwards-compatible with clusters that *do* have a `github-app` descriptor — behavior unchanged on that branch (`credentialId` still passed; sentinel not used).
+- Truly-unconfigured / offline cluster (no api-key file) must keep today's legacy fallback (no JIT provider, ambient `GH_TOKEN`).
+- Token-fetch failure must never silently fall through to ambient `GH_TOKEN` — fail-loud per FR-008 / Clarification Q5.
+**Scale/Scope**: 3 source files modified (1 in workflow-engine, 2 in orchestrator), 1 new helper, ~150 LOC of test additions.
+
+## Constitution Check
+
+No `.specify/memory/constitution.md` present in the repo — no gates to evaluate. Skipped per template guidance.
+
+## Architecture decisions (cross-reference clarifications)
+
+| Decision | Choice | Source |
+|---|---|---|
+| Cache key + `authHealth` key when no descriptor exists | Reserved-prefix sentinel `'__wizard__'` (same constant for both) | [Q1](clarifications.md#q1-synthetic-key-value) |
+| Provider construction precondition | `existsSync('/var/lib/generacy/cluster-api-key')` — *not* a socket probe, *not* unconditional | [Q2](clarifications.md#q2-provider-construction-precondition) |
+| Cloud-side compatibility | None required — relay events fire-and-forget; cloud has no consumer; control-plane resolves installation from cluster identity, not `credentialId` | [Q3](clarifications.md#q3-cloud-side-compatibility-of-synthetic-credential-id-in-relay-events) |
+| Worker mode | Worker process builds its own credential-less provider at startup with independent cache | [Q4](clarifications.md#q4-worker-mode-provider-construction) |
+| Failure behavior | Callers catch `JitTokenError` at loop boundary, log, skip the `gh` call; provider env override always sets `GH_TOKEN` to defeat ambient leakage | [Q5](clarifications.md#q5-behavior-when-jit-fetch-fails-and-ambient-gh_token-exists) |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/777-severity-high-773-not/
+├── plan.md                  # This file
+├── research.md              # Decision rationale, alternatives
+├── data-model.md            # JitGithubTokenProviderOptions shape, sentinel constant
+├── quickstart.md            # Verify fix on a wizard-bootstrapped cluster
+├── contracts/
+│   ├── jit-github-token-provider.ts.md   # New signature for createJitGithubTokenProvider
+│   └── gh-cli-env-override.md            # GhCliGitHubClient.resolveTokenEnv contract
+├── checklists/              # (empty — populated by /checklist if requested)
+├── spec.md                  # (read-only)
+├── clarifications.md        # (read-only)
+└── tasks.md                 # NOT created by /plan — produced by /tasks
+```
+
+### Source Code (repository root)
+
+```text
+packages/orchestrator/
+├── src/
+│   ├── server.ts                                        (MODIFIED)
+│   │   # Lines 201–224: replace `githubAppCredentialId ? … : undefined`
+│   │   # with api-key-presence gate; pass credentialId only when descriptor exists.
+│   ├── services/
+│   │   ├── jit-github-token-provider.ts                 (MODIFIED)
+│   │   │   # `credentialId` becomes optional. When undefined: cache+authHealth key
+│   │   │   # both use the exported `WIZARD_SENTINEL_KEY` constant; client.fetch() is
+│   │   │   # called with no arg (already supported — sends `'{}'`).
+│   │   └── cluster-api-key-probe.ts                     (NEW, ~15 LOC)
+│   │       # Exports `clusterApiKeyExists(path = DEFAULT_KEY_PATH): boolean`.
+│   │       # Pure `fs.existsSync` wrapper for testability; respects
+│   │       # `CLUSTER_API_KEY_PATH` env var for tests.
+│   └── worker/
+│       └── claude-cli-worker.ts                         (MODIFIED)
+│           # Worker mode currently receives tokenProvider via deps. Confirm that
+│           # the worker entry (server.ts isWorkerMode branch) constructs the
+│           # credential-less provider when needed. Worker process inherits the
+│           # same gating logic — no separate change needed in this file itself
+│           # IF server.ts handles both modes (current pattern).
+└── __tests__/
+    └── services/
+        └── jit-github-token-provider.test.ts            (MODIFIED — add)
+            # - credential-less path: cache key + authHealth keyed by '__wizard__'
+            # - client.fetch() called with no argument
+            # - JitTokenError thrown through unchanged
+            # - cache hit/miss/expiry semantics identical with sentinel key
+
+packages/workflow-engine/
+├── src/actions/github/client/
+│   └── gh-cli.ts                                        (MODIFIED)
+│       # `resolveTokenEnv`: when `this.tokenProvider` is set, ALWAYS return an
+│       # env object containing `GH_TOKEN` (= token, or '' on the throw-and-skip
+│       # path if a caller bypasses the throw). Today: returns `undefined` when
+│       # token is falsy → ambient leaks. New invariant: provider present ⇒
+│       # `GH_TOKEN` key always present in env override.
+└── __tests__/actions/github/client/
+    └── gh-cli.test.ts                                   (MODIFIED — add)
+        # - provider present + token returned → env carries GH_TOKEN=token
+        # - provider present + provider throws JitTokenError → propagates;
+        #   no executeCommand('gh', …) call observed
+        # - provider absent → env undefined (existing behavior; no regression)
+```
+
+**Structure Decision**: surgical fix inside the existing monorepo layout. No new packages, no new top-level directories. All changes live next to the files they modify; the api-key probe is a 15-LOC pure helper colocated with `jit-github-token-provider.ts` for direct unit-test access (vs. importing the control-plane's `ClusterApiKeyReader`, which is an async file-reader with caching — overkill here, where we only need existence at startup).
+
+## Implementation phases
+
+### Phase 0 — Research (this command)
+- See [research.md](research.md). Confirms the credential-less code path is already structurally complete on the control-plane side (`JitGitTokenClient.fetch(credentialId?)` handles `undefined` → `'{}'` body) and on the cloud side (`POST /git-token` resolves the installation from the cluster-api-key Authorization, not the request body).
+
+### Phase 1 — Design (this command)
+- See [data-model.md](data-model.md) for the updated `JitGithubTokenProviderOptions` shape and the `WIZARD_SENTINEL_KEY` constant.
+- See [contracts/jit-github-token-provider.ts.md](contracts/jit-github-token-provider.ts.md) for the new function signature.
+- See [contracts/gh-cli-env-override.md](contracts/gh-cli-env-override.md) for the env-override invariant.
+
+### Phase 2 — Tasks (next command: `/tasks`)
+Outline of expected tasks (not exhaustive — produced authoritatively by `/tasks`):
+
+1. Add `WIZARD_SENTINEL_KEY = '__wizard__'` export to `jit-github-token-provider.ts`.
+2. Make `credentialId` optional in `JitGithubTokenProviderOptions`; thread sentinel through cache + authHealth keys.
+3. Add `cluster-api-key-probe.ts` helper.
+4. Update `server.ts` provider construction: gate on `clusterApiKeyExists()`, pass `credentialId` only when descriptor present.
+5. Update `GhCliGitHubClient.resolveTokenEnv` to always include `GH_TOKEN` when provider is set.
+6. Unit tests: credential-less provider (orchestrator), env-override invariant (workflow-engine).
+7. Smoke test: run a wizard-bootstrapped cluster locally and confirm `gh api repos/<org>/<repo>` succeeds with no `github-app` descriptor.
+
+## Complexity Tracking
+
+No constitution violations; table omitted.
+
+## Out of scope
+
+- Synthesizing a `github-app` descriptor on wizard clusters (#777 explicitly chooses the credential-less path instead — simpler, matches the working git path).
+- Cloud-side `refresh-requested` consumer (deferred per [Q3](clarifications.md#q3-cloud-side-compatibility-of-synthetic-credential-id-in-relay-events), already deferred by #762).
+- Removing `wizard-credentials.env` `GH_TOKEN` writes from `wizard-env-writer.ts` (a future cleanup once nothing reads `GH_TOKEN` ambiently — separate issue).
+- Backporting to clusters that pin to a pre-#773 image (the bug only exists with #773 deployed; older images use the static path).
+
+## Next step
+
+Run `/tasks` to generate the dependency-ordered task list.

--- a/specs/777-severity-high-773-not/quickstart.md
+++ b/specs/777-severity-high-773-not/quickstart.md
@@ -1,0 +1,134 @@
+# Quickstart: verify the #777 fix
+
+This guide reproduces the bug on a real wizard-bootstrapped cluster and confirms the fix restores hours-long `gh` operation with zero ambient-token fallback.
+
+## Prerequisites
+
+- A wizard-bootstrapped cluster (any v1.5 cluster bootstrapped via the cloud wizard — i.e. all current clusters).
+- SSH or shell access to the orchestrator container (e.g. via `docker compose exec orchestrator bash` or VS Code tunnel).
+- A GitHub PAT or app installation with read access to the cluster's primary repo (any working `gh auth` outside the container is fine; the container uses its own creds).
+
+## Reproduce the bug (pre-fix)
+
+1. **Wait for the wizard `GH_TOKEN` to expire** (≈ 1 h after activation), OR force-expire it by overwriting the env file:
+   ```sh
+   docker compose exec orchestrator bash -c 'echo "GH_TOKEN=ghs_expired_dummy_token_value" > /var/lib/generacy/wizard-credentials.env'
+   docker compose restart orchestrator
+   ```
+2. **Confirm `/git-token` still returns a valid token** (proves the control-plane path is healthy):
+   ```sh
+   docker compose exec orchestrator \
+     curl -sS --unix-socket /run/generacy-control-plane/control.sock \
+       -X POST http://x/git-token -H 'content-type: application/json' -d '{}'
+   # → {"token":"ghs_…","expiresAt":"…"}
+   ```
+3. **Confirm a credential-less probe with the JIT token works**:
+   ```sh
+   TOKEN=$(docker compose exec orchestrator \
+     curl -sS --unix-socket /run/generacy-control-plane/control.sock \
+       -X POST http://x/git-token -H 'content-type: application/json' -d '{}' \
+     | jq -r .token)
+   docker compose exec -e GH_TOKEN="$TOKEN" orchestrator gh api repos/<org>/<repo>
+   # → 200, repo JSON
+   ```
+4. **Confirm the orchestrator's own `gh` calls 401** (the bug):
+   ```sh
+   docker compose exec orchestrator gh api repos/<org>/<repo>
+   # → HTTP 401: Bad credentials (because GH_TOKEN env in container = expired wizard token)
+   ```
+5. **Confirm the orchestrator logs show no JIT provider construction**:
+   ```sh
+   docker compose logs orchestrator | grep -i 'JitGithubToken\|github-app credential'
+   # → either no matches, or a log line saying provider was not constructed
+   ```
+
+## Apply the fix
+
+1. **Pull a build that includes #777**. Either:
+   - Rebuild the orchestrator image from this branch:
+     ```sh
+     docker compose build --no-cache orchestrator
+     docker compose up -d orchestrator
+     ```
+   - Or, in a dev container with mounted sources, restart after the code change:
+     ```sh
+     docker compose restart orchestrator
+     ```
+2. **Confirm `/var/lib/generacy/cluster-api-key` is present** (precondition for provider construction):
+   ```sh
+   docker compose exec orchestrator test -f /var/lib/generacy/cluster-api-key && echo OK
+   # → OK
+   ```
+
+## Verify the fix
+
+### V1 — gh now works credential-less
+
+```sh
+docker compose exec orchestrator gh api repos/<org>/<repo>
+# → 200, repo JSON (using freshly-fetched JIT token, not ambient)
+```
+
+### V2 — provider was constructed without a `github-app` descriptor
+
+```sh
+# Confirm no github-app descriptor in credentials.yaml:
+docker compose exec orchestrator \
+  cat /workspaces/<primary-repo>/.agency/credentials.yaml | grep -A1 'type:'
+# → no `type: github-app` line
+
+# Confirm the provider was wired (look for the first JIT fetch log line):
+docker compose logs orchestrator | grep -i 'JIT GitHub token' | head
+# → at least one entry, with `credentialId: '__wizard__'` (the sentinel)
+```
+
+### V3 — ambient leak is impossible
+
+Inspect the env of the `gh` subprocess spawned by the label monitor. Easiest: trace one poll cycle in dev logs (with debug logging on the workflow-engine, or with a one-off strace) and confirm `GH_TOKEN` in the spawn env matches the freshly-fetched JIT token, **not** the value in `/var/lib/generacy/wizard-credentials.env`.
+
+Alternatively, in a debug build, log the first 8 chars of `GH_TOKEN` from `GhCliGitHubClient.executeGh` and confirm rotation across hours.
+
+### V4 — fail-loud on /git-token failure
+
+Simulate a control-plane outage and confirm `gh` is **not** spawned with the ambient token:
+
+```sh
+docker compose stop control-plane
+# Wait for a label-monitor poll cycle (default: 60s):
+docker compose logs --tail=200 -f orchestrator | grep -i 'JIT.*failed\|skip'
+# → a warn line ('JIT GitHub token refresh failed'), then a caller-side skip.
+# Confirm no `gh api` 401 line ('Bad credentials') in the same cycle.
+docker compose start control-plane
+```
+
+### V5 — long-run stability
+
+Leave the cluster running for at least 4 hours and confirm zero `gh` 401 lines in orchestrator logs:
+
+```sh
+docker compose logs --since 4h orchestrator | grep -i 'Bad credentials\|HTTP 401'
+# → empty (or only contains pre-fix entries)
+```
+
+### V6 — descriptor-present path unchanged
+
+Manually add a synthetic `github-app` descriptor to `.agency/credentials.yaml`:
+```yaml
+credentials:
+  test-app:
+    type: github-app
+```
+Restart the orchestrator, confirm logs show `credentialId: 'test-app'` (not `'__wizard__'`) in the first JIT fetch entry, and confirm `gh` still works.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `gh api` still 401 with `Bad credentials` after fix | Container wasn't restarted; old binary still loaded | `docker compose restart orchestrator` |
+| No JIT log lines and `gh` still 401 | `/var/lib/generacy/cluster-api-key` is missing | Cluster was never activated — re-run wizard or `npx generacy launch --claim=<code>` |
+| JIT logs but every fetch errors with `CONTROL_SOCKET_UNREACHABLE` | Control-plane crashed (see #624) | `docker compose logs control-plane`; if `init-result.json` shows disabled stores, fix the underlying EACCES |
+| `gh` still uses an old token after sentinel logs appear | Token cache hasn't expired yet (default 5-min refresh window) | Wait ≥ 5 min from the cached token's expiry, or restart orchestrator to flush the cache |
+
+## Rollback
+
+The change is contained to three files. To roll back, revert the commits on this branch and redeploy. No data migration, no config change, no schema change — the rollback restores the pre-fix gating behavior verbatim.

--- a/specs/777-severity-high-773-not/research.md
+++ b/specs/777-severity-high-773-not/research.md
@@ -1,0 +1,111 @@
+# Research: #777 — credential-less JIT gh token provider
+
+## Investigation summary
+
+The spec is grounded in live evidence from the `ai-lawfirm` production cluster. The narrative is verified against the actual code in this repo (post-#773), reproduced here as research notes so future readers don't have to re-derive it.
+
+## Code-side verification of the spec claims
+
+### Claim 1: provider is gated on a `github-app` descriptor
+
+Verified at `packages/orchestrator/src/server.ts:201–224`:
+```ts
+let githubAppCredentialId: string | undefined;
+{
+  const initialDescriptors = await readCredentialDescriptors(agencyDir);
+  const ghapp = initialDescriptors.find((d) => d.type === 'github-app');
+  githubAppCredentialId = ghapp?.credentialId;
+  …
+}
+
+const githubTokenProvider = githubAppCredentialId
+  ? createJitGithubTokenProvider({ … credentialId: githubAppCredentialId, … })
+  : undefined;
+```
+On a wizard-bootstrapped cluster, `.agency/credentials.yaml` carries entries like `GH_TOKEN`/`GH_USERNAME`/`GH_EMAIL` with `type: 'github-pat'` (or similar), never `type: 'github-app'`. So `githubAppCredentialId` stays `undefined`, and `githubTokenProvider` is `undefined`.
+
+### Claim 2: `gh` falls through to ambient `GH_TOKEN`
+
+Verified at `packages/workflow-engine/src/actions/github/client/gh-cli.ts:67–80`:
+```ts
+private async resolveTokenEnv(): Promise<Record<string, string> | undefined> {
+  if (!this.tokenProvider) return undefined;
+  const token = await this.tokenProvider();
+  return token ? { GH_TOKEN: token } : undefined;
+}
+
+private async executeGh(args: string[]) {
+  const env = await this.resolveTokenEnv();
+  const result = await executeCommand('gh', args, { cwd: this.workdir, env });
+  …
+}
+```
+When `env` is `undefined`, `executeCommand` does not override the spawn environment, so the `gh` subprocess inherits the orchestrator's `process.env.GH_TOKEN` — which is the static value seeded by `wizard-env-writer.ts` into `wizard-credentials.env` and sourced by `entrypoint-orchestrator.sh`. That value is a GitHub installation token with a 1-hour TTL.
+
+### Claim 3: the credential-less path *works* end-to-end
+
+Verified at `packages/control-plane/src/services/jit-git-token-client.ts:86–97`:
+```ts
+async fetch(credentialId?: string): Promise<JitGitTokenResponse> {
+  const body = credentialId === undefined ? '{}' : JSON.stringify({ credentialId });
+  …
+}
+```
+The client already accepts an undefined `credentialId` and sends `'{}'`. The control-plane `POST /git-token` handler resolves the installation from the cluster identity (`cluster-api-key` Authorization header), not the request body — proven by the working `git-credential-generacy` path, which calls `client.fetch()` with no argument and successfully clones private repos.
+
+### Claim 4: file-presence is the correct precondition
+
+`/var/lib/generacy/cluster-api-key` is written by the orchestrator's activation flow (`packages/orchestrator/src/activation/persistence.ts`) on first boot and persisted to a tmpfs-backed volume across container restarts. Its presence is exactly the signal that the cluster is cloud-connected and can pull tokens. The control-plane's `ClusterApiKeyReader` (`packages/control-plane/src/services/cluster-api-key.ts`) reads it on every `/git-token` request, so anything past that read fails closed with `CLUSTER_API_KEY_MISSING` — the orchestrator never needs to validate the contents at startup.
+
+## Decisions
+
+### D1: gate on `clusterApiKeyExists()`, not socket probe or unconditional construction
+
+**Chosen**: `fs.existsSync('/var/lib/generacy/cluster-api-key')` at orchestrator startup.
+
+**Rationale**: matches the precondition the working git path implicitly relies on. A socket probe (`fs.existsSync('/run/generacy-control-plane/control.sock')`) is racy — the control-plane socket can bind *after* the orchestrator resolves credential descriptors (this is the same startup-race class #598 fixed for relay-bridge initialization). Unconditional construction breaks the truly-unconfigured case (a cluster with neither api-key nor descriptor) by turning every `gh` call into a thrown `JitTokenError`.
+
+**Alternatives rejected**:
+- *Always construct* — breaks unconfigured/offline clusters by making every `gh` call throw with no recovery. Cluster operators would need to either configure cloud or accept that `gh` doesn't work.
+- *Probe the control-plane socket* — startup race risk; the socket may not be bound yet at descriptor-resolution time, and a single existsSync probe at boot cannot retry. Would reintroduce the same silent-fallback class we're fixing.
+- *Synthesize a `github-app` descriptor for wizard clusters* — large surface change, requires touching `wizard-env-writer.ts` and `.agency/credentials.yaml` write path; doesn't match the architectural invariant ("the control-plane resolves installation from cluster identity, not descriptor id").
+
+### D2: `'__wizard__'` sentinel for cache + authHealth keys
+
+**Chosen**: literal string `'__wizard__'`, exported as `WIZARD_SENTINEL_KEY` from `jit-github-token-provider.ts`.
+
+**Rationale**: self-documenting in logs and relay events; can never collide with real descriptor ids (which are GitHub installation/credential identifiers, not strings starting with `__`); zero cost to recognize-and-ignore if a future cloud consumer wants to filter synthetic ids.
+
+**Alternatives rejected**:
+- `'default'` — acceptable per Q1, but reads like it could be a real fallback value rather than an explicit sentinel. Higher cognitive load in logs.
+- Derived from `clusterId` — introduces variability, requires reading `cluster.json` at provider-construction time, and risks leaking cluster identity into relay events whose existing payloads don't carry it.
+
+### D3: defense-in-depth `GH_TOKEN` env override
+
+**Chosen**: when `this.tokenProvider` is set, `resolveTokenEnv` always returns an env object with the `GH_TOKEN` key (= token, or `''` if a token is missing for any reason). Today's `return token ? { GH_TOKEN: token } : undefined` is the silent-fallback bug structurally embedded into the success path: an empty string token would degrade to ambient. Setting `GH_TOKEN: ''` produces a loud `gh` auth failure rather than a delayed 401 from the wrong token.
+
+**Rationale**: structural — once any caller has injected a provider, ambient inheritance is wrong by construction. Belt-and-braces on top of the JitTokenError throw-and-skip behavior.
+
+### D4: worker-mode provider built in-process at worker startup
+
+**Chosen**: the worker process constructs its own `createJitGithubTokenProvider` via the same code path in `server.ts` (which already runs in both modes). Independent in-process cache.
+
+**Rationale**: cross-process sharing is structurally impossible — the provider is a closure over a `Map`. The current code in `server.ts:201–224` already runs in both `isWorkerMode` and orchestrator mode, so changing the gating condition there fixes both. No separate worker-side construction site exists.
+
+## Implementation patterns referenced
+
+- **#598 deferred-binding pattern**: precedent for the api-key probe gating approach — gate on a stable on-disk signal (file presence) rather than a dynamic runtime signal (socket connect).
+- **#762 GhAuthError + AuthHealthSink**: precedent for fail-loud telemetry around `gh` auth failures. The existing `catch (GhAuthError)` branches in `LabelMonitorService.pollRepo` and `PrFeedbackMonitorService.pollRepo` are the same loop boundaries that will catch `JitTokenError`.
+- **#766 git-credential-generacy**: precedent for the credential-less control-plane path. Already proven on the git side; #777 extends the same precedent to the gh side.
+
+## Key sources / references
+
+- `packages/orchestrator/src/server.ts:201–224` — the bug site.
+- `packages/orchestrator/src/services/jit-github-token-provider.ts:14–97` — function to modify.
+- `packages/control-plane/src/services/jit-git-token-client.ts:86–166` — credential-less branch (already present).
+- `packages/workflow-engine/src/actions/github/client/gh-cli.ts:67–80` — env override site.
+- `packages/control-plane/src/services/cluster-api-key.ts:4` — api-key path constant.
+- `packages/orchestrator/src/services/credential-expiry-watcher.ts:164–175` — `readCredentialDescriptors` (unchanged).
+- `packages/orchestrator/src/services/github-auth-health.ts:73–162` — `recordResult`/`maybeRequestRefresh` (unchanged; receives sentinel key when no descriptor).
+- [CLAUDE.md "Cluster-side JIT Git Credential Helper (#766)"](../../CLAUDE.md) — architectural context for the credential-less path.
+- [CLAUDE.md "Cluster-Side GH_TOKEN Expiry Detection and Refresh Backstop (#762)"](../../CLAUDE.md) — context for `AuthHealthSink` and the relay event flow.

--- a/specs/777-severity-high-773-not/spec.md
+++ b/specs/777-severity-high-773-not/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: ## Severity
+
+**High — #773 does not actually fix the reported failure on real clusters
+
+**Branch**: `777-severity-high-773-not` | **Date**: 2026-06-06 | **Status**: Draft
+
+## Summary
+
+## Severity
+
+**High — #773 does not actually fix the reported failure on real clusters.** The JIT gh-token provider is gated on a `github-app` credential descriptor that wizard-bootstrapped clusters (all current clusters) never have, so the provider is always `undefined` and every `gh` call falls back to the ambient `GH_TOKEN` — the same static 1-hour token #773 was meant to retire. Processing works for ~1h after activation, then all `gh` calls 401 again (label sync, monitor, PR feedback, workers).
+
+## Evidence (live prod cluster, ai-lawfirm, after #773 deploy)
+
+- #773 **is** deployed: `services/jit-github-token-provider.js` present; `server.js` wires `JitGitTokenClient`; no `wizardCredsTokenProvider` left.
+- `POST /git-token` returns a **valid, working** token: `gh api repos/Painworth/ai-lawfirm` succeeds with it (expiry ~36 min out, cached/deduped correctly).
+- Yet the orchestrator's own `gh` calls 401 with `Bad credentials`, using the **ambient `GH_TOKEN` (`ghs_l4ZJ…`)** — which I confirmed is the expired wizard token (`/var/lib/generacy/wizard-credentials.env` `GH_TOKEN` → 401).
+- `git clone` over https **works** (helper bin calls `client.fetch()` credential-less).
+
+## Root cause
+
+`packages/orchestrator/src/server.ts`:
+```ts
+const initialDescriptors = await readCredentialDescriptors(agencyDir);
+const ghapp = initialDescriptors.find(d => d.type === 'github-app');
+githubAppCredentialId = ghapp?.credentialId;            // undefined on wizard clusters
+…
+const githubTokenProvider = githubAppCredentialId
+  ? createJitGithubTokenProvider({ … credentialId: githubAppCredentialId … })
+  : undefined;                                           // → callers fall through to ambient GH_TOKEN
+```
+Wizard-bootstrapped clusters carry only a raw GitHub token credential (`GH_TOKEN`/`GH_USERNAME`/`GH_EMAIL`), **no `github-app` descriptor**, so `githubAppCredentialId` is `undefined`, the provider is never created, and `GhCliGitHubClient.getEnv()` returns `undefined` → `gh` inherits the ambient (expired) `GH_TOKEN`.
+
+The **git** path doesn't hit this because `git-credential-generacy` calls `client.fetch()` with no argument, and the JIT client already handles that:
+```ts
+// control-plane jit-git-token-client.js
+async fetch(credentialId) {
+  const body = credentialId === undefined ? '{}' : JSON.stringify({ credentialId });
+  …
+}
+```
+The control-plane resolves the installation server-side from the cluster-api-key — no descriptor needed. So the gh provider's dependency on a `github-app` `credentialId` is over-specification; the underlying `/git-token` path works credential-less (proven by the working git clone and a direct `{}` probe).
+
+## Fix
+
+Stop gating the gh JIT provider on a `github-app` descriptor. Build it whenever the control-plane `/git-token` path is available (cluster-api-key / cloud pull configured — the same precondition the git helper relies on), and call `fetch()` **credential-less** (pass `credentialId` only when a descriptor actually exists). Make `credentialId` optional in `createJitGithubTokenProvider`:
+
+- Cache key + `authHealth.recordResult(...)` keying fall back to a reserved-prefix sentinel (`'__wizard__'`) when no descriptor is present (see Clarifications Q1).
+- Both orchestrator and worker modes (worker `ClaudeCliWorker` builds its own provider with an independent cache — see Clarifications Q4).
+
+## Clarifications
+
+Resolved decisions from clarification batch 1 (see [clarifications.md](clarifications.md) for full rationale):
+
+- **Synthetic key (Q1)**: Use a reserved-prefix sentinel (`'__wizard__'`) — *not* `'default'` — for both the cache key and `authHealth.recordResult(...)` keying when no `github-app` descriptor exists. Self-documenting in logs/relay payloads; cannot collide with real installation/credential ids; trivial for future cloud consumers to recognize-and-ignore.
+- **Construction precondition (Q2)**: Gate provider construction on the presence of `/var/lib/generacy/cluster-api-key` — *not* a control-plane socket probe and *not* unconditional. This matches the precondition `git-credential-generacy` already relies on, distinguishes a cloud-connected wizard cluster (build provider) from a genuinely unconfigured/offline cluster (keep ambient fallback), and avoids the startup-race class where the socket binds after descriptors are resolved.
+- **Cloud-side compatibility (Q3)**: No cloud-side change required. generacy-cloud currently has no consumer for `refresh-requested`/`auth-failed` events (#762 cloud handler deferred); they are fire-and-forget telemetry. The credential-less path does not depend on cloud push-refresh — JIT re-fetches inline via `/git-token`, which resolves the installation server-side from cluster identity (not from `credentialId`). Continue emitting events with the synthetic id.
+- **Worker mode (Q4)**: Each worker process constructs its own credential-less `createJitGithubTokenProvider` at startup with an independent cache. Providers are closures over a client + `Map` and cannot cross a process boundary, so cross-process sharing is impossible. Worker mode is **in scope** — workers are the primary failure surface for the reported breakage.
+- **Fail-loud behavior (Q5)**: When the JIT provider throws `JitTokenError`, callers (label monitor, PR-feedback monitor, worker) catch at the loop boundary, log, and **skip the `gh` call** for that cycle. The throw must never silently fall through to spawning `gh` with the ambient/expired `GH_TOKEN`. As defense-in-depth, when the provider is present, set `GH_TOKEN: ''` in the `gh` env override so the ambient value cannot leak through an unforeseen caller path. `AuthHealthSink.recordResult({ ok: false, statusCode: 503 })` supplies the observable signal.
+
+## Acceptance criteria
+
+- [ ] A wizard-bootstrapped cluster (no `github-app` descriptor) builds the JIT gh provider and refreshes `gh` tokens via `/git-token`.
+- [ ] Such a cluster runs **many hours** with zero `gh` 401s and no ambient-token fallback.
+- [ ] Regression test: provider is created and fetches credential-less when `initialDescriptors` contains no `github-app` entry, and the api-key file exists.
+- [ ] Negative test: when `/var/lib/generacy/cluster-api-key` is *absent* (truly unconfigured/offline cluster), the provider is NOT created and the legacy fallback path applies.
+- [ ] When a `github-app` descriptor *does* exist, behavior is unchanged (credentialId still passed; sentinel not used).
+- [ ] Cache key and `authHealth` keying use the reserved-prefix sentinel (`'__wizard__'`) consistently in the credential-less path.
+- [ ] `gh` callers that hit `JitTokenError` log, skip the call, and do NOT spawn `gh` with the ambient `GH_TOKEN`.
+- [ ] When the provider is present, the `gh` env override explicitly sets `GH_TOKEN` (to the fresh value, or `''` on the throw-and-skip path) so ambient leakage is impossible.
+- [ ] Worker processes build their own credential-less provider at worker startup with identical fail-loud behavior to the orchestrator.
+
+## Related
+
+- Caused by the gating introduced in #773 (the rest of that PR — JIT client, caching, fail-loud, dual-socket — is correct and working).
+- Mirrors the credential-less precedent already shipped for `git-credential-generacy`.
+- #762 backstop is what surfaced it (the `investigate credential refresh chain` warnings are firing as designed).
+
+## User Stories
+
+### US1: [Primary User Story]
+
+**As a** [user type],
+**I want** [capability],
+**So that** [benefit].
+
+**Acceptance Criteria**:
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR-001 | [Description] | P1 | |
+
+## Success Criteria
+
+| ID | Metric | Target | Measurement |
+|----|--------|--------|-------------|
+| SC-001 | [Metric] | [Target] | [How to measure] |
+
+## Assumptions
+
+- [Assumption 1]
+
+## Out of Scope
+
+- [Exclusion 1]
+
+---
+
+*Generated by speckit*

--- a/specs/777-severity-high-773-not/tasks.md
+++ b/specs/777-severity-high-773-not/tasks.md
@@ -1,0 +1,160 @@
+# Tasks: JIT gh token provider works without `github-app` descriptor (#777)
+
+**Input**: Design documents from `/specs/777-severity-high-773-not/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/jit-github-token-provider.ts.md, contracts/gh-cli-env-override.md, quickstart.md
+**Status**: Complete
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to. This spec is a single bug fix (US1: "wizard-bootstrapped clusters keep `gh` working past the 1h ambient-token expiry").
+
+---
+
+## Phase 1: Core provider changes
+
+- [X] **T001** [US1] Modify `packages/orchestrator/src/services/jit-github-token-provider.ts`:
+  - Export new constant `WIZARD_SENTINEL_KEY = '__wizard__'` (top-level).
+  - Widen `JitGithubTokenProviderOptions.credentialId` from `string` to `string | undefined` (`credentialId?: string`).
+  - In `createJitGithubTokenProvider`, derive `const effectiveKey = credentialId ?? WIZARD_SENTINEL_KEY` once.
+  - Replace every `cache.get(credentialId)` / `cache.set(credentialId, …)` / `cache.delete(credentialId)` with `effectiveKey`.
+  - Replace `authHealth?.recordResult(credentialId, …)` with `authHealth?.recordResult(effectiveKey, …)`.
+  - Replace the warn-log payload field `credentialId` with `credentialId: effectiveKey`.
+  - Leave `client.fetch(credentialId)` call **unchanged** — pass the original (possibly `undefined`) value so the existing `'{}'` branch in `JitGitTokenClient.fetch` is preserved.
+  - Reference: contracts/jit-github-token-provider.ts.md, data-model.md "Constants" + "Modified types".
+
+- [X] **T002** [P] [US1] Create `packages/orchestrator/src/services/cluster-api-key-probe.ts` (~15 LOC):
+  - Export `const DEFAULT_KEY_PATH = '/var/lib/generacy/cluster-api-key'` (must match `packages/control-plane/src/services/cluster-api-key.ts:4`).
+  - Export `clusterApiKeyExists(keyPath?: string): boolean` that returns `fs.existsSync(keyPath ?? process.env.CLUSTER_API_KEY_PATH ?? DEFAULT_KEY_PATH)`.
+  - Pure `node:fs` wrapper. Does NOT read the file's contents.
+  - JSDoc explaining the test override env var and that it is intentionally separate from the control-plane's async `ClusterApiKeyReader`.
+  - Reference: data-model.md "New types".
+
+- [X] **T003** [P] [US1] Tighten `resolveTokenEnv` in `packages/workflow-engine/src/actions/github/client/gh-cli.ts:67-71`:
+  - Change body from `return token ? { GH_TOKEN: token } : undefined;` to `return { GH_TOKEN: token ?? '' };` (only when `this.tokenProvider` is set).
+  - Preserve the early `if (!this.tokenProvider) return undefined;` branch verbatim — legacy callers without a provider keep ambient inheritance.
+  - Add JSDoc above the method capturing the invariant: "provider present ⇒ `GH_TOKEN` always set, never `undefined`". Reference contract document.
+  - Reference: contracts/gh-cli-env-override.md.
+
+---
+
+## Phase 2: Wiring (depends on Phase 1)
+
+- [X] **T004** [US1] Update provider-construction gate in `packages/orchestrator/src/server.ts:201-224`. **Depends on T001, T002.**
+  - Import `clusterApiKeyExists` from `./services/cluster-api-key-probe.js` (alongside existing `createJitGithubTokenProvider` import).
+  - Replace the gating condition `githubAppCredentialId ? createJitGithubTokenProvider({…}) : undefined` with: build the provider when `clusterApiKeyExists()` returns `true`, pass `credentialId: githubAppCredentialId` (may be `undefined`), keep the other options identical. When `clusterApiKeyExists()` is `false`, leave the provider `undefined` (legacy fallback for truly-unconfigured clusters).
+  - Update the leading comment block (lines 211-216) to describe the new gate and the credential-less branch.
+  - Do NOT touch the downstream references to `githubAppCredentialId` at lines 358 / 386 — they pass through to other services unchanged.
+  - Reference: research.md D1, plan.md "Project Structure".
+
+- [X] **T005** [P] [US1] Add `JitTokenError` catch branches at loop-boundary call sites so a JIT-fetch failure logs and skips the cycle (never silently spawns `gh` with the ambient token). Mirror the existing `GhAuthError` catch pattern from #762. Touched files:
+  - `packages/orchestrator/src/services/label-monitor-service.ts` — `pollRepo` catch chain: add a `catch (err) { if (err instanceof JitTokenError) { log.warn({ code: err.code, repo }, 'JIT token fetch failed — skipping label monitor cycle'); return; } throw err; }` branch *before* the existing `GhAuthError` branch (or fold into the same chain).
+  - `packages/orchestrator/src/services/pr-feedback-monitor-service.ts` — same treatment in `pollRepo`.
+  - `packages/orchestrator/src/services/webhook-setup-service.ts` — wrap the `executeCommand('gh', …)` paths (and any `GhCliGitHubClient` calls) in a per-call try/catch that logs and continues on `JitTokenError`. Webhook setup is best-effort, so a per-repo throw should not abort the whole setup pass.
+  - `packages/orchestrator/src/worker/claude-cli-worker.ts` — sibling-fan-out call site (`gh pr ready` loop near `markReadyForReview` / `linkedPRs` handling): ensure the surrounding try/catch logs `JitTokenError` and continues with the next sibling.
+  - Imports: add `import { JitTokenError } from '@generacy-ai/control-plane';` to each modified file that doesn't already import it.
+  - Reference: contracts/gh-cli-env-override.md "Caller obligations".
+
+---
+
+## Phase 3: Tests (parallel with Phase 2)
+
+- [X] **T006** [P] [US1] Unit tests for `packages/orchestrator/__tests__/services/jit-github-token-provider.test.ts` (extend existing file; reuse the existing fake `JitGitTokenClient`). Add cases:
+  - `creates provider when credentialId omitted` — `createJitGithubTokenProvider({ client, logger })` returns a function.
+  - `uses WIZARD_SENTINEL_KEY as cache key when credentialId omitted` — first call fetches, second call within `refreshWindowMs` returns the cached token without re-calling the client (verifies the cache write/read keys are consistent under the sentinel).
+  - `calls client.fetch() with no argument when credentialId omitted` — spy on `client.fetch`; first arg is `undefined`.
+  - `records authHealth under WIZARD_SENTINEL_KEY on failure` — fake `AuthHealthSink` spy; first arg of `recordResult` is `'__wizard__'`.
+  - `propagates JitTokenError unchanged in credential-less path` — assert `err.code`, `err.message` preserved.
+  - `passes credentialId to client.fetch when defined` — regression for descriptor path (`credentialId: 'foo'` → `client.fetch('foo')`).
+  - `uses descriptor credentialId as cache key when defined` — sentinel not used; authHealth recorded under `'foo'`.
+  - Import `WIZARD_SENTINEL_KEY` from the module under test for explicit assertions (do not duplicate the literal in tests).
+  - Reference: contracts/jit-github-token-provider.ts.md "Tests".
+
+- [X] **T007** [P] [US1] Unit tests for `packages/workflow-engine/__tests__/actions/github/client/gh-cli.test.ts` (extend existing file). Add cases:
+  - `resolveTokenEnv returns { GH_TOKEN } when provider returns a token` — env value matches provider output.
+  - `resolveTokenEnv returns { GH_TOKEN: '' } when provider returns empty string` — explicit empty string in env, NOT `undefined`.
+  - `resolveTokenEnv returns undefined when no provider configured` — legacy behavior preserved.
+  - `executeGh propagates JitTokenError when provider throws` — mock `executeCommand` (or the equivalent existing shim); assert it is NOT called and the error rethrown unchanged.
+  - Reference: contracts/gh-cli-env-override.md "Tests".
+
+- [X] **T008** [P] [US1] Unit tests for `packages/orchestrator/__tests__/services/cluster-api-key-probe.test.ts` (new file):
+  - `returns true when key file exists at default path` — use `vi.mock('node:fs')` or a temp dir + env-var override.
+  - `returns false when key file missing at default path`.
+  - `honors explicit keyPath argument over env var and default`.
+  - `honors CLUSTER_API_KEY_PATH env var when no explicit keyPath given`.
+  - Reference: data-model.md "New types".
+
+- [X] **T009** [P] [US1] Integration-style test (or regression test in `packages/orchestrator/__tests__/server.test.ts` if one exists, otherwise extend `jit-github-token-provider.test.ts` with a small `server.ts` wiring shim test) covering the three gating outcomes:
+  - **Descriptor present + api-key present**: provider constructed, `credentialId` is the descriptor's id, sentinel NOT used.
+  - **No descriptor + api-key present**: provider constructed, `credentialId` is `undefined`, sentinel used internally (verified via cache + authHealth keying).
+  - **No api-key**: provider is `undefined` (legacy fallback).
+  - If no `server.test.ts` exists, isolate via direct calls to `createJitGithubTokenProvider` + `clusterApiKeyExists` rather than booting Fastify.
+  - Reference: spec.md "Acceptance criteria" bullets 1, 4, 5.
+
+---
+
+## Phase 4: Manual verification (depends on Phases 1-3)
+
+- [ ] **T010** [US1] Run quickstart.md verification on a wizard-bootstrapped cluster:
+  - V1: `gh api repos/<org>/<repo>` succeeds from inside the orchestrator container after the wizard `GH_TOKEN` has been force-expired.
+  - V2: orchestrator logs show `credentialId: '__wizard__'` on the first JIT fetch line; `.agency/credentials.yaml` confirmed to have no `type: github-app` entry.
+  - V3: spawn-env trace (or debug-build log) confirms the `GH_TOKEN` env passed to the `gh` subprocess is the fresh JIT token, not the value in `/var/lib/generacy/wizard-credentials.env`.
+  - V4: with control-plane stopped, the next poll cycle emits a `JIT GitHub token refresh failed` warn line and a caller-side skip; no `Bad credentials` / HTTP 401 in the same cycle.
+  - V5: long-run check — leave the cluster running ≥ 4 hours; `docker compose logs --since 4h orchestrator | grep -i 'Bad credentials\|HTTP 401'` is empty.
+  - V6: descriptor-present regression — add a synthetic `github-app` descriptor; first JIT fetch log shows the real `credentialId`, NOT `'__wizard__'`; `gh` still works.
+  - Reference: quickstart.md.
+
+---
+
+## Dependencies & Execution Order
+
+**Within Phase 1**:
+- T001 (provider edits) and T002 (api-key probe) touch different files and are independent → can run in parallel.
+- T003 (gh-cli env override) is in a different package (workflow-engine) and depends on nothing → parallel with T001/T002.
+
+**Phase 2 (T004, T005)**:
+- T004 (server.ts wiring) imports both `WIZARD_SENTINEL_KEY` indirect dependencies and `clusterApiKeyExists` — **blocks on T001 + T002**.
+- T005 (caller catch branches) imports `JitTokenError` (already exported from control-plane today) — does NOT depend on T001-T004 builds and can start as soon as T001 lands (so the provider's failure path is wired into a catch chain at the same time). Practically: run after T001 finishes (small) or in parallel with T003-T004.
+
+**Phase 3 (tests, T006-T009)**:
+- T006 blocked on T001.
+- T007 blocked on T003.
+- T008 blocked on T002.
+- T009 blocked on T001 + T002 + T004.
+- All four are in different files → parallel once their prerequisite implementation tasks finish.
+
+**Phase 4 (T010)**:
+- Blocked on all of Phases 1-3 landing (and a clean orchestrator build deployed to a wizard-bootstrapped cluster).
+
+### Parallel execution graph
+
+```
+T001 ──┬─► T004 ──┬─► T009 ──┐
+       │          │          │
+T002 ──┘          │          │
+                  │          │
+T003 ────────► T007 ─────────┤──► T010
+                             │
+T001 ────────► T006 ─────────┤
+                             │
+T002 ────────► T008 ─────────┤
+                             │
+T001 ────────► T005 ─────────┘
+```
+
+Round 1 (parallel): **T001, T002, T003**.
+Round 2 (parallel, after T001/T002): **T004, T005, T006, T007, T008**.
+Round 3 (parallel, after T004): **T009**.
+Round 4 (manual): **T010**.
+
+---
+
+## Notes
+
+- **Single user story (US1)** — this is a high-severity bug fix, not a multi-story feature. Every task carries the `[US1]` tag for consistency with the format.
+- **No setup phase** — all packages, build tooling, and test infra already exist.
+- **No data model migration / no config migration** — the change is purely behavioral. Rollback is `git revert` of the implementation commits.
+- **`/speckit:implement` next** to begin execution.
+
+---
+
+*Generated by speckit*


### PR DESCRIPTION
* chore(speckit): complete specify phase for #777

* chore(speckit): complete clarify phase for #777

* chore(speckit): complete clarify phase for #777

* chore(speckit): complete plan phase for #777

* chore(speckit): complete tasks phase for #777

* wip(speckit): partial implement progress for #777 (retry 1)

* chore(speckit): complete implement phase for #777

* test: align gh-cli token-injection tests with credential-less invariant; add changeset (#777)

The resolution-failed tests still asserted the pre-fix env: undefined behavior; update them to the new invariant (provider present ⇒ GH_TOKEN always set to '' so gh can't inherit the expired ambient token). Add the missing changeset for the orchestrator/workflow-engine source changes.



---------