### PR TITLE
fix(onboarding): unblock App Config step + non-blocking label sync

### DIFF
--- a/.changeset/app-config-manifest-readiness.md
+++ b/.changeset/app-config-manifest-readiness.md
@@ -1,0 +1,14 @@
+---
+"@generacy-ai/control-plane": patch
+---
+
+Disambiguate "workspace still cloning" from "cloned, no appConfig declared" in the app-config manifest endpoint.
+
+`GET /control-plane/app-config/manifest` previously returned `null` for both
+states, so the cloud bootstrap UI couldn't tell them apart and had to poll a
+fixed 300s window before falling back to the empty state. The handler now keys
+readiness on the presence of a `.generacy/cluster.yaml` (or `cluster.local.yaml`)
+at the resolved dir: it returns `null` only while the workspace repo hasn't been
+cloned yet, and a non-null empty manifest (`{schemaVersion:'1',env:[],files:[]}`)
+once it's cloned but declares no `appConfig`. The UI can now advance the instant
+the clone lands instead of waiting out the poll window.

--- a/.changeset/async-label-sync-boot.md
+++ b/.changeset/async-label-sync-boot.md
@@ -1,0 +1,14 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+Run repo label sync fire-and-forget after `server.listen()` instead of blocking boot.
+
+`LabelSyncService.syncAll` walks dozens of sequential GitHub label create/update
+calls (~30s on a fresh repo creating ~68 labels) and was `await`ed before the
+server started listening. On a wizard cluster's post-activation self-restart —
+where the label monitor first becomes enabled with the repo present — that kept
+the orchestrator, and therefore the relay and the cloud bootstrap UI, unreachable
+for the entire sync. Label sync now runs in the onReady hook (like the existing
+monitors), so the server becomes ready and reconnects the relay immediately;
+labels sync in the background. Cuts ~30s off the onboarding restart window.

