### PR TITLE
fix(extension): point dashboard app links to app.generacy.ai

### DIFF
--- a/.changeset/cleanup-extension-app-links.md
+++ b/.changeset/cleanup-extension-app-links.md
@@ -1,0 +1,7 @@
+---
+---
+
+Point the extension's org-dashboard app links (upgrade, billing, invite member,
+settings, integrations) at `app.generacy.ai` instead of `generacy.ai`. No
+version bump — `generacy-extension` is versioned outside changesets (empty
+changeset satisfies the release gate).

--- a/packages/generacy-extension/src/views/cloud/dashboard/panel.ts
+++ b/packages/generacy-extension/src/views/cloud/dashboard/panel.ts
@@ -409,19 +409,19 @@ export class OrgDashboardPanel {
 
       case 'upgrade':
         void vscode.env.openExternal(
-          vscode.Uri.parse(`https://generacy.ai/upgrade?tier=${message.targetTier}`)
+          vscode.Uri.parse(`https://app.generacy.ai/upgrade?tier=${message.targetTier}`)
         );
         break;
 
       case 'manageBilling':
         void vscode.env.openExternal(
-          vscode.Uri.parse('https://generacy.ai/billing')
+          vscode.Uri.parse('https://app.generacy.ai/billing')
         );
         break;
 
       case 'inviteMember':
         void vscode.env.openExternal(
-          vscode.Uri.parse('https://generacy.ai/settings/members')
+          vscode.Uri.parse('https://app.generacy.ai/settings/members')
         );
         break;
 

--- a/packages/generacy-extension/src/views/cloud/dashboard/webview.ts
+++ b/packages/generacy-extension/src/views/cloud/dashboard/webview.ts
@@ -325,11 +325,11 @@ function getQuickActionsSection(organization: OrgDashboardData['organization']):
     <section class="card">
       <h2>Quick Actions</h2>
       <div class="quick-actions">
-        <button class="action-btn" onclick="openLink('https://generacy.ai/settings')">
+        <button class="action-btn" onclick="openLink('https://app.generacy.ai/settings')">
           <span class="action-icon">&#x2699;</span>
           <span>Settings</span>
         </button>
-        <button class="action-btn" onclick="openLink('https://generacy.ai/integrations')">
+        <button class="action-btn" onclick="openLink('https://app.generacy.ai/integrations')">
           <span class="action-icon">&#x1F517;</span>
           <span>Integrations</span>
         </button>

--- a/packages/generacy/.agency/credentials.yaml
+++ b/packages/generacy/.agency/credentials.yaml
@@ -1,6 +1,0 @@
-credentials:
-  github-main-org:
-    type: github-app
-    backend: cluster-local
-    status: active
-    updatedAt: 2026-06-08T14:54:50.339Z

--- a/packages/generacy/.agency/credentials.yaml
+++ b/packages/generacy/.agency/credentials.yaml
@@ -1,0 +1,6 @@
+credentials:
+  github-main-org:
+    type: github-app
+    backend: cluster-local
+    status: active
+    updatedAt: 2026-06-08T14:54:50.339Z


### PR DESCRIPTION
Post-apex-cutover cleanup. The extension dashboard linked app pages (settings/billing/upgrade/integrations/settings/members) at `generacy.ai`, which now serves marketing — repointed to `app.generacy.ai`. Marketing/content links (`/pricing`, `/docs`, `/support`) stay on `generacy.ai`. The #55 apex redirects already cover these, so this just removes the redirect hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)