### PR TITLE
fix(orchestrator): make boot-resume reachable on wizard clusters (await relayBridge.start() stranded the dispatch)

### DIFF
--- a/.changeset/boot-resume-blocking-relaybridge-start.md
+++ b/.changeset/boot-resume-blocking-relaybridge-start.md
@@ -1,0 +1,24 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+fix(orchestrator): boot-resume never fired on wizard clusters — `await relayBridge.start()` stranded the post-activation dispatch
+
+The `#834` boot-resume was placed after `await relayBridge.start()` in
+`activateInBackground` (the startup path every wizard-provisioned cluster takes,
+since the relay API key is reloaded from disk rather than present in the process
+env). `RelayBridge.start()` awaits `client.connect()`, which is a long-lived
+reconnect loop that only resolves on disconnect — so on a healthy relay the
+`await` never returns and `runPostActivationBranch()` was unreachable dead code.
+The VS Code tunnel therefore never auto-resumed after a `generacy stop`/`start`.
+
+Start the relay bridge fire-and-forget (`relayBridge.start().catch(...)`),
+mirroring the synchronous existing-key path, so the post-activation dispatch
+runs. Verified end-to-end on a live cluster: after an orchestrator restart the
+boot-resume fires and the tunnel reconnects with no manual intervention.
+
+The `#834` regression test could not catch this: its relay-client mock resolved
+`connect()` immediately and its control-plane mock omitted `DockerEngineClient`
+(making `relayBridge` null), so the blocking `start()` path was never exercised.
+The test now keeps `connect()` pending and constructs a non-null bridge, and
+fails if the fix is reverted.