--- a/packages/control-plane/__tests__/routes/app-config.test.ts
+++ b/packages/control-plane/__tests__/routes/app-config.test.ts
@@ -93,7 +93,10 @@ describe('app-config routes', () => {
   });
 
   describe('GET /app-config/manifest', () => {
-    it('returns null when no appConfig in cluster.yaml', async () => {
+    it('returns an empty (non-null) manifest when cluster.yaml exists but declares no appConfig', async () => {
+      // #626: a cloned workspace that declares no appConfig is "ready, empty",
+      // distinct from "still cloning" — so it returns a non-null empty manifest
+      // (not null) and the cloud UI can stop polling immediately.
       await fs.writeFile(
         path.join(generacyDir, 'cluster.yaml'),
         YAML.stringify({ channel: 'stable', workers: 1 }),
@@ -104,7 +107,10 @@ describe('app-config routes', () => {
 
       expect(res.writeHead).toHaveBeenCalledWith(200);
       const body = JSON.parse(res.end.mock.calls[0][0]);
-      expect(body).toBeNull();
+      expect(body).not.toBeNull();
+      expect(body.schemaVersion).toBe('1');
+      expect(body.env).toEqual([]);
+      expect(body.files).toEqual([]);
     });
 
     it('returns parsed appConfig when present', async () => {

--- a/packages/control-plane/src/routes/app-config.ts
+++ b/packages/control-plane/src/routes/app-config.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import type http from 'node:http';
 import path from 'node:path';
 import { z } from 'zod';
@@ -50,6 +51,56 @@ export async function readManifest(): Promise<AppConfig | null> {
   return AppConfigSchema.parse(merged.appConfig);
 }
 
+/** Manifest returned once the workspace is cloned but declares no appConfig. */
+const EMPTY_MANIFEST: AppConfig = AppConfigSchema.parse({ schemaVersion: '1' });
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Readiness-aware manifest read for the cloud bootstrap UI.
+ *
+ * The bare `readManifest()` returns `null` for two different states, which the
+ * cloud UI can't tell apart from a single response:
+ *   - the workspace repo hasn't been cloned yet, and
+ *   - it's cloned but the app declares no `appConfig`.
+ * The UI therefore has to poll a fixed window (300s) before it can safely show
+ * the empty state. This disambiguates them by the presence of a cluster config
+ * file at the resolved `.generacy` dir:
+ *   - `{ ready: false }` — no cluster.yaml / cluster.local.yaml on disk yet
+ *     (still cloning). The handler surfaces this as HTTP-200 `null` so the UI
+ *     keeps polling, exactly as before.
+ *   - `{ ready: true, manifest }` — cloned. `manifest` is the parsed appConfig,
+ *     or an empty (but non-null) manifest when the app declares none, so the UI
+ *     can advance the instant the clone lands instead of waiting out its window.
+ */
+export async function readManifestState(): Promise<
+  { ready: false } | { ready: true; manifest: AppConfig }
+> {
+  const generacyDir = await resolveGeneracyDir();
+  const [canonicalExists, localExists] = await Promise.all([
+    fileExists(path.join(generacyDir, 'cluster.yaml')),
+    fileExists(path.join(generacyDir, 'cluster.local.yaml')),
+  ]);
+
+  if (!canonicalExists && !localExists) {
+    return { ready: false };
+  }
+
+  const { merged } = await readMergedClusterConfig(generacyDir);
+  if (merged.appConfig === undefined || merged.appConfig === null) {
+    return { ready: true, manifest: EMPTY_MANIFEST };
+  }
+
+  return { ready: true, manifest: AppConfigSchema.parse(merged.appConfig) };
+}
+
 // --- Store instances (injected from bin/control-plane.ts) ---
 
 let envStoreInstance: AppConfigEnvStore | undefined;
@@ -98,10 +149,12 @@ export async function handleGetManifest(
   _params: Record<string, string>,
 ): Promise<void> {
   try {
-    const appConfig = await readManifest();
+    const state = await readManifestState();
     res.setHeader('Content-Type', 'application/json');
     res.writeHead(200);
-    res.end(JSON.stringify(appConfig));
+    // Not-ready → `null` so the cloud UI keeps polling; ready → the (possibly
+    // empty) manifest so it can advance immediately.
+    res.end(JSON.stringify(state.ready ? state.manifest : null));
   } catch (err: unknown) {
     res.setHeader('Content-Type', 'application/json');
     res.writeHead(500);

--- a/packages/orchestrator/src/__tests__/server-label-sync-async.test.ts
+++ b/packages/orchestrator/src/__tests__/server-label-sync-async.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Label sync must not block server.listen().
+ *
+ * A wizard cluster restarts itself once after post-activation so entrypoints
+ * re-run with the repo present. On that restart the label monitor is enabled
+ * and `LabelSyncService.syncAll` walks dozens of sequential GitHub label
+ * create/update calls (~30s on a fresh repo). Previously this was `await`ed
+ * before `server.listen()`, so the orchestrator — and therefore the relay and
+ * the cloud bootstrap UI — stayed unreachable for the full sync duration.
+ *
+ * Label sync now runs fire-and-forget in the onReady hook. These tests pin that
+ * contract: the server binds and serves /health even while syncAll is pending
+ * or has rejected.
+ */
+
+import { describe, it, expect, afterEach, vi, type Mock } from 'vitest';
+import { createServer } from '../server.js';
+import { createTestConfig } from '../config/index.js';
+import type { FastifyInstance } from 'fastify';
+import { activate } from '../activation/index.js';
+import { LabelSyncService } from '../services/label-sync-service.js';
+
+// Controllable syncAll so each test drives the pending / rejected states.
+const syncAllMock = vi.fn();
+vi.mock('../services/label-sync-service.js', () => ({
+  LabelSyncService: vi.fn().mockImplementation(() => ({
+    syncAll: syncAllMock,
+  })),
+}));
+
+// Mock activate so the wizard-mode activation path never resolves (relay bridge
+// stays uninitialized) — mirrors server-background-activation.test.ts.
+vi.mock('../activation/index.js', () => ({
+  activate: vi.fn(),
+}));
+
+// Avoid real relay / control-plane connections.
+vi.mock('@generacy-ai/cluster-relay', () => ({
+  ClusterRelayClient: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn(),
+    isConnected: false,
+  })),
+}));
+vi.mock('@generacy-ai/control-plane', () => ({
+  TunnelHandler: vi.fn().mockImplementation(() => ({})),
+  getCodeServerManager: vi.fn().mockReturnValue(null),
+}));
+
+const activateMock = activate as Mock;
+
+function buildConfig(overrides: Partial<Parameters<typeof createTestConfig>[0]> = {}) {
+  return createTestConfig({
+    server: { port: 0, host: '127.0.0.1' },
+    redis: { url: 'redis://127.0.0.1:1' },
+    auth: {
+      enabled: false,
+      providers: [],
+      jwt: { secret: 'test-secret-at-least-32-characters-long', expiresIn: '1h' },
+    },
+    logging: { level: 'error', pretty: false },
+    // repositories.length > 0 activates the label-sync path; labelMonitor stays
+    // false (its default) so no monitor makes real GitHub calls.
+    repositories: [{ owner: 'acme', repo: 'widget' }],
+    relay: {
+      apiKey: undefined, // triggers (mocked) background activation
+      cloudUrl: 'wss://test.example.com/relay',
+    } as any,
+    ...overrides,
+  });
+}
+
+describe('Label sync is fire-and-forget (does not block listen)', () => {
+  let server: FastifyInstance;
+
+  afterEach(async () => {
+    if (server) await server.close();
+    // Clear call history only — restoreAllMocks would wipe the LabelSyncService
+    // class mock implementation, breaking `new LabelSyncService()` in later tests.
+    syncAllMock.mockClear();
+    activateMock.mockClear();
+  });
+
+  it('binds and serves /health while syncAll is still pending', async () => {
+    activateMock.mockReturnValue(new Promise(() => {})); // never resolves
+    // syncAll never resolves: if it were awaited before listen, createServer /
+    // listen would hang and this test would time out.
+    syncAllMock.mockReturnValue(new Promise(() => {}));
+
+    server = await createServer({ config: buildConfig() });
+    await server.listen({ port: 0, host: '127.0.0.1' });
+
+    const response = await server.inject({ method: 'GET', url: '/health' });
+    expect(response.statusCode).toBe(200);
+
+    // Kicked off after the server became ready (fire-and-forget).
+    await vi.waitFor(() => {
+      expect(syncAllMock).toHaveBeenCalledTimes(1);
+    }, { timeout: 2000 });
+  }, 15_000);
+
+  it('keeps serving /health when syncAll rejects', async () => {
+    activateMock.mockReturnValue(new Promise(() => {}));
+    syncAllMock.mockRejectedValue(new Error('GitHub label API failed'));
+
+    server = await createServer({ config: buildConfig() });
+    await server.listen({ port: 0, host: '127.0.0.1' });
+
+    await vi.waitFor(() => {
+      expect(syncAllMock).toHaveBeenCalledTimes(1);
+    }, { timeout: 2000 });
+
+    // Give the rejection handler a tick to run.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const response = await server.inject({ method: 'GET', url: '/health' });
+    expect(response.statusCode).toBe(200);
+  }, 15_000);
+});

--- a/packages/orchestrator/src/server.ts
+++ b/packages/orchestrator/src/server.ts
@@ -240,22 +240,19 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
       })
     : undefined;
 
-  // Sync labels for watched repositories (skip in worker mode)
+  // Label sync for watched repos. Constructed here but RUN fire-and-forget in
+  // the onReady hook (after server.listen), not awaited here: syncAll walks
+  // dozens of sequential GitHub label create/update calls (~30s on a fresh repo
+  // creating ~68 labels), and awaiting it before listen blocks the server from
+  // becoming ready. That is on the critical path of a wizard cluster's
+  // post-activation restart — a blocking sync kept the orchestrator (and thus
+  // the relay + cloud UI) unreachable for the full sync duration. Labels aren't
+  // needed for the server to serve requests, and the label monitor tolerates
+  // definitions being created concurrently (a freshly-cloned repo has no issues
+  // to label yet).
+  let labelSyncService: LabelSyncService | null = null;
   if (!isWorkerMode && config.repositories.length > 0) {
-    const labelSyncService = new LabelSyncService(server.log, createGitHubClient, githubTokenProvider);
-    try {
-      const syncResult = await labelSyncService.syncAll(config.repositories);
-      server.log.info(
-        `Label sync complete: ${syncResult.successfulRepos}/${syncResult.totalRepos} repos succeeded`
-      );
-      if (syncResult.failedRepos > 0) {
-        server.log.warn(`Label sync: ${syncResult.failedRepos} repo(s) failed`);
-      }
-    } catch (error) {
-      server.log.warn(
-        `Label sync failed: ${error instanceof Error ? error.message : String(error)}`
-      );
-    }
+    labelSyncService = new LabelSyncService(server.log, createGitHubClient, githubTokenProvider);
   }
 
   // Initialize Redis client (shared across services)
@@ -948,6 +945,27 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
       }
     } else {
       // Full mode: start monitors, Smee, webhook setup (no dispatcher)
+
+      // Fire-and-forget label sync (see the construction site above): kicked off
+      // after listen so its sequential GitHub API calls never block server-ready.
+      if (labelSyncService) {
+        labelSyncService
+          .syncAll(config.repositories)
+          .then((syncResult) => {
+            server.log.info(
+              `Label sync complete: ${syncResult.successfulRepos}/${syncResult.totalRepos} repos succeeded`
+            );
+            if (syncResult.failedRepos > 0) {
+              server.log.warn(`Label sync: ${syncResult.failedRepos} repo(s) failed`);
+            }
+          })
+          .catch((error) => {
+            server.log.warn(
+              `Label sync failed: ${error instanceof Error ? error.message : String(error)}`
+            );
+          });
+      }
+
       if (labelMonitorService) {
         labelMonitorService.startPolling().catch((error) => {
           server.log.error({ err: error }, 'Label monitor polling failed');


### PR DESCRIPTION
## Why

While bringing up a fresh local cluster, the cluster-setup **App Config** step (step 4/5) kept showing its "Setting up your workspace…" spinner for a long time (~90s felt, longer worst-case) even though the orchestrator logs showed it *connected/ready* well before. Tracing it end-to-end (frontend → cloud API → control-plane → orchestrator boot + a real cluster's logs) surfaced two distinct causes, both fixed here.

## Root causes & fixes

### 1. control-plane — `GET /app-config/manifest` conflated two states
The endpoint returned bare `null` both when the workspace repo **hadn't been cloned yet** and when it was **cloned but declared no `appConfig`**. The cloud bootstrap UI can't distinguish those from a single response, so it polls a fixed **300s** window before falling back to the empty state — a freshly-cloned no-config app could hang the spinner for minutes.

Now readiness is keyed on the presence of `cluster.yaml` / `cluster.local.yaml` at the resolved `.generacy` dir:
- **not cloned yet** → `null` (UI keeps polling, unchanged wire behavior)
- **cloned, no `appConfig`** → non-null empty manifest `{schemaVersion:'1',env:[],files:[]}` → UI advances immediately

No cloud changes needed — the API already forwards a bare manifest and the frontend already renders the empty state on a non-null empty manifest.

### 2. orchestrator — blocking label sync delayed server-ready
`LabelSyncService.syncAll` walks ~68 sequential GitHub label create/update calls (~30s on a fresh repo) and was `await`ed **before `server.listen()`**. On a wizard cluster's post-activation self-restart (where the label monitor first turns on with the repo present) this kept the orchestrator — and therefore the relay reconnect and the cloud UI — unreachable for the entire sync. Measured on a real cluster: label sync `16:19:15.6 → 16:19:49.1`, and "server ready" only fired at `16:19:49.28`.

Label sync now runs fire-and-forget in the `onReady` hook (like the existing monitors), so the server becomes ready and reconnects the relay immediately; labels sync in the background. Cuts ~30s off the onboarding restart window.

## Tests
- control-plane: updated the manifest test so "cluster.yaml exists but no `appConfig`" now asserts a non-null empty manifest; the "cluster.yaml absent → null" case still guards the not-ready path. Full control-plane suite green (527).
- orchestrator: new `server-label-sync-async.test.ts` pins that the server binds and serves `/health` while `syncAll` is pending or has rejected (a never-resolving `syncAll` would hang boot if it were still awaited). Server-boot + label-sync suites green (47).
- Changesets added for both packages (patch).

## Notes / follow-ups (not in this PR)
- The post-activation hook re-runs credential setup + `generacy setup workspace/build` on the 2nd (post-restart) boot before hitting the restart-skip marker (~9s wasted) — worth trimming.
- Replacing the post-activation container self-restart with in-process re-resolution (reload repos/identity + enable the label monitor on a lifecycle signal) would remove the restart entirely — larger change spanning orchestrator + worker entrypoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)