### PR TITLE
fix(orchestrator): loopback-only auth exemption for /cockpit/gates (#1030)

### DIFF
--- a/.changeset/fix-cockpit-gates-loopback-auth.md
+++ b/.changeset/fix-cockpit-gates-loopback-auth.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+fix(orchestrator): stop `/cockpit/gates` open/ack 401ing under `--gates=ui`. The co-located cockpit MCP POSTs gate open/ack over loopback with no API key by design, but the route was behind the global auth middleware and not exempt, so every remote gate 401'd and the plugin fell back to a local `AskUserQuestion` (fatal for headless UI-driven runs). Exempt `/cockpit/gates[/:id/ack]` from API-key auth **only** for a loopback TCP peer (`socket.remoteAddress`, not the spoofable `request.ip`), so the host-published `0.0.0.0` listener never exposes an unauthenticated, cloud-forwarding gate surface to the network.

--- a/packages/orchestrator/src/auth/middleware.ts
+++ b/packages/orchestrator/src/auth/middleware.ts
@@ -32,6 +32,36 @@ export interface AuthMiddlewareOptions {
 }
 
 /**
+ * Routes exempted from API-key auth ONLY when the request originates from the
+ * loopback interface. `/cockpit/gates` (and `/cockpit/gates/:id/ack`) are POSTed
+ * by the co-located cockpit MCP over 127.0.0.1 and carry no API key by design —
+ * the MCP gate client has no key path (see
+ * `packages/generacy/src/cli/commands/cockpit/mcp/gates/client.ts`). The
+ * orchestrator HTTP listener binds `0.0.0.0` (config default) and is
+ * host-published, so these state-mutating, cloud-forwarding routes must NOT be
+ * globally exempt like `skipRoutes`; they are allowed only when the TCP peer is
+ * loopback. Network callers still receive 401.
+ */
+const LOOPBACK_ONLY_EXEMPT_PREFIXES = ['/cockpit/gates'];
+
+/** IPv4/IPv6 loopback forms Node reports for a same-host TCP peer. */
+const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+/**
+ * True when `routePath` is a loopback-only-exempt route AND the request's
+ * un-spoofable TCP peer address is loopback. Uses the raw socket
+ * `remoteAddress` — NOT the trustProxy-derived `request.ip`, which a client
+ * could spoof via `X-Forwarded-For` — because this gates an auth bypass.
+ */
+function isLoopbackExemptRoute(request: FastifyRequest, routePath: string): boolean {
+  if (!LOOPBACK_ONLY_EXEMPT_PREFIXES.some((route) => routePath.startsWith(route))) {
+    return false;
+  }
+  const peer = request.socket?.remoteAddress ?? '';
+  return LOOPBACK_ADDRESSES.has(peer);
+}
+
+/**
  * Create authentication middleware
  */
 export function createAuthMiddleware(options: AuthMiddlewareOptions) {
@@ -56,6 +86,20 @@ export function createAuthMiddleware(options: AuthMiddlewareOptions) {
     if (skipRoutes.some((route) => routePath.startsWith(route))) {
       request.auth = {
         userId: 'anonymous',
+        method: 'api-key',
+        scopes: [],
+      };
+      return;
+    }
+
+    // Loopback-only exemption: the co-located cockpit MCP POSTs gate open/ack
+    // to `/cockpit/gates[/:id/ack]` over 127.0.0.1 with no API key by design.
+    // Exempt these routes ONLY for a loopback TCP peer so the host-published
+    // `0.0.0.0` listener does not expose an unauthenticated, cloud-forwarding
+    // gate surface to the network (a plain `skipRoutes` entry would).
+    if (isLoopbackExemptRoute(request, routePath)) {
+      request.auth = {
+        userId: 'cockpit-mcp-loopback',
         method: 'api-key',
         scopes: [],
       };

--- a/packages/orchestrator/tests/unit/auth/middleware.test.ts
+++ b/packages/orchestrator/tests/unit/auth/middleware.test.ts
@@ -14,6 +14,7 @@ function createMockRequest(overrides: Partial<{
   jwtVerify: () => Promise<unknown>;
   user: unknown;
   auth: unknown;
+  socket: { remoteAddress?: string };
 }> = {}): FastifyRequest {
   const req: Record<string, unknown> = {
     headers: {},
@@ -23,6 +24,9 @@ function createMockRequest(overrides: Partial<{
     jwtVerify: vi.fn().mockRejectedValue(new Error('No JWT configured')),
     user: null,
     auth: undefined,
+    // Default TCP peer is loopback (tests run locally). The loopback-only gate
+    // exemption keys off this un-spoofable socket address, not request.ip.
+    socket: { remoteAddress: '127.0.0.1' },
     ...overrides,
   };
   return req as unknown as FastifyRequest;
@@ -91,6 +95,89 @@ describe('createAuthMiddleware', () => {
         scopes: [],
       });
       expect(reply._statusCode).toBe(0); // no error status set
+    });
+  });
+
+  describe('loopback-only gate exemption (/cockpit/gates)', () => {
+    // The co-located cockpit MCP POSTs gate open/ack over 127.0.0.1 with no API
+    // key by design; the route is exempt ONLY for a loopback TCP peer so the
+    // host-published 0.0.0.0 listener does not expose it to the network.
+    it('exempts /cockpit/gates from a loopback peer (no key required)', async () => {
+      const middleware = createAuthMiddleware({ apiKeyStore, enabled: true });
+      const request = createMockRequest({
+        url: '/cockpit/gates',
+        routeOptions: { url: '/cockpit/gates' },
+        socket: { remoteAddress: '127.0.0.1' },
+      });
+      const reply = createMockReply();
+
+      await middleware(request, reply);
+
+      expect(request.auth).toEqual({
+        userId: 'cockpit-mcp-loopback',
+        method: 'api-key',
+        scopes: [],
+      });
+      expect(reply._statusCode).toBe(0);
+    });
+
+    it('exempts /cockpit/gates/:id/ack from a loopback peer', async () => {
+      const middleware = createAuthMiddleware({ apiKeyStore, enabled: true });
+      const request = createMockRequest({
+        url: '/cockpit/gates/abc123/ack',
+        routeOptions: { url: '/cockpit/gates/:id/ack' },
+        socket: { remoteAddress: '::ffff:127.0.0.1' },
+      });
+      const reply = createMockReply();
+
+      await middleware(request, reply);
+
+      expect(request.auth?.userId).toBe('cockpit-mcp-loopback');
+      expect(reply._statusCode).toBe(0);
+    });
+
+    it('exempts an IPv6 loopback (::1) peer', async () => {
+      const middleware = createAuthMiddleware({ apiKeyStore, enabled: true });
+      const request = createMockRequest({
+        url: '/cockpit/gates',
+        routeOptions: { url: '/cockpit/gates' },
+        socket: { remoteAddress: '::1' },
+      });
+      const reply = createMockReply();
+
+      await middleware(request, reply);
+
+      expect(request.auth?.userId).toBe('cockpit-mcp-loopback');
+      expect(reply._statusCode).toBe(0);
+    });
+
+    it('does NOT exempt /cockpit/gates from a non-loopback peer — 401', async () => {
+      const middleware = createAuthMiddleware({ apiKeyStore, enabled: true });
+      const request = createMockRequest({
+        url: '/cockpit/gates',
+        routeOptions: { url: '/cockpit/gates' },
+        socket: { remoteAddress: '172.17.0.1' }, // docker bridge gateway
+      });
+      const reply = createMockReply();
+
+      await middleware(request, reply);
+
+      expect(reply._statusCode).toBe(401);
+      expect(request.auth).toBeUndefined();
+    });
+
+    it('does NOT exempt a non-gate route even from loopback — 401', async () => {
+      const middleware = createAuthMiddleware({ apiKeyStore, enabled: true });
+      const request = createMockRequest({
+        url: '/workflows',
+        routeOptions: { url: '/workflows' },
+        socket: { remoteAddress: '127.0.0.1' },
+      });
+      const reply = createMockReply();
+
+      await middleware(request, reply);
+
+      expect(reply._statusCode).toBe(401);
     });
   });
 


### PR DESCRIPTION
Fixes generacy-ai/generacy#1030. Part of the Cockpit Remote Gates epic (generacy-ai/generacy-cloud#850); unblocks the agency#450 dogfood.

## Problem

Under `--gates=ui`, the co-located cockpit MCP POSTs gate open/ack to `POST /cockpit/gates[/:id/ack]` over `127.0.0.1` with **no API key** (the MCP gate client has no key path by design — these are "localhost" routes per the plan). But the route sits behind the orchestrator's global `authMiddleware` and is not in `skipRoutes`, so every gate 401'd (`urn:generacy:error:unauthorized`) and the plugin fell back to a local `AskUserQuestion` — fatal for headless UI-driven runs. See #1030 for the full trace (401 is orchestrator-local, `ip:127.0.0.1`, 1.14 ms — not cloud activation).

## Why not a plain `skipRoutes` entry

The orchestrator HTTP listener binds `0.0.0.0` (config default `server.host`) and is host-published, so a blanket exemption would expose an unauthenticated, state-mutating, cloud-forwarding gate surface to the network.

## Fix

Exempt `/cockpit/gates[/:id/ack]` from API-key auth **only** when the request's un-spoofable TCP peer (`socket.remoteAddress`, **not** the trustProxy-derived `request.ip`) is loopback (`127.0.0.1` / `::1` / `::ffff:127.0.0.1`). The co-located MCP already calls from loopback; network callers still 401. Non-gate routes are unaffected.

## Changes

- `packages/orchestrator/src/auth/middleware.ts` — `isLoopbackExemptRoute` helper + loopback gate in `authMiddleware`.
- `packages/orchestrator/tests/unit/auth/middleware.test.ts` — 5 new cases (loopback allow for gate + ack + `::1`; non-loopback 401; non-gate-from-loopback 401). **20/20 pass.**
- changeset (`@generacy-ai/orchestrator` patch).

## Verification

- [x] `vitest run tests/unit/auth/middleware.test.ts` → 20 passed.
- [ ] End-to-end: `--gates=ui` opens gates in the generacy.ai inbox on an auth-enabled cluster (re-run after publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
