### PR TITLE
fix(cockpit-mcp): real input schema for cockpit_gate_open (#1032)

### DIFF
--- a/.changeset/fix-cockpit-gate-open-input-schema.md
+++ b/.changeset/fix-cockpit-gate-open-input-schema.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+fix(cockpit-mcp): give `cockpit_gate_open` a real input schema so `--gates=ui` stops 401/invalid-args'ing. `GateRecordSchema` was a `z.record().and(z.object({}).passthrough())` intersection, which has no `.shape` — so the MCP SDK advertised an **empty** input schema for the tool. With no declared property types, the tool-call boundary stringified the typed `generation` (number) and `scope` (object) fields, and the orchestrator's authoritative `GateOpenSchema` rejected the envelope as `invalid-args`. Replace it with a flat `z.object({...}).passthrough()` that types the fields (mirroring `GateOpenSchema`, but leniently so it never rejects an envelope the orchestrator would accept). Adds a regression pin.

--- a/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-open.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-open.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 import { cockpitGateOpen } from '../tools/cockpit_gate_open.js';
+import { CockpitGateOpenInputSchema } from '../schemas.js';
 
 function jsonResponse(status: number, body: unknown, text?: string): Response {
   return new Response(text ?? (body === undefined ? '' : JSON.stringify(body)), {
@@ -21,11 +22,15 @@ const BASE_DEPS = {
   orchestratorTimeoutMs: 5000,
 };
 
+// A realistic gate-open envelope matching the authoritative GateOpenSchema:
+// `generation` is a number and `scope` is an object (the two fields whose
+// mistyping caused the empty-input-schema stringification bug).
 const CANONICAL_GATE: Record<string, unknown> = {
-  kind: 'clarification-review',
-  scope: 'generacy-ai/generacy#1022',
-  phase: 'clarify',
+  kind: 'gate-open',
+  gateId: 'g_1022',
   generation: 1,
+  scope: { kind: 'clarification-review', ref: 'generacy-ai/generacy#1022', phase: 'clarify' },
+  openedAt: '2026-07-22T00:00:00.000Z',
 };
 
 describe('cockpit_gate_open parity (#1022)', () => {
@@ -164,5 +169,48 @@ describe('cockpit_gate_open parity (#1022)', () => {
     if (result.status !== 'error') return;
     expect(result.class).toBe('internal');
     expect(result.detail).toBe('orchestrator returned malformed gate-open response');
+  });
+});
+
+describe('cockpit_gate_open input schema — empty-schema/stringification regression', () => {
+  // Root cause of the invalid-args bug: GateRecordSchema was a
+  // `z.record().and(z.object({}).passthrough())` intersection. A ZodIntersection
+  // has no `.shape`, so the MCP SDK advertised an EMPTY input schema and the
+  // tool-call boundary stringified the typed `generation` (number) and `scope`
+  // (object) fields; the orchestrator then rejected them as invalid-args.
+  it('is a flat object schema exposing a .shape with generation + scope', () => {
+    const shape = (
+      CockpitGateOpenInputSchema as unknown as { shape?: Record<string, unknown> }
+    ).shape;
+    expect(shape, 'gate-open input schema must be a flat z.object with a .shape').toBeDefined();
+    expect(Object.keys(shape ?? {})).toEqual(
+      expect.arrayContaining(['gateId', 'generation', 'scope', 'openedAt']),
+    );
+  });
+
+  it('accepts a valid envelope, preserving generation:number and scope:object', () => {
+    const parsed = CockpitGateOpenInputSchema.safeParse({
+      kind: 'gate-open',
+      gateId: 'g_1',
+      generation: 2,
+      scope: { ref: 'o/r#1' },
+      openedAt: '2026-07-22T00:00:00.000Z',
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const data = parsed.data as Record<string, unknown>;
+    expect(typeof data.generation).toBe('number');
+    expect(typeof data.scope).toBe('object');
+  });
+
+  it('rejects a stringified generation (the mistyping the bug produced)', () => {
+    const parsed = CockpitGateOpenInputSchema.safeParse({
+      kind: 'gate-open',
+      gateId: 'g_1',
+      generation: '2',
+      scope: { ref: 'o/r#1' },
+      openedAt: '2026-07-22T00:00:00.000Z',
+    });
+    expect(parsed.success).toBe(false);
   });
 });

--- a/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
@@ -17,12 +17,34 @@
 import { z } from 'zod';
 
 /**
- * Caller-supplied gate record. Local schema is a passthrough object so the
- * orchestrator remains the sole authority on `GateRecord` shape.
+ * Caller-supplied gate record. MUST be a flat `z.object({...}).passthrough()`
+ * — NOT a `z.record().and(...)` intersection.
+ *
+ * An intersection has no `.shape`, so the MCP SDK advertised an EMPTY input
+ * schema for `cockpit_gate_open`. With no declared property types, the tool-
+ * call boundary stringified the typed `generation` (number) and `scope`
+ * (object) fields, and the orchestrator's authoritative `GateOpenSchema`
+ * rejected the envelope as `invalid-args`. Enumerating the fields with their
+ * true types makes the SDK advertise a real schema so the harness sends
+ * numbers as numbers and objects as objects.
+ *
+ * Field types mirror `@generacy-ai/cockpit`'s `GateOpenSchema` (the sole
+ * authority the orchestrator validates against) but stay intentionally more
+ * lenient — `kind` is a plain string (not the `'gate-open'` literal),
+ * `openedAt` is a plain string (not `.datetime()`) — so this boundary never
+ * rejects an envelope the orchestrator would accept. `.passthrough()` still
+ * forwards unknown fields verbatim, keeping the orchestrator the sole
+ * authority on the full `GateRecord` shape.
  */
 export const GateRecordSchema = z
-  .record(z.unknown())
-  .and(z.object({}).passthrough());
+  .object({
+    kind: z.string().optional(),
+    gateId: z.string().min(1),
+    generation: z.number().int().nonnegative(),
+    scope: z.object({}).passthrough(),
+    openedAt: z.string(),
+  })
+  .passthrough();
 export type GateRecord = z.infer<typeof GateRecordSchema>;
 
 /**


### PR DESCRIPTION
Fixes generacy-ai/generacy#1032. Third blocker in the `--gates=ui` remote-gates path, unmasked once the orchestrator 401 (#1031) was fixed. Part of epic generacy-ai/generacy-cloud#850; unblocks agency#450.

## Problem

`cockpit_gate_open`'s input schema was a `z.record().and(z.object({}).passthrough())` **intersection** — which has no `.shape`, so the MCP SDK advertised an **empty** input schema. With no declared property types, the tool-call boundary stringified the typed `generation` (number) and `scope` (object) fields, and the orchestrator's `GateOpenSchema` rejected the envelope as `invalid-args`.

## Fix

Flat `z.object({ kind?, gateId, generation: number, scope: object, openedAt }).passthrough()` — types mirror the authoritative `GateOpenSchema` but stay lenient (`kind`/`openedAt` plain strings) so this boundary never rejects an envelope the orchestrator would accept; `.passthrough()` keeps the orchestrator the sole shape authority.

## Changes

- `mcp/gates/schemas.ts` — `GateRecordSchema` → flat typed object.
- `mcp/__tests__/parity-gate-open.test.ts` — realistic envelope fixture + 3 regression pins (schema exposes `.shape` with typed `generation`/`scope`; rejects a stringified `generation`).
- changeset (`@generacy-ai/generacy` patch).

## Verification

- [x] 69 MCP gate tests pass (`parity-gate-open`, `parity-gate-ack`, `tool-schema-audit`, gate `client`).

## Note

#1032 also documents a **related** `cockpit_gate_ack` envelope mismatch (missing `kind`/`generation`/`ackedAt` vs `GateAckSchema`) that will surface next — cross-repo, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
