### PR TITLE
fix(orchestrator): per-phase worker timeouts so plan/implement aren't killed at 10m

### DIFF
--- a/.changeset/fix-per-phase-worker-timeouts.md
+++ b/.changeset/fix-per-phase-worker-timeouts.md
@@ -1,0 +1,19 @@
+---
+"@generacy-ai/orchestrator": minor
+---
+
+fix: per-phase worker timeouts so plan/implement aren't killed at 10m
+
+The orchestrator worker applied a single flat `phaseTimeoutMs` (default 10m) to
+every CLI phase, so the heavier `plan` and `implement` phases were SIGKILL'd at
+the deadline mid-work (the worker never wrote `plan.md`), surfacing as a
+`failed:plan` label ~10m after `phase:plan`.
+
+`WorkerConfig` now supports `phaseTimeoutOverrides`, a per-phase map that falls
+back to `phaseTimeoutMs` for any phase without an override. `plan` and
+`implement` default to 60m; the fallback for the lighter phases is raised to
+20m. Overrides are
+configurable without code changes via `orchestrator.yaml`
+(`worker.phaseTimeoutOverrides`) or env vars: `WORKER_PHASE_TIMEOUT_MS` for the
+fallback and `WORKER_PHASE_TIMEOUT_<PHASE>_MS` (e.g. `WORKER_PHASE_TIMEOUT_PLAN_MS`)
+per phase.

--- a/packages/orchestrator/src/config/loader.ts
+++ b/packages/orchestrator/src/config/loader.ts
@@ -217,6 +217,33 @@ function loadFromEnv(): Record<string, unknown> {
     (config.worker as Record<string, unknown>).workspaceDir = workerWorkspaceDir;
   }
 
+  // Worker phase timeout: flat fallback applied to phases without a per-phase override
+  const phaseTimeoutMs = process.env['WORKER_PHASE_TIMEOUT_MS'] ?? process.env[`${ENV_PREFIX}WORKER_PHASE_TIMEOUT_MS`];
+  if (phaseTimeoutMs) {
+    if (!config.worker) {
+      config.worker = {};
+    }
+    (config.worker as Record<string, unknown>).phaseTimeoutMs = parseInt(phaseTimeoutMs, 10);
+  }
+
+  // Per-phase timeout overrides: WORKER_PHASE_TIMEOUT_<PHASE>_MS (e.g. WORKER_PHASE_TIMEOUT_PLAN_MS).
+  // `validate` is excluded — it runs a shell command on a separate timeout path.
+  const overridablePhases = ['specify', 'clarify', 'plan', 'tasks', 'implement'] as const;
+  for (const phase of overridablePhases) {
+    const suffix = `WORKER_PHASE_TIMEOUT_${phase.toUpperCase()}_MS`;
+    const value = process.env[suffix] ?? process.env[`${ENV_PREFIX}${suffix}`];
+    if (value) {
+      if (!config.worker) {
+        config.worker = {};
+      }
+      const worker = config.worker as Record<string, unknown>;
+      if (!worker.phaseTimeoutOverrides) {
+        worker.phaseTimeoutOverrides = {};
+      }
+      (worker.phaseTimeoutOverrides as Record<string, unknown>)[phase] = parseInt(value, 10);
+    }
+  }
+
   // Credential role: env var overrides config file
   const credentialRole = process.env['GENERACY_CREDENTIAL_ROLE']
     ?? (configPath ? tryLoadDefaultsRole(configPath) : null);

