### PR TITLE
fix(cockpit-mcp): cockpit_gate_ack builds the full ack envelope (#1034)

### DIFF
--- a/.changeset/fix-cockpit-gate-ack-envelope.md
+++ b/.changeset/fix-cockpit-gate-ack-envelope.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+fix(cockpit-mcp): `cockpit_gate_ack` now builds the full ack envelope the orchestrator requires. It POSTed only `{ outcome, detail? }`, but the orchestrator's authoritative `GateAckSchema` (`@generacy-ai/cockpit`) requires `{ kind:'gate-ack', gateId, generation:number, outcome, ackedAt }` — so gate resolution 400'd after a gate opened. The ack tool input now takes `generation` (the answered delivery's generation, which the cloud's `upsertGate` stale-guard needs), and the tool builds `{ kind:'gate-ack', gateId, generation, outcome, ackedAt: now, detail? }`. Part of the gate wire-contract reconciliation (#1034); pairs with the agency plugin passing `generation` to the ack.

--- a/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-ack.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-ack.test.ts
@@ -19,6 +19,7 @@ const BASE_DEPS = {
 
 const CANONICAL_INPUT = {
   gateId: 'gate_01HK7Z',
+  generation: 1,
   outcome: 'approved',
 };
 
@@ -170,9 +171,9 @@ describe('cockpit_gate_ack parity (#1022)', () => {
     expect(result.detail).toMatch(/timed out after 15ms/);
   });
 
-  it('detail present + happy path → wire body contains {outcome, detail} verbatim', async () => {
+  it('detail present + happy path → wire body carries outcome + detail (in the full envelope)', async () => {
     const spy = vi.fn(async () => jsonResponse(200, { ok: true }));
-    const input = { gateId: 'g_5', outcome: 'approved', detail: 'batch 1 answers look correct' };
+    const input = { gateId: 'g_5', generation: 1, outcome: 'approved', detail: 'batch 1 answers look correct' };
     const result = await cockpitGateAck(input, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -180,18 +181,61 @@ describe('cockpit_gate_ack parity (#1022)', () => {
     expect(result.status).toBe('ok');
     // Verify the URL includes the encoded gateId.
     expect(spy.mock.calls[0]?.[0]).toBe('http://mock.local/cockpit/gates/g_5/ack');
-    // Verify the wire body carries {outcome, detail}, not gateId.
+    // Verify the wire body carries outcome + detail (gateId travels in the path).
     const init = spy.mock.calls[0]?.[1] as RequestInit;
     const body = JSON.parse(String(init.body));
-    expect(body).toEqual({ outcome: 'approved', detail: 'batch 1 answers look correct' });
+    expect(body.outcome).toBe('approved');
+    expect(body.detail).toBe('batch 1 answers look correct');
+    expect(body.gateId).toBeUndefined();
   });
 
   it('encodes gateId in URL path', async () => {
     const spy = vi.fn(async () => jsonResponse(200, {}));
-    await cockpitGateAck({ gateId: 'g/with spaces', outcome: 'approved' }, {
+    await cockpitGateAck({ gateId: 'g/with spaces', generation: 1, outcome: 'approved' }, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
     expect(spy.mock.calls[0]?.[0]).toBe('http://mock.local/cockpit/gates/g%2Fwith%20spaces/ack');
+  });
+});
+
+describe('cockpit_gate_ack envelope (GateAckSchema reconciliation)', () => {
+  // The orchestrator's authoritative GateAckSchema requires
+  // { kind:'gate-ack', gateId, generation:number, outcome, ackedAt }.
+  // The tool must build that full envelope from the caller's
+  // { gateId, generation, outcome, detail? } — gateId in the path, kind +
+  // ackedAt added here — or gate resolution 400s.
+  it('POSTs a full envelope: kind=gate-ack, generation (number), outcome, ackedAt', async () => {
+    let sentBody: unknown;
+    const spy = vi.fn(async (_url: string, init: RequestInit) => {
+      sentBody = JSON.parse(String(init.body));
+      return jsonResponse(200, { accepted: true });
+    });
+    const result = await cockpitGateAck(
+      { gateId: 'g_1', generation: 3, outcome: 'applied', detail: 'ok' },
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
+    expect(result.status).toBe('ok');
+    const body = sentBody as Record<string, unknown>;
+    expect(body.kind).toBe('gate-ack');
+    expect(body.generation).toBe(3);
+    expect(typeof body.generation).toBe('number');
+    expect(body.outcome).toBe('applied');
+    expect(typeof body.ackedAt).toBe('string');
+    expect(body.detail).toBe('ok');
+    // gateId travels in the path, not the body.
+    expect(body.gateId).toBeUndefined();
+  });
+
+  it('missing generation → invalid-args (no fetch)', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true }));
+    const result = await cockpitGateAck(
+      { gateId: 'g_1', outcome: 'applied' } as unknown,
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('invalid-args');
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
@@ -48,12 +48,20 @@ export const GateRecordSchema = z
 export type GateRecord = z.infer<typeof GateRecordSchema>;
 
 /**
- * Strict three-field ack input. `.strict()` catches typos (`gate_id` vs
- * `gateId`) at the tool boundary with a clear `invalid-args` error.
+ * Ack input. `.strict()` catches typos (`gate_id` vs `gateId`) at the tool
+ * boundary with a clear `invalid-args` error.
+ *
+ * `generation` is REQUIRED: the orchestrator's authoritative `GateAckSchema`
+ * (`@generacy-ai/cockpit`) needs it, and the cloud's `upsertGate` uses it for
+ * the stale-generation no-op guard (a lower generation is dropped). The
+ * caller passes the answered delivery's `generation`; the tool then builds the
+ * full `{ kind:'gate-ack', gateId, generation, outcome, ackedAt, detail? }`
+ * envelope (adding `kind` + `ackedAt`).
  */
 export const GateAckInputSchema = z
   .object({
     gateId: z.string().min(1),
+    generation: z.number().int().nonnegative(),
     outcome: z.string().min(1),
     detail: z.string().optional(),
   })

--- a/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_ack.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_ack.ts
@@ -29,7 +29,21 @@ export function cockpitGateAck(
     }
 
     const options = resolveGateOptions(deps);
-    const body: { outcome: string; detail?: string } = { outcome: parsed.data.outcome };
+    // Build the full gate-ack envelope the orchestrator's GateAckSchema
+    // requires. `gateId` travels in the path; `kind` and `ackedAt` are added
+    // here (the caller supplies gateId/generation/outcome/detail?).
+    const body: {
+      kind: 'gate-ack';
+      generation: number;
+      outcome: string;
+      ackedAt: string;
+      detail?: string;
+    } = {
+      kind: 'gate-ack',
+      generation: parsed.data.generation,
+      outcome: parsed.data.outcome,
+      ackedAt: new Date().toISOString(),
+    };
     if (parsed.data.detail !== undefined) body.detail = parsed.data.detail;
 
     return invokeGate<CockpitGateAckData>(


### PR DESCRIPTION
Blocker #4 in the `--gates=ui` remote-gate path (agency#450 dogfood). Part of the wire-contract reconciliation generacy-ai/generacy#1034. **Pairs with generacy-ai/agency (plugin passes `generation`) — both must land + publish.**

## Problem

`cockpit_gate_ack` POSTed only `{ outcome, detail? }`, but the orchestrator's authoritative `GateAckSchema` (`@generacy-ai/cockpit`) requires `{ kind:'gate-ack', gateId, generation:number, outcome, ackedAt }`. So once a gate finally opens (after #1031 + #1033), **resolving it 400s**.

## Fix

- `GateAckInputSchema` gains `generation` (the answered delivery's generation — the cloud's `upsertGate` stale-guard needs it).
- The tool builds the full envelope: `{ kind:'gate-ack', gateId, generation, outcome, ackedAt: now, detail? }` (`gateId` in the path; `kind` + `ackedAt` added by the tool).

## Changes

- `mcp/gates/schemas.ts`, `mcp/tools/cockpit_gate_ack.ts` — accept generation, build envelope.
- `mcp/__tests__/parity-gate-ack.test.ts` — fixture + 2 regression pins (full-envelope body; missing-generation → invalid-args).
- changeset (`@generacy-ai/generacy` patch).

## Verification

- [x] 71 MCP gate tests pass (`parity-gate-ack`, `parity-gate-open`, `tool-schema-audit`, `client`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
