### PR TITLE
feat(orchestrator): per-repo validate command overrides via .generacy/config.yaml

### DIFF
--- a/.changeset/feat-per-repo-validate-command.md
+++ b/.changeset/feat-per-repo-validate-command.md
@@ -1,0 +1,24 @@
+---
+"@generacy-ai/config": minor
+"@generacy-ai/orchestrator": minor
+---
+
+feat(orchestrator): per-repo validate command overrides via .generacy/config.yaml
+
+The validate-phase commands (`validateCommand` / `preValidateCommand`) were
+orchestrator-global and monorepo-shaped (`pnpm test && pnpm build`). A single
+orchestrator serves many repos, so a single-package repo with a different shape
+(e.g. an Astro site with no `test` script) failed validate on every issue —
+`pnpm test` exits non-zero before the build runs.
+
+The target repo's `.generacy/config.yaml` `orchestrator` block can now set
+`validateCommand` / `preValidateCommand`, which are merged onto the global
+worker config per-job before the phase loop runs.
+
+- `@generacy-ai/config`: `OrchestratorSettingsSchema` gains optional
+  `validateCommand` / `preValidateCommand`.
+- `@generacy-ai/orchestrator`: new pure helper `applyRepoValidateOverrides`
+  (preserves an explicit empty `preValidateCommand` = skip install); the worker
+  loads the repo's orchestrator settings at the existing per-job config hook and
+  passes the merged config to the phase loop. Backward-compatible — repos
+  without the block keep the global defaults.

--- a/packages/config/src/__tests__/loader.test.ts
+++ b/packages/config/src/__tests__/loader.test.ts
@@ -418,4 +418,25 @@ describe('tryLoadOrchestratorSettings', () => {
     writeFileSync(configPath, 'orchestrator:\n  smeeChannelUrl: not-a-url\n');
     expect(() => tryLoadOrchestratorSettings(configPath)).toThrow();
   });
+
+  it('parses per-repo validate command overrides', () => {
+    const configPath = join(tempDir, 'config.yaml');
+    writeFileSync(configPath, [
+      'orchestrator:',
+      '  preValidateCommand: pnpm install',
+      '  validateCommand: pnpm build',
+    ].join('\n'));
+
+    const result = tryLoadOrchestratorSettings(configPath);
+    expect(result?.validateCommand).toBe('pnpm build');
+    expect(result?.preValidateCommand).toBe('pnpm install');
+  });
+
+  it('preserves an explicit empty preValidateCommand (skip install)', () => {
+    const configPath = join(tempDir, 'config.yaml');
+    writeFileSync(configPath, "orchestrator:\n  preValidateCommand: ''\n");
+
+    const result = tryLoadOrchestratorSettings(configPath);
+    expect(result?.preValidateCommand).toBe('');
+  });
 });