--- a/packages/orchestrator/src/worker/__tests__/config.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { WorkerConfigSchema } from '../config.js';
+import { WorkerConfigSchema, resolvePhaseTimeoutMs } from '../config.js';
 
 describe('WorkerConfigSchema - maxImplementRetries', () => {
   it('defaults to 2', () => {
@@ -28,5 +28,47 @@ describe('WorkerConfigSchema - maxImplementRetries', () => {
 
   it('rejects string values', () => {
     expect(() => WorkerConfigSchema.parse({ maxImplementRetries: '2' })).toThrow();
+  });
+});
+
+describe('WorkerConfigSchema - phaseTimeoutOverrides', () => {
+  it('defaults plan and implement to 60 minutes', () => {
+    const config = WorkerConfigSchema.parse({});
+    expect(config.phaseTimeoutMs).toBe(1_200_000);
+    expect(config.phaseTimeoutOverrides.plan).toBe(3_600_000);
+    expect(config.phaseTimeoutOverrides.implement).toBe(3_600_000);
+    expect(config.phaseTimeoutOverrides.specify).toBeUndefined();
+  });
+
+  it('keeps sibling defaults when only one phase is overridden (partial object)', () => {
+    const config = WorkerConfigSchema.parse({ phaseTimeoutOverrides: { plan: 2_400_000 } });
+    expect(config.phaseTimeoutOverrides.plan).toBe(2_400_000);
+    // implement default must survive a partial override of plan
+    expect(config.phaseTimeoutOverrides.implement).toBe(3_600_000);
+  });
+
+  it('rejects overrides below the 60s minimum', () => {
+    expect(() => WorkerConfigSchema.parse({ phaseTimeoutOverrides: { plan: 30_000 } })).toThrow();
+  });
+});
+
+describe('resolvePhaseTimeoutMs', () => {
+  it('returns the per-phase override when present', () => {
+    const config = WorkerConfigSchema.parse({ phaseTimeoutMs: 1_200_000 });
+    expect(resolvePhaseTimeoutMs(config, 'plan')).toBe(3_600_000);
+    expect(resolvePhaseTimeoutMs(config, 'implement')).toBe(3_600_000);
+  });
+
+  it('falls back to phaseTimeoutMs for phases without an override', () => {
+    const config = WorkerConfigSchema.parse({ phaseTimeoutMs: 1_200_000 });
+    expect(resolvePhaseTimeoutMs(config, 'specify')).toBe(1_200_000);
+    expect(resolvePhaseTimeoutMs(config, 'clarify')).toBe(1_200_000);
+    expect(resolvePhaseTimeoutMs(config, 'tasks')).toBe(1_200_000);
+  });
+
+  it('falls back to phaseTimeoutMs when overrides are absent (hand-built config)', () => {
+    // Configs constructed directly (tests, callers) bypass Zod and omit the field.
+    const config = { phaseTimeoutMs: 720_000 } as unknown as Parameters<typeof resolvePhaseTimeoutMs>[0];
+    expect(resolvePhaseTimeoutMs(config, 'plan')).toBe(720_000);
   });
 });

--- a/packages/orchestrator/src/worker/config.ts
+++ b/packages/orchestrator/src/worker/config.ts
@@ -14,11 +14,40 @@ export const GateDefinitionSchema = z.object({
 });
 
 /**
+ * Per-phase wall-clock timeout overrides (milliseconds).
+ *
+ * Each CLI phase is killed (SIGTERM → grace → SIGKILL) once its wall-clock
+ * runtime exceeds its timeout. The `plan` and `implement` phases are
+ * structurally heavier than the others — `plan` fans out research subagents,
+ * `implement` writes code — so they default to a larger budget than the flat
+ * `phaseTimeoutMs`. Any phase without an override falls back to `phaseTimeoutMs`.
+ *
+ * Defined per-field (rather than as a `z.record`) so that overriding one phase
+ * via config/env does not drop the defaults for the others — Zod applies the
+ * remaining field defaults when the object is present but partial.
+ *
+ * `validate` is intentionally excluded: that phase runs a shell command via a
+ * separate code path with its own timeout, not `phaseTimeoutMs`.
+ */
+export const PhaseTimeoutOverridesSchema = z
+  .object({
+    specify: z.number().int().min(60_000).optional(),
+    clarify: z.number().int().min(60_000).optional(),
+    plan: z.number().int().min(60_000).default(3_600_000),
+    tasks: z.number().int().min(60_000).optional(),
+    implement: z.number().int().min(60_000).default(3_600_000),
+  })
+  .default({});
+export type PhaseTimeoutOverrides = z.infer<typeof PhaseTimeoutOverridesSchema>;
+
+/**
  * Worker configuration schema
  */
 export const WorkerConfigSchema = z.object({
-  /** Timeout per phase in milliseconds */
-  phaseTimeoutMs: z.number().int().min(60_000).default(600_000),
+  /** Fallback timeout per phase in milliseconds (used when no per-phase override applies) */
+  phaseTimeoutMs: z.number().int().min(60_000).default(1_200_000),
+  /** Per-phase timeout overrides keyed by phase name */
+  phaseTimeoutOverrides: PhaseTimeoutOverridesSchema,
   /** Base directory for repo checkouts */
   workspaceDir: z.string().default('/tmp/orchestrator-workspaces'),
   /** Grace period for shutdown in milliseconds */
@@ -50,3 +79,16 @@ export const WorkerConfigSchema = z.object({
 });
 
 export type WorkerConfig = z.infer<typeof WorkerConfigSchema>;
+
+/**
+ * Resolve the wall-clock timeout (ms) for a CLI phase: the per-phase override
+ * if one is configured, otherwise the flat `phaseTimeoutMs` fallback.
+ */
+export function resolvePhaseTimeoutMs(
+  config: WorkerConfig,
+  phase: Exclude<WorkflowPhase, 'validate'>,
+): number {
+  // Optional-chained: configs built by hand (tests, direct construction) bypass
+  // Zod and may omit phaseTimeoutOverrides entirely.
+  return config.phaseTimeoutOverrides?.[phase] ?? config.phaseTimeoutMs;
+}

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -1,6 +1,7 @@
 import type { WorkerContext, PhaseResult, Logger, WorkflowPhase, JobEventEmitter, PhaseAfterHandler } from './types.js';
 import { PHASE_SEQUENCE, PHASE_TO_STAGE } from './types.js';
 import type { WorkerConfig } from './config.js';
+import { resolvePhaseTimeoutMs } from './config.js';
 import type { LabelManager } from './label-manager.js';
 import type { StageCommentManager } from './stage-comment-manager.js';
 import type { GateChecker } from './gate-checker.js';
@@ -190,13 +191,14 @@ export class PhaseLoop {
           const prompt = siblingBlock
             ? `${siblingBlock}\n\n${context.issueUrl}`
             : context.issueUrl;
+          const cliPhase = phase as Exclude<typeof phase, 'validate'>;
           result = await cliSpawner.spawnPhase(
-            phase as Exclude<typeof phase, 'validate'>,
+            cliPhase,
             {
               prompt,
               cwd: context.checkoutPath,
               env: { CLAUDE_HEADLESS: 'true' },
-              timeoutMs: config.phaseTimeoutMs,
+              timeoutMs: resolvePhaseTimeoutMs(config, cliPhase),
               signal: context.signal,
               resumeSessionId: currentSessionId,
               siblingWorkdirs: context.siblingWorkdirs,


### PR DESCRIPTION
## Problem

The orchestrator worker applied a **single flat `phaseTimeoutMs` (default 10m)** to every CLI phase. The heavier `plan` and `implement` phases hit that wall-clock deadline mid-work and were SIGKILL'd before writing their artifacts (e.g. `plan.md`), surfacing as a `failed:<phase>` label ~10m after `phase:<phase>`.

This was diagnosed on a downstream project where **all 6 plan attempts died at 10m03–04s**, regardless of what the agent was doing — the signature of an external wall-clock kill, not an agent error. Worker conversation logs showed productive research running the entire 10 minutes, then an abrupt stop with no error trace.

### Root cause path
- `worker/config.ts` — `phaseTimeoutMs` default `600_000`, used for **all** phases.
- `worker/phase-loop.ts` — passed `config.phaseTimeoutMs` into every `spawnPhase()`.
- `worker/cli-spawner.ts` — enforced it via `setTimeout → SIGTERM → 5s grace → SIGKILL`.

`plan` is structurally the heaviest phase (fans out research subagents) yet shared the same budget as `specify`/`clarify`, which finish in ~3m.

## Fix

Add `WorkerConfig.phaseTimeoutOverrides` — a per-phase map that falls back to `phaseTimeoutMs` for any phase without an override.

- **Light phases** (`specify`, `clarify`, `tasks`) — fallback `phaseTimeoutMs` raised to **20m**.
- **Heavy phases** (`plan`, `implement`) — default to **60m**.
- `resolvePhaseTimeoutMs(config, phase)` resolves override → fallback, and is used in `phase-loop`.
- Per-field schema (not `z.record`) so overriding one phase via config/env doesn't drop the others' defaults.

### Operator overrides (previously unreachable from deployment)
- `orchestrator.yaml`: `worker.phaseTimeoutOverrides`
- Env: `WORKER_PHASE_TIMEOUT_MS` (fallback) and `WORKER_PHASE_TIMEOUT_<PHASE>_MS` (e.g. `WORKER_PHASE_TIMEOUT_PLAN_MS`)

## Notes
- Raising the flat `phaseTimeoutMs` to 20m also raises the PR-feedback CLI timeout (same field in `pr-feedback-handler.ts`) — intended.
- `validate` is unaffected (separate hardcoded constant on its own code path).
- Behavior change: clusters on this build immediately get 20m/60m with no config.

## Testing
- `tsc` build clean.
- 6 new tests in `worker/__tests__/config.test.ts` (defaults, partial-override survival, min bound, resolver). All 40 config/phase-loop tests pass.
- Pre-existing unrelated failures (activation/relay/webhook suites) confirmed failing identically on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)