--- a/packages/orchestrator/src/__tests__/server-boot-resume-wizard-branch.test.ts
+++ b/packages/orchestrator/src/__tests__/server-boot-resume-wizard-branch.test.ts
@@ -25,9 +25,20 @@ vi.mock('../activation/index.js', () => ({
 
 vi.mock('@generacy-ai/cluster-relay', () => ({
   ClusterRelayClient: vi.fn().mockImplementation(() => ({
-    connect: vi.fn().mockResolvedValue(undefined),
+    // connect() must stay PENDING to honor the real client's contract: it runs a
+    // long-lived reconnect loop that only resolves on disconnect. A mock that
+    // resolves immediately hides the blocking-await bug where `await
+    // relayBridge.start()` stranded the post-activation dispatch as dead code
+    // (that mock is exactly why the original #834 fix shipped green but broken).
+    connect: vi.fn(() => new Promise<void>(() => {})),
     disconnect: vi.fn().mockResolvedValue(undefined),
     send: vi.fn(),
+    // RelayBridge.start() registers these before awaiting connect(); without
+    // them start() would throw synchronously instead of hanging, masking the
+    // real "start() never resolves while connected" behavior.
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
     isConnected: false,
   })),
 }));
@@ -35,6 +46,11 @@ vi.mock('@generacy-ai/cluster-relay', () => ({
 vi.mock('@generacy-ai/control-plane', () => ({
   TunnelHandler: vi.fn().mockImplementation(() => ({})),
   getCodeServerManager: vi.fn().mockReturnValue(null),
+  // Required so initializeRelayBridge() constructs a NON-null relayBridge and
+  // actually reaches relayBridge.start(). Without it, `new DockerEngineClient()`
+  // throws, initializeRelayBridge swallows it, relayBridge is null, start() is
+  // never called — and the blocking-await path under test is never exercised.
+  DockerEngineClient: vi.fn().mockImplementation(() => ({})),
 }));
 
 vi.mock('../services/boot-resume-service.js', () => ({

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -828,9 +828,17 @@ async function activateInBackground(
 
   onInitialized(relayBridge, conversationManager);
 
-  // Server is already listening — start relay bridge directly
+  // Server is already listening — start relay bridge directly.
+  // Fire-and-forget: relayBridge.start() awaits client.connect(), which is a
+  // long-lived reconnect loop that only resolves on disconnect. Awaiting it
+  // here would strand everything below (identity-split detection, the
+  // post-activation dispatch) as unreachable dead code — the bug that made the
+  // #834 boot-resume never fire on wizard-provisioned clusters. Mirrors the
+  // synchronous existing-key path, which also starts the bridge fire-and-forget.
   if (relayBridge) {
-    await relayBridge.start();
+    relayBridge.start().catch((err) => {
+      server.log.error({ err }, 'Relay bridge start failed');
+    });
   }
 
   // Detect identity split after relay bridge has started (wizard-mode path, #750).


### PR DESCRIPTION
## Summary

Third and final fix in the tunnel-after-stop/start chain (#824 → #834 → this). The VS Code tunnel still didn't auto-resume after `generacy stop`/`start` on wizard-provisioned clusters, despite #834 landing the boot-resume in the correct branch.

**Root cause:** in `activateInBackground` — the startup path *every* wizard cluster takes (the relay API key is reloaded from `/var/lib/generacy/cluster-api-key`, not present in the process env) — the boot-resume dispatch sat after `await relayBridge.start()`:

```ts
if (relayBridge) {
  await relayBridge.start();      // ← never returns on a healthy relay
}
...
await runPostActivationBranch({...})  // unreachable dead code
```

`RelayBridge.start()` awaits `client.connect()` (`relay-bridge.js`), and `connect()` is a `while (running)` reconnect loop whose inner `connectOnce()` only resolves when the WebSocket **closes**. So on a live connection `start()` never resolves, and everything after it — identity-split detection *and* the #834 post-activation dispatch — was unreachable. The synchronous existing-key path already avoids this by starting the bridge fire-and-forget (`server.ts:645`, with the comment *"The background activation path calls relayBridge.start() itself"* — it did, but wrongly awaited it).

**Fix:** start the relay bridge fire-and-forget in `activateInBackground`, mirroring the existing-key path, so `runPostActivationBranch()` runs.

## Why #834's test didn't catch it

The `server-boot-resume-wizard-branch.test.ts` regression test:
- mocked the relay client's `connect()` as `mockResolvedValue(undefined)` (resolves immediately), hiding the never-resolves-while-connected contract; and
- omitted `DockerEngineClient` from the `@generacy-ai/control-plane` mock, so `initializeRelayBridge` threw, `relayBridge` was `null`, and `start()` was never called at all.

Either alone made the blocking-await path unreachable in the test, so it passed green while production hung. This PR keeps `connect()` **pending** and constructs a **non-null** bridge, so the test now exercises the real path — reverting the one-line source fix fails Case 1 and Case 2.

## Verification

**Live cluster (`sniplink`), end-to-end.** Built this branch, injected it into the orchestrator, restarted the container, and observed the boot-resume fire with **no manual intervention**:

```
Boot resume: waiting for control-plane socket
Boot resume: control-plane ready — dispatching lifecycle actions
Boot resume: both lifecycle actions dispatched
```

`code tunnel` came up automatically within ~5s and connected (established `:443` sessions to the Microsoft relay). Before the fix, none of those log lines appeared and no tunnel process existed.

**Automated:**
- `pnpm typecheck` ✅
- `server-boot-resume-wizard-branch.test.ts`, `post-activation-dispatch.test.ts`, `boot-resume-service.test.ts` — 16 passed ✅
- Reverting the source fix ⇒ Case 1 & Case 2 fail (hang on the pending `connect()`), confirming the test is now a real guard.

## Follow-up worth noting

This is the third round where a fix was correct in the abstract but defeated by a real-environment detail the test mocks papered over (wrong branch → then blocking await). The broader lesson for this subsystem: the relay-client and control-plane mocks used in server-startup tests should model the real lifecycle contracts (`connect()` stays pending; `DockerEngineClient` constructs) so startup-ordering bugs can't ship green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