--- a/packages/config/src/template-schema.ts
+++ b/packages/config/src/template-schema.ts
@@ -10,6 +10,20 @@ export const OrchestratorSettingsSchema = z.object({
   labelMonitor: z.boolean().optional(),
   webhookSetup: z.boolean().optional(),
   smeeChannelUrl: z.string().url().optional(),
+  /**
+   * Per-repo override for the validate-phase command. When set, it replaces the
+   * orchestrator's global `validateCommand` for jobs in this repo. The global
+   * default (`pnpm test && pnpm build`) assumes a `test` script and a monorepo;
+   * single-package repos (e.g. an Astro site with only a `build` script) set
+   * this to `pnpm build` so the validate phase doesn't fail on a missing script.
+   */
+  validateCommand: z.string().optional(),
+  /**
+   * Per-repo override for the pre-validate install command. Empty string skips
+   * the install step. When set, it replaces the orchestrator's global
+   * `preValidateCommand` for jobs in this repo.
+   */
+  preValidateCommand: z.string().optional(),
 });
 
 export const TemplateConfigSchema = z.object({

--- a/packages/orchestrator/src/worker/__tests__/config.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { WorkerConfigSchema, resolvePhaseTimeoutMs } from '../config.js';
+import { WorkerConfigSchema, resolvePhaseTimeoutMs, applyRepoValidateOverrides } from '../config.js';
 
 describe('WorkerConfigSchema - maxImplementRetries', () => {
   it('defaults to 2', () => {
@@ -70,5 +70,48 @@ describe('resolvePhaseTimeoutMs', () => {
     // Configs constructed directly (tests, callers) bypass Zod and omit the field.
     const config = { phaseTimeoutMs: 720_000 } as unknown as Parameters<typeof resolvePhaseTimeoutMs>[0];
     expect(resolvePhaseTimeoutMs(config, 'plan')).toBe(720_000);
+  });
+});
+
+describe('applyRepoValidateOverrides', () => {
+  const base = WorkerConfigSchema.parse({});
+
+  it('returns the same config object when settings are null/undefined', () => {
+    expect(applyRepoValidateOverrides(base, null)).toBe(base);
+    expect(applyRepoValidateOverrides(base, undefined)).toBe(base);
+  });
+
+  it('returns the same config object when no validate fields are set', () => {
+    expect(applyRepoValidateOverrides(base, { labelMonitor: true })).toBe(base);
+  });
+
+  it('overrides validateCommand only', () => {
+    const result = applyRepoValidateOverrides(base, { validateCommand: 'pnpm build' });
+    expect(result).not.toBe(base);
+    expect(result.validateCommand).toBe('pnpm build');
+    // preValidateCommand falls back to the global default
+    expect(result.preValidateCommand).toBe(base.preValidateCommand);
+  });
+
+  it('overrides both validate commands', () => {
+    const result = applyRepoValidateOverrides(base, {
+      validateCommand: 'pnpm build',
+      preValidateCommand: 'pnpm install',
+    });
+    expect(result.validateCommand).toBe('pnpm build');
+    expect(result.preValidateCommand).toBe('pnpm install');
+  });
+
+  it('preserves an explicit empty preValidateCommand (skip install)', () => {
+    const result = applyRepoValidateOverrides(base, { preValidateCommand: '' });
+    expect(result).not.toBe(base);
+    expect(result.preValidateCommand).toBe('');
+    expect(result.validateCommand).toBe(base.validateCommand);
+  });
+
+  it('does not mutate the input config', () => {
+    const snapshot = base.validateCommand;
+    applyRepoValidateOverrides(base, { validateCommand: 'pnpm build' });
+    expect(base.validateCommand).toBe(snapshot);
   });
 });

--- a/packages/orchestrator/src/worker/claude-cli-worker.ts
+++ b/packages/orchestrator/src/worker/claude-cli-worker.ts
@@ -3,13 +3,14 @@ import type { ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { resolveSiblingWorkdirs, tryLoadWorkspaceConfig, findWorkspaceConfigPath } from '@generacy-ai/config';
+import { resolveSiblingWorkdirs, tryLoadWorkspaceConfig, tryLoadOrchestratorSettings, findWorkspaceConfigPath } from '@generacy-ai/config';
 import { createGitHubClient, createFeature, registerProcessLauncher, clearProcessLauncher, siblingFanoutHandler, FilesystemWorkflowStore } from '@generacy-ai/workflow-engine';
 import type { LaunchFunctionRequest, LaunchFunctionHandle, LinkedPR, SiblingFanoutContext } from '@generacy-ai/workflow-engine';
 import type { QueueItem } from '../types/index.js';
 import type { WorkerContext, ProcessFactory, ChildProcessHandle, Logger, JobEventEmitter } from './types.js';
 import { getPhaseSequence } from './types.js';
 import type { WorkerConfig } from './config.js';
+import { applyRepoValidateOverrides } from './config.js';
 import { PhaseResolver } from './phase-resolver.js';
 import { LabelManager } from './label-manager.js';
 import { StageCommentManager } from './stage-comment-manager.js';
@@ -353,6 +354,23 @@ export class ClaudeCliWorker {
         }
       }
 
+      // 5c. Apply per-repo validate-command overrides from the target repo's
+      // .generacy/config.yaml. The orchestrator's global validate defaults are
+      // monorepo-shaped (`pnpm test && pnpm build`); repos with a different
+      // shape (e.g. a single-package Astro site with no `test` script) override
+      // them so the validate phase doesn't fail on a missing script.
+      const orchSettings = configPath ? tryLoadOrchestratorSettings(configPath) : null;
+      const effectiveConfig = applyRepoValidateOverrides(this.config, orchSettings);
+      if (effectiveConfig !== this.config) {
+        workerLogger.info(
+          {
+            validateCommand: effectiveConfig.validateCommand,
+            preValidateCommand: effectiveConfig.preValidateCommand,
+          },
+          'Applied per-repo validate-command override from .generacy/config.yaml',
+        );
+      }
+
       // 6. Build WorkerContext
       const context: WorkerContext = {
         workerId,
@@ -476,7 +494,7 @@ export class ClaudeCliWorker {
       // 8. Execute the phase loop
       const phaseSequence = getPhaseSequence(item.workflowName);
       const phaseLoop = new PhaseLoop(workerLogger);
-      const loopResult = await phaseLoop.executeLoop(context, this.config, {
+      const loopResult = await phaseLoop.executeLoop(context, effectiveConfig, {
         labelManager,
         stageCommentManager,
         gateChecker,

--- a/packages/orchestrator/src/worker/config.ts
+++ b/packages/orchestrator/src/worker/config.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { OrchestratorSettings } from '@generacy-ai/config';
 import type { WorkflowPhase } from './types.js';
 
 /**
@@ -79,6 +80,41 @@ export const WorkerConfigSchema = z.object({
 });
 
 export type WorkerConfig = z.infer<typeof WorkerConfigSchema>;
+
+/**
+ * Merge per-repo validate-command overrides onto the global worker config.
+ *
+ * The target repo's `.generacy/config.yaml` `orchestrator` block may set
+ * `validateCommand` / `preValidateCommand`. The global defaults are
+ * monorepo-shaped (`pnpm test && pnpm build`); single-package repos (e.g. an
+ * Astro site with only a `build` script) override them so the validate phase
+ * doesn't fail on a missing `test` script before it can reach the build.
+ *
+ * Only those two fields are overridable per-repo. An explicit empty
+ * `preValidateCommand` is preserved (it means "skip the install step"). Returns
+ * the original config object unchanged when there are no applicable overrides,
+ * so callers can cheaply detect "no override" via reference equality.
+ */
+export function applyRepoValidateOverrides(
+  config: WorkerConfig,
+  settings: OrchestratorSettings | null | undefined,
+): WorkerConfig {
+  if (
+    settings == null ||
+    (settings.validateCommand === undefined && settings.preValidateCommand === undefined)
+  ) {
+    return config;
+  }
+  return {
+    ...config,
+    ...(settings.validateCommand !== undefined
+      ? { validateCommand: settings.validateCommand }
+      : {}),
+    ...(settings.preValidateCommand !== undefined
+      ? { preValidateCommand: settings.preValidateCommand }
+      : {}),
+  };
+}
 
 /**
  * Resolve the wall-clock timeout (ms) for a CLI phase: the per-phase override


### PR DESCRIPTION
## Problem

The `validate` phase is a shell command run by the worker — `validateCommand` (default `pnpm test && pnpm build`) and `preValidateCommand` (default `pnpm install && pnpm -r --filter './packages/*' build`). These are **orchestrator-global**, shaped for the generacy monorepo. A single orchestrator serves many repos, so a single-package repo with a different shape — e.g. **generacy-marketing** (Astro SSG, no `test` script) — fails validate on `pnpm test` (`ERR_PNPM_NO_SCRIPT`) before the build ever runs, on **every** issue (`failed:validate` + `agent:error`). There was no per-repo escape hatch.

## Change

Make the validate commands overridable per-repo via the target repo's `.generacy/config.yaml` `orchestrator:` block:

```yaml
orchestrator:
  preValidateCommand: pnpm install
  validateCommand: pnpm build
```

- **`@generacy-ai/config` `OrchestratorSettingsSchema`** — add optional `validateCommand` / `preValidateCommand`.
- **`worker/config.ts`** — add pure helper `applyRepoValidateOverrides(config, settings)`. Only those two fields are overridable; an explicit empty `preValidateCommand` is preserved (means "skip install"); returns the same object ref when there's no override (cheap change detection).
- **`claude-cli-worker.ts`** — at the existing per-job config hook (where the repo's `.generacy/config.yaml` is already read for sibling workdirs), load `tryLoadOrchestratorSettings` and pass the merged config to the phase loop. Backward-compatible: repos without the block use the global defaults.

## Tests

- config loader: parses the new fields; preserves explicit empty `preValidateCommand`.
- worker config: `applyRepoValidateOverrides` — null/empty passthrough (same ref), single/both overrides, empty-string preserve, no input mutation.
- Full suites green: `@generacy-ai/config` 53, `@generacy-ai/orchestrator` 132. Typecheck + ESLint clean.

## Rollout

Takes effect after an orchestrator release + `generacy update` on the cluster. The companion repo PR (generacy-marketing#32) adds both the `.generacy/config.yaml` override and a `test` script that unblocks immediately without a redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)