### PR TITLE
fix(orchestrator): keep wrapped clarification options whole (#948)

### DIFF
--- a/.changeset/948-clarification-options-truncation.md
+++ b/.changeset/948-clarification-options-truncation.md
@@ -1,0 +1,21 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+Fix clarification options being truncated when an option description wraps (#948).
+
+`parseClarifications()` extracted the `**Options**:` block by matching a run of
+consecutive `- ` lines, so the first continuation line ended the block. A
+hard-wrapped option description — or one carrying indented sub-bullets — was
+therefore cut off mid-sentence, and every option after it was silently dropped
+before `postClarifications()` rendered and posted the comment. The human
+answering the gate never saw the missing options.
+
+The block is now delimited the same way `**Context**` and `**Question**` already
+are (to the next `**Field**:` line, `###` heading, or EOF), with continuation
+lines attached to the option above them. Across the 1,440 questions carrying
+options in the repo's shipped `clarifications.md` files, this recovers 17
+dropped options and 6 truncated descriptions.
+
+Comments already posted are unaffected — the poster dedups on its marker and
+will not repost.

--- a/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
@@ -184,6 +184,83 @@ describe('parseClarifications', () => {
     const q2 = questions[1]!;
     expect(q2.options).toBeUndefined();
   });
+
+  // Regression: hard-wrapped option descriptions ended the options block at the
+  // first continuation line, truncating that option mid-sentence and dropping
+  // every option after it. Shape taken from specs/787-epic-generacy-ai-tetrad.
+  it('keeps hard-wrapped option descriptions whole and parses later options', () => {
+    const questions = parseClarifications(`### Q1: Epic scoping flag
+**Context**: Neither verb has a documented way to discover which epic to
+scope to.
+**Question**: How should \`watch\` and \`status\` determine which issues to
+include?
+**Options**:
+- A: Require an \`--epic\` flag on both verbs. Single-epic only;
+  multiple invocations for multiple epics.
+- B: Auto-discover every epic from manifests, scope to the union of all
+  manifest-listed issues. No flag needed.
+- C: Take no epic argument; emit every open issue.
+
+**Answer**: *Pending*
+`);
+
+    const options = questions[0]!.options!;
+    expect(options.map((o) => o.label)).toEqual(['A', 'B', 'C']);
+    expect(options[0]!.description).toContain('multiple invocations for multiple epics.');
+    expect(options[1]!.description).toContain('No flag needed.');
+  });
+
+  // Regression: an option carrying indented sub-bullets truncated identically.
+  // Shape taken from specs/916-found-during-cockpit-v1.
+  it('keeps indented sub-bullets attached to their option', () => {
+    const questions = parseClarifications(`### Q4: Shortened description content
+**Question**: What content shape should the shortened descriptions take?
+**Options**:
+- A: **Terse cause only, keep issue ref**. Examples:
+  - \`blocked:stuck-feedback-loop\`: \`PR-feedback loop paused.\`
+  - \`blocked:stuck-validate-fix\`: \`Validate-fix paused (#892).\`
+- B: **Cause only, no directive**. Slightly terser.
+- C: **Cause + issue ref only**. Very short.
+
+**Answer**: *Pending*
+`);
+
+    const options = questions[0]!.options!;
+    expect(options.map((o) => o.label)).toEqual(['A', 'B', 'C']);
+    expect(options[0]!.description).toContain('blocked:stuck-validate-fix');
+    expect(options[2]!.description).toBe('**Cause + issue ref only**. Very short.');
+  });
+
+  it('parses options separated by blank lines', () => {
+    const questions = parseClarifications(`### Q1: Topic
+**Question**: Which?
+**Options**:
+- A) First option
+
+- B) Second option
+
+**Answer**: *Pending*
+`);
+
+    const options = questions[0]!.options!;
+    expect(options).toEqual([
+      { label: 'A', description: 'First option' },
+      { label: 'B', description: 'Second option' },
+    ]);
+  });
+
+  it('does not absorb the Answer line into the last option', () => {
+    const questions = parseClarifications(`### Q1: Topic
+**Question**: Which?
+**Options**:
+- A) Only option
+**Answer**: Use A
+`);
+
+    expect(questions[0]!.options).toEqual([{ label: 'A', description: 'Only option' }]);
+    expect(questions[0]!.answered).toBe(true);
+    expect(questions[0]!.answer).toBe('Use A');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/orchestrator/src/worker/clarification-poster.ts
+++ b/packages/orchestrator/src/worker/clarification-poster.ts
@@ -274,18 +274,26 @@ export function parseClarifications(content: string): ClarificationQuestion[] {
     const questionMatch = section.match(/\*\*Question\*\*:\s*(.+?)(?=\n\*\*|\n###|$)/s);
     const question = questionMatch ? questionMatch[1]!.trim() : '';
 
-    // Extract options
-    const optionsMatch = section.match(/\*\*Options\*\*:\s*\n((?:- .+\n?)+)/);
+    // Extract options. The block runs to the next `**Field**:` line, `###`
+    // heading, or EOF — the same delimiters Context and Question use above.
+    // An option's description may hard-wrap or carry indented sub-bullets;
+    // such continuation lines belong to the option above them. Matching only
+    // consecutive `- ` lines would end the block at the first continuation,
+    // truncating that option mid-sentence and dropping every option after it.
+    const optionsMatch = section.match(/\*\*Options\*\*:\s*\n([\s\S]+?)(?=\n\*\*|\n###|$)/);
     let options: ClarificationOption[] | undefined;
     if (optionsMatch) {
       options = [];
-      const optionLines = optionsMatch[1]!.trim().split('\n');
-      for (const line of optionLines) {
-        const optMatch = line.match(/^- ([A-Z])[):]\s*(.+)$/);
+      for (const line of optionsMatch[1]!.trim().split('\n')) {
+        const optMatch = line.match(/^- ([A-Z])[):]\s*(.*)$/);
         if (optMatch) {
-          options.push({ label: optMatch[1]!, description: optMatch[2]!.trim() });
+          options.push({ label: optMatch[1]!, description: optMatch[2]! });
+        } else if (options.length > 0) {
+          options[options.length - 1]!.description += `\n${line}`;
         }
       }
+      for (const opt of options) opt.description = opt.description.trim();
+      options = options.filter((opt) => opt.description !== '');
       if (options.length === 0) options = undefined;
     }
 


### PR DESCRIPTION
Fixes #948.

Found during a cockpit auto smoke test on `christrudelpw/snappoll`: the engine posted clarification batches for #3/#4 with an option cut off mid-sentence and the options after it missing. The truncation is baked into the posted comment before cockpit reads it — not a display or MCP issue.

## Root cause

`parseClarifications()` extracted the options block with:

```js
/\*\*Options\*\*:\s*\n((?:- .+\n?)+)/
```

That matches only a run of **consecutive lines starting with `- `**, so the first line that doesn't ends the block. When the clarify agent hard-wraps an option description, the continuation line terminates the match — truncating that option mid-sentence and dropping every option after it. `postClarifications()` then renders the lossy parse via `formatComment()` and posts it.

Both triggering shapes render correctly on GitHub and appear in shipped specs:

**Hard-wrapped** (`specs/787-epic-generacy-ai-tetrad`) — parses to `A` only, truncated at `"Single-epic only;"`; B/C/D dropped:

```
- A: Require an `--epic <owner/repo#NNN>` flag on both verbs. Single-epic only;
  multiple invocations for multiple epics.
- B: Auto-discover every epic from `.generacy/epics/*.yaml` manifests, …
```

**Indented sub-bullets** (`specs/916-found-during-cockpit-v1`) — same failure.

It reproduced intermittently because most batches happen to keep each option on one long line.

`**Context**` and `**Question**` immediately above already delimit on `(?=\n\*\*|\n###|$)` and tolerate wrapping — `**Options**` was the odd one out, which reads as an oversight rather than a decision.

## Fix

Delimit the options block the same way, attaching continuation lines to the option above them. The change is contained: the parsed options are consumed only by `formatComment()` in this same module.

## Verification

The existing fixture only used short single-line options (`- A) OAuth 2.0`), which cannot reproduce this — so I verified against real data rather than trusting the tests that let it ship. Running the **actual patched parser** over all 269 shipped `clarifications.md` files (1,440 questions carrying options):

| | before | after |
|---|---|---|
| options silently dropped | 17 | **0** |
| options truncated mid-description | 6 | **0** |

Also: 857 tests pass across the worker suite (including 4 new regression tests built from both real failing shapes), and `tsc --noEmit` is clean.

## Note for reviewers

This prevents recurrence but does **not** repair batches already posted — `postClarifications()` dedups on its marker and won't repost. snappoll #3/#4 must be answered from the source `clarifications.md`, or the comments deleted to force a repost after this deploys.

Separately, the smoke test also surfaced that snappoll #3's Q3 offered a factually wrong premise. That's the clarify agent inventing content, a different problem, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
