### PR TITLE
docs(claude): document the changeset CI gate and how to satisfy it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,45 @@ pnpm install
 pnpm dev
 ```
 
+## Changesets (required — CI gate)
+
+**If your diff touches a non-test file under `packages/<pkg>/src/`, the PR must add
+a new `.changeset/*.md` file.** Otherwise CI fails with:
+
+> ::error::This PR modifies packages/*/src/ but adds no changeset.
+
+Speckit phases do **not** generate changesets, so the implement phase must write one
+itself — this is the single most common reason a speckit PR lands red. Add it as part
+of the implementation, not as an afterthought:
+
+```bash
+pnpm changeset            # interactive
+# or hand-write .changeset/<issue-number>-<slug>.md
+```
+
+Rules:
+
+- It must be a **newly added** file in the PR diff (the gate greps `--diff-filter=A`
+  against the base). Editing an existing changeset does not satisfy it.
+- **Test-only** changes under `packages/*/src/` are exempt — the gate skips diffs whose
+  in-scope files are all `*.test.ts` / `*.spec.ts` / `__tests__/`.
+- List **every** package whose non-test `src/` changed. The gate only checks that *some*
+  changeset was added, so a changeset missing a package still passes CI but silently
+  ships that package unreleased — get this right by hand.
+- Bump level: new capability → `minor`; defect fix (`workflow:speckit-bugfix`) → `patch`;
+  new label vocabulary in `workflow-engine` → `minor`.
+- New exports that are **not** re-exported from the package's public `index.ts` are
+  internal surface, not API — still `patch`.
+- Genuinely needs no release (comment-only, or a refactor with no public surface)?
+  `pnpm changeset --empty`.
+- When unsure, copy the shape of a comparable existing changeset in `.changeset/`.
+
+Note: `pnpm changeset status --since=origin/develop` will not see your changeset until
+it is committed (it reads git, not the working tree). Plain `changeset status` reads the
+directory.
+
+Gate definition: `.github/workflows/changeset-bot.yml`.
+
 ## MCP Testing Tools
 
 For browser automation and UI testing, see:


### PR DESCRIPTION
## Summary

Every orchestrator-produced speckit PR lands red on the changeset gate — #932, #933, #936, #938, #944, #945, #946, i.e. **7 for 7** in one sitting. The cause is structural, not a one-off: the speckit phases never generate a changeset, but `changeset-bot` fails any PR whose diff touches non-test files under `packages/*/src/` without adding one. Each of those PRs needed a changeset added by hand before it could merge.

`CLAUDE.md` is loaded into every Claude session in this repo, so this documents the gate where the implement phase will actually see it.

## What's documented

- The exact trigger and the verbatim CI error.
- The `--diff-filter=A` rule — the changeset must be a **newly added** file; editing an existing one doesn't count.
- The test-only exemption (`*.test.ts` / `*.spec.ts` / `__tests__/`).
- Bump-level conventions: capability → `minor`, `workflow:speckit-bugfix` → `patch`, new `workflow-engine` label vocabulary → `minor`, and internal (non-`index.ts`-exported) additions staying `patch`.
- That the gate only checks *some* changeset was added — so one missing a package still passes CI but silently ships that package unreleased.
- The `--empty` escape hatch, and the `changeset status --since` gotcha (it reads git, so it can't see an uncommitted changeset).

Every claim was verified against `.github/workflows/changeset-bot.yml`.

## Notes

Docs-only — touches no `packages/*/src/`, so the changeset gate does not apply to this PR itself.

This addresses the symptom (agents not knowing) rather than the root cause. The stronger fix is for the speckit implement phase to emit a changeset as a task, which is worth considering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)