### PR TITLE
fix(cockpit): pass each gh search term as a separate arg

### DIFF
--- a/.changeset/fix-cockpit-gh-search-quoting.md
+++ b/.changeset/fix-cockpit-gh-search-quoting.md
@@ -1,0 +1,9 @@
+---
+"@generacy-ai/cockpit": patch
+---
+
+Fix `cockpit status` / `cockpit watch` listings: pass each `gh search issues`
+term as a separate argument. The query was passed as a single positional arg,
+so gh folded trailing qualifiers into the first one's quoted value (e.g.
+`repo:"o/r is:open"`), producing an invalid query that failed every repo- and
+epic-scoped listing.

--- a/packages/cockpit/src/__tests__/gh-wrapper.test.ts
+++ b/packages/cockpit/src/__tests__/gh-wrapper.test.ts
@@ -60,7 +60,7 @@ describe('GhCliWrapper', () => {
       expect(calls).toHaveLength(1);
       expect(calls[0]?.cmd).toBe('gh');
       const args = calls[0]?.args ?? [];
-      expect(args.slice(0, 3)).toEqual(['search', 'issues', 'repo:o/r is:issue']);
+      expect(args.slice(0, 4)).toEqual(['search', 'issues', 'repo:o/r', 'is:issue']);
       expect(args).toContain('--json');
       expect(args).toContain('number,title,state,labels,url,body,author,createdAt');
       expect(args).toContain('--limit');
@@ -75,6 +75,36 @@ describe('GhCliWrapper', () => {
         body: 'body',
         author: { login: 'alice' },
       });
+    });
+
+    it('splits multi-qualifier queries into separate args (regression: no arg holds spaces)', async () => {
+      const { runner, calls } = stubRunner();
+      const wrapper = new GhCliWrapper(runner);
+      await wrapper.listIssues('repo:o/r is:issue label:epic-child #85');
+      const args = calls[0]?.args ?? [];
+      expect(args.slice(0, 6)).toEqual([
+        'search',
+        'issues',
+        'repo:o/r',
+        'is:issue',
+        'label:epic-child',
+        '#85',
+      ]);
+      // Previously the whole query was passed as one arg, so gh folded the
+      // trailing qualifiers into repo:"o/r is:issue ..." and rejected the query.
+      for (const arg of args) expect(arg).not.toMatch(/\s/);
+    });
+
+    it('keeps quoted phrases as a single arg', async () => {
+      const { runner, calls } = stubRunner();
+      const wrapper = new GhCliWrapper(runner);
+      await wrapper.listIssues('repo:o/r "exact phrase"');
+      expect(calls[0]?.args.slice(0, 4)).toEqual([
+        'search',
+        'issues',
+        'repo:o/r',
+        '"exact phrase"',
+      ]);
     });
 
     it('defaults limit to 100', async () => {

--- a/packages/cockpit/src/gh/wrapper.ts
+++ b/packages/cockpit/src/gh/wrapper.ts
@@ -421,10 +421,15 @@ export class GhCliWrapper implements GhWrapper {
 
   async listIssues(query: string, options: ListIssuesOptions = {}): Promise<Issue[]> {
     const limit = options.limit ?? 100;
+    // `gh search issues` expects each query term/qualifier as its own argument.
+    // Passing the whole query as a single arg makes gh fold trailing qualifiers
+    // into the first one's quoted value (e.g. `repo:"o/r is:open"`), producing an
+    // invalid query. Tokenize on whitespace, keeping "quoted phrases" intact.
+    const terms = query.match(/"[^"]*"|\S+/g) ?? [];
     const args = [
       'search',
       'issues',
-      query,
+      ...terms,
       '--json',
       'number,title,state,labels,url,body,author,createdAt',
       '--limit',


### PR DESCRIPTION
## Problem

`GhCliWrapper.listIssues` passed the entire query string as a **single positional argument** to `gh search issues`:

```ts
const args = ['search', 'issues', query, '--json', …];
```

`gh` reads the leading `repo:` qualifier and folds everything after it — including spaces and trailing qualifiers — into that qualifier's quoted value, yielding an invalid query and a hard failure:

```
$ generacy cockpit status --repos generacy-ai/tetrad-development
cockpit: failed to list issues ...: gh search issues failed (exit 1):
Invalid search query "( repo:"generacy-ai/tetrad-development is:open" ) type:issue".
```

This broke **every** listing path — `cockpit status` and `cockpit watch`, both repo-scoped and epic-scoped (the `resolveEpicIssues` label fallback in `manifest/scoping.ts`).

## Fix

Tokenize the query so each term/qualifier reaches `gh` as its own argument, keeping `"quoted phrases"` intact:

```ts
const terms = query.match(/"[^"]*"|\S+/g) ?? [];
const args = ['search', 'issues', ...terms, '--json', …];
```

## Tests

- Updated the `listIssues` test that had codified the single-arg behavior.
- Added regression coverage: a multi-qualifier query splits into separate args (asserting no arg smuggles a space), plus a quoted-phrase case.
- `pnpm --filter @generacy-ai/cockpit test` → **162 passed**; `build` (tsc) clean.

Found by dogfooding the cockpit against its own epic (generacy-ai/tetrad-development#85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
