### PR TITLE
fix(cockpit): classify GitHub rate-limit errors as retriable in the doorbell startup-retry

### DIFF
--- a/.changeset/doorbell-ratelimit-retriable.md
+++ b/.changeset/doorbell-ratelimit-retriable.md
@@ -1,0 +1,7 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+fix(cockpit): treat GitHub rate-limit errors as retriable in the doorbell startup-retry classifier
+
+`classifyGhError` did not recognize GitHub rate-limit errors — the GraphQL primary limit surfaces as plain text (`API rate limit already exceeded …`) with no `HTTP 429` marker, and the secondary/abuse limit arrives as `HTTP 403` — so both fell through to `permanent`, causing `generacy cockpit doorbell` to `exit(3)` instead of retrying. Because rate-limiting is the dominant transient `gh` failure on a shared token, a rate-limited `acquireEpicBus`/`resolveEpic` would kill the wake sensor mid-run and drop `/cockpit:auto` to the 5-minute heartbeat. Primary, secondary, and abuse-detection rate-limit messages are now classified retriable, matched before the permanent 401/403 rules so a 403 secondary limit is no longer mistaken for a scope error.

--- a/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/startup-retry.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/startup-retry.test.ts
@@ -63,6 +63,24 @@ describe('classifyGhError', () => {
     }
   });
 
+  it('maps GitHub rate-limit errors → retriable rate-limit (incl. HTTP-403 secondary, before the permanent 403 rule)', () => {
+    for (const message of [
+      // GraphQL primary limit — plain text, no HTTP status (as seen in the wild).
+      'GraphQL: API rate limit already exceeded for installation ID 113597939',
+      // REST primary limit.
+      'API rate limit exceeded for user ID 42',
+      // Secondary limit — arrives as HTTP 403; must NOT be classified permanent.
+      'HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes',
+      // Legacy abuse-detection wording.
+      'You have triggered an abuse detection mechanism',
+    ]) {
+      expect(classifyGhError(makeError(message))).toEqual({
+        kind: 'retriable',
+        hint: 'rate-limit',
+      });
+    }
+  });
+
   it('maps HTTP 401 → permanent bad-credentials', () => {
     expect(classifyGhError(makeError('HTTP 401 Unauthorized'))).toEqual({
       kind: 'permanent',

--- a/packages/generacy/src/cli/commands/cockpit/doorbell/startup-retry.ts
+++ b/packages/generacy/src/cli/commands/cockpit/doorbell/startup-retry.ts
@@ -81,6 +81,21 @@ export function classifyGhError(err: unknown): GhErrorClass {
   if (retriableHttp) {
     return { kind: 'retriable', hint: `http-${retriableHttp[1]}` };
   }
+  // Retriable: GitHub primary/secondary rate limits. These do NOT reliably
+  // surface as "HTTP 429" — the GraphQL primary limit arrives as plain text
+  // ("API rate limit exceeded" / "...rate limit already exceeded...") with no
+  // HTTP status, and the secondary/abuse limit arrives as HTTP 403. They MUST
+  // be matched here, before the permanent 401/403 rules below, or a
+  // rate-limited `gh` call is misclassified as permanent and the doorbell
+  // exit(3)s instead of retrying — the exact failure this envelope exists to
+  // prevent, since rate-limiting is the dominant transient `gh` failure.
+  if (
+    /rate limit (?:already )?exceeded/i.test(message) ||
+    /secondary rate limit/i.test(message) ||
+    /abuse detection/i.test(message)
+  ) {
+    return { kind: 'retriable', hint: 'rate-limit' };
+  }
 
   // Permanent: 401 / Bad credentials.
   if (/\bHTTP\s+401\b/.test(message) || /Bad credentials/i.test(message)) {


### PR DESCRIPTION
## Summary

Fixes the doorbell (`generacy cockpit doorbell` — the `/cockpit:auto` wake sensor) exiting mid-run on a GitHub **rate-limit** error, which drops `/cockpit:auto` back to the 5-minute heartbeat.

`classifyGhError` (in the #980 startup-retry envelope) did not recognize GitHub rate-limit errors as retriable:
- The **GraphQL primary** limit surfaces as plain text — `API rate limit already exceeded for installation ID …` — with **no `HTTP 429`** marker → fell through to `permanent: unknown`.
- The **secondary / abuse** limit arrives as **`HTTP 403`** → matched the permanent `403 → scope-or-sso` rule.

So a rate-limited `acquireEpicBus` / `resolveEpic` returned `permanent` → the doorbell `exit(3)`d instead of entering the retry loop. Because #431 made the auto skill passive (no re-spawn), that dropped `/cockpit:auto` to the heartbeat for the rest of the run. Rate-limiting is the dominant transient `gh` failure on a shared token, so this was the doorbell's most common death.

## Change

Classify primary, secondary, and abuse-detection rate-limit messages as **retriable**, matched **before** the permanent 401/403 rules (so a `403` secondary limit is no longer mistaken for a scope error). `runStartupRetry` already retries retriable errors indefinitely (bounded ~2 min initial window → ~5 min late-retry, staying alive), so this one-classifier fix simply routes rate-limits into the existing recovery path — no control-flow changes.

## Test

Added a `classifyGhError` case covering the GraphQL primary, REST primary, HTTP-403 secondary, and abuse-detection messages. The 403 case also re-pins the ordering against the permanent-403 rule. Full doorbell suite (71 tests) green; `tsc --noEmit`, eslint, and prettier all clean.

## Evidence

Confirmed while dogfooding on a running `snappoll` preview cluster: the doorbell reached `source=smee` and delivered a burst of real-time wakes, then exited after a `gh` rate-limit. The orchestrator's own logs show the exact string this fix now matches:

```
GraphQL: API rate limit already exceeded for installation ID 113597939
```

Follow-up to #980, which shipped the retry envelope but classified rate-limits as permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
