### PR TITLE
fix(cockpit): conform gate wire contract to frozen spec (#1034)

### DIFF
--- a/.changeset/1034-gate-wire-contract-reconcile.md
+++ b/.changeset/1034-gate-wire-contract-reconcile.md
@@ -1,0 +1,49 @@
+---
+"@generacy-ai/cockpit": patch
+"@generacy-ai/orchestrator": patch
+"@generacy-ai/generacy": patch
+---
+
+fix(cockpit): conform the gate wire contract to the frozen spec (#1034).
+
+The `packages/cockpit/src/gates/` module previously shipped an invented gate
+wire envelope (`kind`-discriminated, `scope`-wrapped, with a `gate-ack`
+sub-event and a nested-`answer` down-path) that matched **neither** the frozen
+authoritative contract in
+`tetrad-development/docs/cockpit-remote-gates-plan.md § "Wire contracts"` **nor**
+the generacy-cloud receiver (`gates-wire.md` Shapes 1/2/3), which dispatches on
+`data.type` and log-drops any unknown subtype. Net effect: the orchestrator's
+own `GateOpenSchema` rejected the plugin's `cockpit_gate_open` call, and even a
+patched frame would have been silently dropped cloud-side (`data.type ===
+undefined`) — no gate ever reached the operator inbox. This supersedes the
+envelope portions of #1032/#1033 (gate-open `scope`) and the gate-ack work
+(#1035), which refined the wrong shape.
+
+Now conformant to the frozen contract (the cloud is the authoritative
+receiver/sender; these schemas mirror it field-for-field):
+
+- **Schema module** (`packages/cockpit/src/gates/`): `GateOpenSchema`
+  (`type:'gate-open'`, flat — `gateKey`, `gateType` enum, `title`/`body`/
+  `options`/`allowFreeText`/`sessionId`/`askedAt`, 24-hex `gateId`),
+  `GateOutcomeSchema` (`type:'gate-outcome'` — THE ACK, replaces `GateAckSchema`),
+  `GateAnswerSchema` (down-path `type:'gate-answer'`, flat `optionId`/`freeText`/
+  `actor`, both `freeText` and `actor.email`/`actor.displayName` **nullable** to
+  match what the cloud sends). Adds `deriveGateKey`/`deriveGateId`
+  (`sha256(gateKey)[:24]`). Removes the dead `GateAckSchema` /
+  `GateAnswerEnvelopeSchema`.
+- **Orchestrator** (`routes/cockpit-gates.ts`, `routes/cockpit-answers.ts`): the
+  `/ack` route now stamps `type:'gate-outcome'` (path-authoritative `gateId`,
+  defaulted `at`) instead of emitting a `gate-ack`; the emitted relay `data`
+  carries `type` as the cloud sub-event discriminator; `/cockpit/answers`
+  validates the frozen flat `GateAnswerSchema` (24-hex `gateId`) before append.
+- **MCP tools**: `cockpit_gate_open` now **derives** `gateKey`+`gateId` in TS
+  and self-validates the assembled frozen record before POSTing (the plugin/LLM
+  never hand-builds a sha256); `cockpit_gate_ack` assembles a `gate-outcome`.
+- **Doorbell**: the answers tailer parses the frozen flat down-path line
+  (`type`/`gateKey`/flat `optionId`/`freeText`/`actor`); repo-scope filter keys
+  on the `gateKey` issue-ref (owner/repo, child-issue numbers pass).
+
+Known follow-up: cross-repo child-issue answers are dropped by the tailer's
+owner/repo scope filter (documented inline; cross-repo remote gates are not yet
+exercised). Pairs with the `@generacy-ai/claude-plugin-cockpit` change that
+emits the frozen record shape.

--- a/packages/cockpit/src/__tests__/gates-id.test.ts
+++ b/packages/cockpit/src/__tests__/gates-id.test.ts
@@ -2,14 +2,20 @@ import { describe, expect, it } from 'vitest';
 import { deriveGateId, deriveGateKey } from '../gates/index.js';
 
 describe('deriveGateKey', () => {
-  it('emits `<owner>/<repo>#<number>:<gateType>:<generation>` verbatim', () => {
-    const key = deriveGateKey({
-      issueRef: { owner: 'generacy-ai', repo: 'generacy', number: 1020 },
-      gateType: 'artifact-review',
-      generation: 'spec-review:abc1234',
-    });
+  it('emits `<issueRef>:<gateType>:<generation>` verbatim (issueRef already owner/repo#N)', () => {
+    const key = deriveGateKey(
+      'generacy-ai/generacy#1020',
+      'artifact-review',
+      'spec-review:abc1234',
+    );
     expect(key).toBe('generacy-ai/generacy#1020:artifact-review:spec-review:abc1234');
     expect(key).toMatch(/^[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+#\d+:[a-z-]+:.+$/);
+  });
+
+  it('coerces a numeric generation to string', () => {
+    expect(deriveGateKey('generacy-ai/generacy#1000', 'phase-queue', 2)).toBe(
+      'generacy-ai/generacy#1000:phase-queue:2',
+    );
   });
 });
 
@@ -34,24 +40,16 @@ describe('deriveGateId', () => {
   });
 
   it('changes when gateType changes (d)', () => {
-    const issueRef = { owner: 'generacy-ai', repo: 'generacy', number: 1020 };
-    const a = deriveGateId(
-      deriveGateKey({ issueRef, gateType: 'artifact-review', generation: 'x' }),
-    );
-    const b = deriveGateId(
-      deriveGateKey({ issueRef, gateType: 'implementation-review', generation: 'x' }),
-    );
+    const issueRef = 'generacy-ai/generacy#1020';
+    const a = deriveGateId(deriveGateKey(issueRef, 'artifact-review', 'x'));
+    const b = deriveGateId(deriveGateKey(issueRef, 'implementation-review', 'x'));
     expect(a).not.toBe(b);
   });
 
   it('changes when generation changes (d)', () => {
-    const issueRef = { owner: 'generacy-ai', repo: 'generacy', number: 1020 };
-    const a = deriveGateId(
-      deriveGateKey({ issueRef, gateType: 'artifact-review', generation: 'g1' }),
-    );
-    const b = deriveGateId(
-      deriveGateKey({ issueRef, gateType: 'artifact-review', generation: 'g2' }),
-    );
+    const issueRef = 'generacy-ai/generacy#1020';
+    const a = deriveGateId(deriveGateKey(issueRef, 'artifact-review', 'g1'));
+    const b = deriveGateId(deriveGateKey(issueRef, 'artifact-review', 'g2'));
     expect(a).not.toBe(b);
   });
 });

--- a/packages/cockpit/src/__tests__/gates-schemas.test.ts
+++ b/packages/cockpit/src/__tests__/gates-schemas.test.ts
@@ -1,111 +1,122 @@
 import { describe, expect, it } from 'vitest';
 import {
-  GateRecordSchema,
+  GateOpenSchema,
   GateAnswerSchema,
+  GateOutcomeSchema,
   MALFORMED_FIXTURES,
   VALID_ANSWER_FIXTURES,
+  VALID_ACK_FIXTURES,
   VALID_FIXTURES,
   GATE_TYPES,
 } from '../gates/index.js';
 
 describe('gates wire-contract schemas', () => {
-  describe('GateRecord round-trip (a)', () => {
+  describe('gate-open round-trip (a)', () => {
     it.each([...GATE_TYPES])('round-trips %s fixture through JSON', (gateType) => {
       const fixture = VALID_FIXTURES[gateType];
-      const parsed = GateRecordSchema.parse(JSON.parse(JSON.stringify(fixture)));
+      const parsed = GateOpenSchema.parse(JSON.parse(JSON.stringify(fixture)));
       expect(parsed).toEqual(fixture);
     });
   });
 
-  describe('malformed rejection (b)', () => {
-    it('missing-description rejects and names the offending field', () => {
-      expect(() => GateRecordSchema.parse(MALFORMED_FIXTURES['missing-description'])).toThrow(
-        /description/,
-      );
+  describe('gate-outcome + gate-answer fixtures parse (a2)', () => {
+    it.each([...GATE_TYPES])('answer fixture %s parses', (gateType) => {
+      expect(() => GateAnswerSchema.parse(VALID_ANSWER_FIXTURES[gateType])).not.toThrow();
     });
 
-    it('empty-gate-id rejects', () => {
-      expect(() => GateRecordSchema.parse(MALFORMED_FIXTURES['empty-gate-id'])).toThrow();
-    });
-
-    it('unknown-gate-type rejects', () => {
-      expect(() =>
-        GateRecordSchema.parse(MALFORMED_FIXTURES['unknown-gate-type']),
-      ).toThrow();
-    });
-
-    it('non-hex-gate-id-prefix rejects', () => {
-      expect(() =>
-        GateRecordSchema.parse(MALFORMED_FIXTURES['non-hex-gate-id-prefix']),
-      ).toThrow();
-    });
-
-    it('invalid-issue-url rejects', () => {
-      expect(() =>
-        GateRecordSchema.parse(MALFORMED_FIXTURES['invalid-issue-url']),
-      ).toThrow();
-    });
-
-    it('record-missing-title rejects and names title', () => {
-      expect(() =>
-        GateRecordSchema.parse(MALFORMED_FIXTURES['record-missing-title']),
-      ).toThrow(/title/);
+    it.each(['applied', 'superseded', 'failed'] as const)('outcome fixture %s parses', (k) => {
+      expect(() => GateOutcomeSchema.parse(VALID_ACK_FIXTURES[k])).not.toThrow();
     });
   });
 
-  describe('allowFreeText invariant (c)', () => {
-    it('allowFreeText:false is rejected (Q4)', () => {
+  describe('malformed rejection (b)', () => {
+    it('wrong-type-literal rejects and names type', () => {
+      const r = GateOpenSchema.safeParse(MALFORMED_FIXTURES['wrong-type-literal']);
+      expect(r.success).toBe(false);
+      if (!r.success) expect(r.error.issues.some((i) => i.path.includes('type'))).toBe(true);
+    });
+
+    it('option-missing-id rejects', () => {
+      expect(() => GateOpenSchema.parse(MALFORMED_FIXTURES['option-missing-id'])).toThrow();
+    });
+
+    it('empty-gate-id rejects', () => {
+      expect(() => GateOpenSchema.parse(MALFORMED_FIXTURES['empty-gate-id'])).toThrow();
+    });
+
+    it('wrong-length-gate-id rejects', () => {
+      expect(() => GateOpenSchema.parse(MALFORMED_FIXTURES['wrong-length-gate-id'])).toThrow();
+    });
+
+    it('unknown-gate-type rejects', () => {
+      expect(() => GateOpenSchema.parse(MALFORMED_FIXTURES['unknown-gate-type'])).toThrow();
+    });
+
+    it('invalid-issue-url rejects', () => {
+      expect(() => GateOpenSchema.parse(MALFORMED_FIXTURES['invalid-issue-url'])).toThrow();
+    });
+
+    it('record-missing-title rejects and names title', () => {
+      expect(() => GateOpenSchema.parse(MALFORMED_FIXTURES['record-missing-title'])).toThrow(
+        /title/,
+      );
+    });
+  });
+
+  describe('allowFreeText is a plain boolean (c)', () => {
+    it('allowFreeText:false is ACCEPTED (frozen contract: z.boolean, not literal true)', () => {
+      const ok = { ...VALID_FIXTURES.clarification, allowFreeText: false };
+      expect(() => GateOpenSchema.parse(ok)).not.toThrow();
+    });
+
+    it('allow-free-text-non-boolean rejects and names allowFreeText', () => {
       expect(() =>
-        GateRecordSchema.parse(MALFORMED_FIXTURES['allow-free-text-false']),
+        GateOpenSchema.parse(MALFORMED_FIXTURES['allow-free-text-non-boolean']),
       ).toThrow(/allowFreeText/);
     });
   });
 
-  describe('GateAnswer refine (d)', () => {
-    it('optionId=null with empty freeText fails with the exact refine message', () => {
-      const result = GateAnswerSchema.safeParse(
-        MALFORMED_FIXTURES['answer-null-option-empty-free-text'],
-      );
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        const messages = result.error.issues.map((issue) => issue.message);
-        expect(messages).toContain('optionId=null requires a non-empty freeText');
-      }
-    });
-
-    it('optionId=null with a non-empty freeText passes', () => {
-      const answer = VALID_ANSWER_FIXTURES['artifact-review'];
-      expect(answer.optionId).toBeNull();
-      expect(answer.freeText).toBeDefined();
+  describe('gate-answer does NOT tighten optionId/freeText (d)', () => {
+    it('optionId=null with null freeText is accepted (no XOR refine)', () => {
+      const answer = { ...VALID_ANSWER_FIXTURES.clarification, optionId: null, freeText: null };
       expect(() => GateAnswerSchema.parse(answer)).not.toThrow();
     });
 
-    it('optionId set with no freeText passes', () => {
+    it('optionId set with null freeText passes', () => {
       const answer = VALID_ANSWER_FIXTURES.clarification;
       expect(answer.optionId).not.toBeNull();
+      expect(answer.freeText).toBeNull();
       expect(() => GateAnswerSchema.parse(answer)).not.toThrow();
+    });
+
+    it('answer-invalid-email rejects', () => {
+      expect(() => GateAnswerSchema.parse(MALFORMED_FIXTURES['answer-invalid-email'])).toThrow();
+    });
+
+    it('answer-wrong-type-literal rejects', () => {
+      expect(() =>
+        GateAnswerSchema.parse(MALFORMED_FIXTURES['answer-wrong-type-literal']),
+      ).toThrow();
     });
   });
 
-  describe('datetime with offset (e)', () => {
-    it('rejects a naive Date.toString() timestamp', () => {
-      expect(() =>
-        GateRecordSchema.parse(MALFORMED_FIXTURES['naive-timestamp']),
-      ).toThrow(/askedAt/);
+  describe('datetime (e)', () => {
+    it('rejects a naive Date.toString() timestamp on askedAt', () => {
+      expect(() => GateOpenSchema.parse(MALFORMED_FIXTURES['naive-timestamp'])).toThrow(/askedAt/);
     });
 
     it('accepts a new Date().toISOString() timestamp', () => {
       const fixture = VALID_FIXTURES.clarification;
       const withNow = { ...fixture, askedAt: new Date().toISOString() };
-      expect(() => GateRecordSchema.parse(withNow)).not.toThrow();
+      expect(() => GateOpenSchema.parse(withNow)).not.toThrow();
     });
   });
 
-  describe('forward-compat additive fields', () => {
-    it('unknown fields pass through (schema uses plain z.object, not .strict())', () => {
+  describe('unknown fields are stripped, not rejected (f)', () => {
+    it('additive fields do not throw (plain z.object, not .strict())', () => {
       const fixture = VALID_FIXTURES.clarification;
       const extended = { ...fixture, futureField: 'harmless' };
-      expect(() => GateRecordSchema.parse(extended)).not.toThrow();
+      expect(() => GateOpenSchema.parse(extended)).not.toThrow();
     });
   });
 });

--- a/packages/cockpit/src/gates/__tests__/schema.test.ts
+++ b/packages/cockpit/src/gates/__tests__/schema.test.ts
@@ -2,222 +2,232 @@ import { describe, expect, it } from 'vitest';
 import { ZodError } from 'zod';
 import {
   GateOpenSchema,
-  GateAckSchema,
-  GateAnswerEnvelopeSchema,
+  GateOutcomeSchema,
+  GateAnswerSchema,
+  deriveGateKey,
+  deriveGateId,
 } from '../schema.js';
 
+// Canonical Shape 1 — gate-open (cluster → cloud). Flat, type-literal, string refs.
 const canonicalOpen = {
-  kind: 'gate-open',
-  gateId: 'g_smoke_001',
-  generation: 0,
-  scope: {
-    owner: 'generacy-ai',
-    repo: 'generacy',
-    issueNumber: 1021,
-  },
-  openedAt: '2026-07-21T15:04:05.123Z',
-  payload: { question: 'proceed?' },
-};
+  type: 'gate-open',
+  gateId: deriveGateId(
+    deriveGateKey('generacy-ai/generacy#1021', 'artifact-review', 'spec-review:abc1234'),
+  ),
+  gateKey: 'generacy-ai/generacy#1021:artifact-review:spec-review:abc1234',
+  gateType: 'artifact-review',
+  epicRef: 'generacy-ai/generacy#1000',
+  issueRef: 'generacy-ai/generacy#1021',
+  issueTitle: 'cockpit remote gates',
+  issueUrl: 'https://github.com/generacy-ai/generacy/issues/1021',
+  title: 'Review the spec',
+  body: 'Approve the drafted spec?',
+  options: [
+    { id: 'approve', label: 'Approve', recommended: true },
+    { id: 'changes', label: 'Request changes', description: 'Send back for edits' },
+  ],
+  allowFreeText: true,
+  sessionId: 'sess-001',
+  askedAt: '2026-07-21T15:04:05.123Z',
+} as const;
 
-const canonicalAck = {
-  kind: 'gate-ack',
-  gateId: 'g_smoke_001',
-  generation: 0,
-  outcome: 'answered',
-  ackedAt: '2026-07-21T15:04:11.900Z',
-  answer: { choice: 'proceed' },
-};
+// Canonical Shape 2 — gate-outcome (THE ACK).
+const canonicalOutcome = {
+  type: 'gate-outcome',
+  gateId: canonicalOpen.gateId,
+  outcome: 'applied',
+  at: '2026-07-21T15:04:11.900Z',
+} as const;
 
+// Canonical Shape 3 — gate-answer (cloud → cluster, down-path).
 const canonicalAnswer = {
-  kind: 'gate-answer',
-  deliveryId: 'dlv_smoke_001',
-  gateId: 'g_smoke_001',
-  generation: 0,
+  type: 'gate-answer',
+  gateId: canonicalOpen.gateId,
+  gateKey: canonicalOpen.gateKey,
+  optionId: 'approve',
+  freeText: null,
+  actor: { userId: 'user-1', email: 'op@example.com', displayName: 'Op' },
   answeredAt: '2026-07-21T15:04:11.100Z',
-  answer: { choice: 'proceed' },
-};
+  deliveryId: 'dlv-001',
+} as const;
 
-describe('GateOpenSchema', () => {
+describe('GateOpenSchema (Shape 1)', () => {
   it('parses a canonical wire example', () => {
     expect(() => GateOpenSchema.parse(canonicalOpen)).not.toThrow();
   });
 
-  it('preserves passthrough fields', () => {
-    const parsed = GateOpenSchema.parse({
-      ...canonicalOpen,
-      extraFutureField: 'kept',
-      payload: { deep: { nested: true } },
-    });
-    expect((parsed as Record<string, unknown>).extraFutureField).toBe('kept');
-    expect(parsed.payload).toEqual({ deep: { nested: true } });
-  });
-
-  it('rejects missing required fields', () => {
-    const { gateId: _gateId, ...withoutGateId } = canonicalOpen;
-    void _gateId;
-    const result = GateOpenSchema.safeParse(withoutGateId);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path.includes('gateId'))).toBe(
-        true,
-      );
-    }
-  });
-
-  it('rejects wrong discriminator literal', () => {
-    const result = GateOpenSchema.safeParse({
-      ...canonicalOpen,
-      kind: 'gate-ack',
-    });
+  it('rejects the wrong type discriminator', () => {
+    const result = GateOpenSchema.safeParse({ ...canonicalOpen, type: 'gate-outcome' });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error).toBeInstanceOf(ZodError);
-      expect(result.error.issues.some((i) => i.path.includes('kind'))).toBe(
-        true,
-      );
+      expect(result.error.issues.some((i) => i.path.includes('type'))).toBe(true);
     }
   });
 
-  it('rejects empty gateId', () => {
-    const result = GateOpenSchema.safeParse({ ...canonicalOpen, gateId: '' });
-    expect(result.success).toBe(false);
+  it('rejects a gateId that is not exactly 24 chars', () => {
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, gateId: 'tooshort' }).success).toBe(false);
+    expect(
+      GateOpenSchema.safeParse({ ...canonicalOpen, gateId: canonicalOpen.gateId + 'a' }).success,
+    ).toBe(false);
   });
 
-  it('rejects non-integer generation', () => {
-    const result = GateOpenSchema.safeParse({
-      ...canonicalOpen,
-      generation: 1.5,
-    });
-    expect(result.success).toBe(false);
+  it('rejects an unknown gateType', () => {
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, gateType: 'nope' }).success).toBe(false);
   });
 
-  it('rejects negative generation', () => {
-    const result = GateOpenSchema.safeParse({
-      ...canonicalOpen,
-      generation: -1,
-    });
-    expect(result.success).toBe(false);
+  it('requires allowFreeText to be a boolean', () => {
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, allowFreeText: 'yes' }).success).toBe(false);
+    // both boolean values are accepted (not pinned to true).
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, allowFreeText: false }).success).toBe(true);
   });
 
-  it('rejects non-ISO8601 openedAt', () => {
-    const result = GateOpenSchema.safeParse({
-      ...canonicalOpen,
-      openedAt: 'not-a-date',
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('accepts scope as any object shape (passthrough)', () => {
+  it('option description is optional', () => {
     const parsed = GateOpenSchema.parse({
       ...canonicalOpen,
-      scope: { anythingGoes: true },
+      options: [{ id: 'x', label: 'X' }],
     });
-    expect(parsed.scope).toEqual({ anythingGoes: true });
+    expect(parsed.options[0].description).toBeUndefined();
+  });
+
+  it('rejects an option missing its id', () => {
+    expect(
+      GateOpenSchema.safeParse({ ...canonicalOpen, options: [{ label: 'X' }] }).success,
+    ).toBe(false);
+  });
+
+  it('requires a fully-qualified issueUrl', () => {
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, issueUrl: 'generacy-ai/generacy#1021' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects a naive (non-ISO-8601) askedAt', () => {
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, askedAt: 'not-a-date' }).success).toBe(false);
+  });
+
+  it('rejects a non-positive prNumber', () => {
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, prNumber: 0 }).success).toBe(false);
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, prNumber: 42 }).success).toBe(true);
+  });
+
+  it('caps options at 20', () => {
+    const many = Array.from({ length: 21 }, (_, i) => ({ id: `o${i}`, label: `O${i}` }));
+    expect(GateOpenSchema.safeParse({ ...canonicalOpen, options: many }).success).toBe(false);
   });
 });
 
-describe('GateAckSchema', () => {
+describe('GateOutcomeSchema (Shape 2 — the ACK)', () => {
   it('parses a canonical wire example', () => {
-    expect(() => GateAckSchema.parse(canonicalAck)).not.toThrow();
+    expect(() => GateOutcomeSchema.parse(canonicalOutcome)).not.toThrow();
   });
 
-  it('preserves passthrough fields (answer)', () => {
-    const parsed = GateAckSchema.parse({
-      ...canonicalAck,
-      answer: { operator: 'yes', metadata: { ts: 1 } },
-    });
-    expect(parsed.answer).toEqual({ operator: 'yes', metadata: { ts: 1 } });
-  });
-
-  it('rejects missing outcome', () => {
-    const { outcome: _outcome, ...withoutOutcome } = canonicalAck;
-    void _outcome;
-    const result = GateAckSchema.safeParse(withoutOutcome);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path.includes('outcome'))).toBe(
-        true,
-      );
+  it('accepts each closed outcome value and an optional detail', () => {
+    for (const outcome of ['applied', 'superseded', 'failed'] as const) {
+      expect(GateOutcomeSchema.safeParse({ ...canonicalOutcome, outcome }).success).toBe(true);
     }
+    expect(GateOutcomeSchema.safeParse({ ...canonicalOutcome, detail: 'why' }).success).toBe(true);
   });
 
-  it('rejects empty outcome', () => {
-    const result = GateAckSchema.safeParse({ ...canonicalAck, outcome: '' });
-    expect(result.success).toBe(false);
+  it('rejects an outcome outside the closed enum', () => {
+    expect(GateOutcomeSchema.safeParse({ ...canonicalOutcome, outcome: 'answered' }).success).toBe(
+      false,
+    );
   });
 
-  it('rejects wrong kind literal', () => {
-    const result = GateAckSchema.safeParse({
-      ...canonicalAck,
-      kind: 'gate-open',
-    });
-    expect(result.success).toBe(false);
+  it('rejects the wrong type discriminator', () => {
+    expect(GateOutcomeSchema.safeParse({ ...canonicalOutcome, type: 'gate-open' }).success).toBe(
+      false,
+    );
   });
 
-  it('rejects empty gateId', () => {
-    const result = GateAckSchema.safeParse({ ...canonicalAck, gateId: '' });
-    expect(result.success).toBe(false);
+  it('has no generation and uses `at` (not ackedAt)', () => {
+    const parsed = GateOutcomeSchema.parse(canonicalOutcome);
+    expect(parsed).not.toHaveProperty('generation');
+    expect(parsed.at).toBe(canonicalOutcome.at);
   });
 });
 
-describe('GateAnswerEnvelopeSchema', () => {
-  it('parses a canonical wire example', () => {
-    expect(() => GateAnswerEnvelopeSchema.parse(canonicalAnswer)).not.toThrow();
+describe('GateAnswerSchema (Shape 3 — down-path)', () => {
+  it('parses a canonical option answer with freeText: null', () => {
+    expect(() => GateAnswerSchema.parse(canonicalAnswer)).not.toThrow();
   });
 
-  it('preserves passthrough fields', () => {
-    const parsed = GateAnswerEnvelopeSchema.parse({
-      ...canonicalAnswer,
-      extra: 'kept',
-    });
-    expect((parsed as Record<string, unknown>).extra).toBe('kept');
+  it('accepts a pure free-text answer (optionId: null)', () => {
+    expect(
+      GateAnswerSchema.safeParse({ ...canonicalAnswer, optionId: null, freeText: 'do this' })
+        .success,
+    ).toBe(true);
   });
 
-  it('rejects missing deliveryId', () => {
-    const { deliveryId: _deliveryId, ...withoutDeliveryId } = canonicalAnswer;
-    void _deliveryId;
-    const result = GateAnswerEnvelopeSchema.safeParse(withoutDeliveryId);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((i) => i.path.includes('deliveryId')),
-      ).toBe(true);
-    }
+  it('does NOT tighten optionId/freeText — null option with null freeText is accepted', () => {
+    // The cloud sends the unused side as an explicit null; the receiver must not
+    // re-impose an XOR refine.
+    expect(
+      GateAnswerSchema.safeParse({ ...canonicalAnswer, optionId: null, freeText: null }).success,
+    ).toBe(true);
   });
 
-  it('rejects empty deliveryId', () => {
-    const result = GateAnswerEnvelopeSchema.safeParse({
-      ...canonicalAnswer,
-      deliveryId: '',
-    });
-    expect(result.success).toBe(false);
+  it('allows a null actor email and displayName', () => {
+    expect(
+      GateAnswerSchema.safeParse({
+        ...canonicalAnswer,
+        actor: { userId: 'u', email: null, displayName: null },
+      }).success,
+    ).toBe(true);
   });
 
-  it('rejects wrong kind literal', () => {
-    const result = GateAnswerEnvelopeSchema.safeParse({
-      ...canonicalAnswer,
-      kind: 'gate-open',
-    });
-    expect(result.success).toBe(false);
+  it('rejects a malformed (non-null) actor email', () => {
+    expect(
+      GateAnswerSchema.safeParse({
+        ...canonicalAnswer,
+        actor: { ...canonicalAnswer.actor, email: 'not-an-email' },
+      }).success,
+    ).toBe(false);
   });
 
-  it('rejects non-ISO8601 answeredAt', () => {
-    const result = GateAnswerEnvelopeSchema.safeParse({
-      ...canonicalAnswer,
-      answeredAt: 'not-a-date',
-    });
-    expect(result.success).toBe(false);
+  it('rejects the wrong type discriminator', () => {
+    expect(GateAnswerSchema.safeParse({ ...canonicalAnswer, type: 'gate-open' }).success).toBe(
+      false,
+    );
   });
 
-  it('accepts answer field of any type', () => {
-    expect(() =>
-      GateAnswerEnvelopeSchema.parse({ ...canonicalAnswer, answer: 'string' }),
-    ).not.toThrow();
-    expect(() =>
-      GateAnswerEnvelopeSchema.parse({ ...canonicalAnswer, answer: 42 }),
-    ).not.toThrow();
-    expect(() =>
-      GateAnswerEnvelopeSchema.parse({ ...canonicalAnswer, answer: null }),
-    ).not.toThrow();
+  it('requires deliveryId', () => {
+    const { deliveryId: _d, ...withoutDelivery } = canonicalAnswer;
+    void _d;
+    expect(GateAnswerSchema.safeParse(withoutDelivery).success).toBe(false);
+  });
+});
+
+describe('gateKey / gateId derivation', () => {
+  it('emits `<issueRef>:<gateType>:<generation>` verbatim (issueRef already owner/repo#N)', () => {
+    expect(deriveGateKey('generacy-ai/generacy#1020', 'artifact-review', 'spec-review:abc1234')).toBe(
+      'generacy-ai/generacy#1020:artifact-review:spec-review:abc1234',
+    );
+  });
+
+  it('coerces a numeric generation to string', () => {
+    expect(deriveGateKey('generacy-ai/generacy#1000', 'phase-queue', 2)).toBe(
+      'generacy-ai/generacy#1000:phase-queue:2',
+    );
+  });
+
+  it('deriveGateId is deterministic and 24 lowercase hex chars', () => {
+    const key = 'generacy-ai/generacy#1020:artifact-review:spec-review:abc1234';
+    expect(deriveGateId(key)).toBe(deriveGateId(key));
+    expect(deriveGateId(key)).toMatch(/^[0-9a-f]{24}$/);
+  });
+
+  it('matches a hand-computed sha256 prefix for a fixed pre-image (algorithm lock)', () => {
+    const key = 'generacy-ai/generacy#1020:artifact-review:spec-review:abc1234';
+    expect(deriveGateId(key)).toBe('65d9cea2c9b50f53efde6ecb');
+  });
+
+  it('changes when gateType or generation changes', () => {
+    const a = deriveGateId(deriveGateKey('r#1', 'artifact-review', 'x'));
+    const b = deriveGateId(deriveGateKey('r#1', 'implementation-review', 'x'));
+    const c = deriveGateId(deriveGateKey('r#1', 'artifact-review', 'y'));
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
   });
 });

--- a/packages/cockpit/src/gates/fixtures.ts
+++ b/packages/cockpit/src/gates/fixtures.ts
@@ -1,32 +1,35 @@
-import { deriveGateKey, deriveGateId } from './gate-id.js';
-import {
-  deriveClarificationGeneration,
-  deriveArtifactReviewGeneration,
-  deriveImplementationReviewGeneration,
-  deriveManualValidationGeneration,
-  deriveEscalationGeneration,
-  derivePhaseQueueGeneration,
-  deriveFilingGeneration,
-  deriveScopeDrainedGeneration,
-} from './generation.js';
 import {
   GateAnswerSchema,
-  GateOutcomeAckSchema,
-  GateRecordSchema,
+  GateOpenSchema,
+  GateOutcomeSchema,
+  deriveGateId,
+  deriveGateKey,
   type GateAnswer,
-  type GateOutcomeAck,
-  type GateRecord,
-  type IssueRef,
-} from './schemas.js';
-import type { GateType } from './types.js';
+  type GateOpen,
+  type GateOutcome,
+  type GateType,
+} from './schema.js';
+import { issueRefToString, type IssueRef } from './schemas.js';
+import {
+  deriveArtifactReviewGeneration,
+  deriveClarificationGeneration,
+  deriveEscalationGeneration,
+  deriveFilingGeneration,
+  deriveImplementationReviewGeneration,
+  deriveManualValidationGeneration,
+  derivePhaseQueueGeneration,
+  deriveScopeDrainedGeneration,
+} from './generation.js';
 
 const EPIC_REF: IssueRef = { owner: 'generacy-ai', repo: 'generacy', number: 1000 };
 const ISSUE_REF: IssueRef = { owner: 'generacy-ai', repo: 'generacy', number: 1020 };
 const TRACKING_REF: IssueRef = { owner: 'generacy-ai', repo: 'generacy', number: 900 };
+const EPIC_REF_STR = issueRefToString(EPIC_REF);
+const ISSUE_REF_STR = issueRefToString(ISSUE_REF);
 const SESSION_ID = 'sess-abc123def456';
 const ASKED_AT = '2026-07-21T12:00:00.000Z';
 const ANSWERED_AT = '2026-07-21T12:05:00.000Z';
-const ACK_AT = '2026-07-21T12:05:01.000Z';
+const OUTCOME_AT = '2026-07-21T12:05:01.000Z';
 
 const ACTOR = {
   userId: 'user-1',
@@ -39,60 +42,39 @@ const DEFAULT_OPTIONS = [
   { id: 'opt-b', label: 'Reject', description: 'Reject and halt', recommended: true },
 ] as const;
 
-interface GenerationBundle {
-  gateType: GateType;
-  generation: string;
-}
-
-const GENERATIONS: Record<GateType, GenerationBundle> = {
-  clarification: {
-    gateType: 'clarification',
-    generation: deriveClarificationGeneration({ batchId: 'batch-abc123' }),
-  },
-  'artifact-review': {
-    gateType: 'artifact-review',
-    generation: deriveArtifactReviewGeneration({ kind: 'spec-review', headSha: 'abc1234' }),
-  },
-  'implementation-review': {
-    gateType: 'implementation-review',
-    generation: deriveImplementationReviewGeneration({ headSha: 'def5678' }),
-  },
-  'manual-validation': {
-    gateType: 'manual-validation',
-    generation: deriveManualValidationGeneration({ phaseNumber: 2 }),
-  },
-  escalation: {
-    gateType: 'escalation',
-    generation: deriveEscalationGeneration({
-      subtype: 'stalled',
-      labelOrState: 'agent:error',
-      counter: 1,
-    }),
-  },
-  'phase-queue': {
-    gateType: 'phase-queue',
-    generation: derivePhaseQueueGeneration({ phaseNumber: 3 }),
-  },
-  filing: {
-    gateType: 'filing',
-    generation: deriveFilingGeneration({ draftHash: 'feedbeef1234' }),
-  },
-  'scope-drained': {
-    gateType: 'scope-drained',
-    generation: deriveScopeDrainedGeneration({ trackingIssueRef: TRACKING_REF, counter: 1 }),
-  },
+const GENERATIONS: Record<GateType, string> = {
+  clarification: deriveClarificationGeneration({ batchId: 'batch-abc123' }),
+  'artifact-review': deriveArtifactReviewGeneration({ kind: 'spec-review', headSha: 'abc1234' }),
+  'implementation-review': deriveImplementationReviewGeneration({ headSha: 'def5678' }),
+  'manual-validation': deriveManualValidationGeneration({ phaseNumber: 2 }),
+  escalation: deriveEscalationGeneration({
+    subtype: 'stalled',
+    labelOrState: 'agent:error',
+    counter: 1,
+  }),
+  'phase-queue': derivePhaseQueueGeneration({ phaseNumber: 3 }),
+  filing: deriveFilingGeneration({ draftHash: 'feedbeef1234' }),
+  'scope-drained': deriveScopeDrainedGeneration({ trackingIssueRef: TRACKING_REF, counter: 1 }),
 };
 
-function buildRecord(gateType: GateType): GateRecord {
-  const { generation } = GENERATIONS[gateType];
-  const gateKey = deriveGateKey({ issueRef: ISSUE_REF, gateType, generation });
+// phase-queue is the sole per-issue exception: its wire `issueRef` slot carries
+// the EPIC ref, not a child issue (see the auto.md UI-mode gate-mapping table).
+function issueRefFor(gateType: GateType): string {
+  return gateType === 'phase-queue' ? EPIC_REF_STR : ISSUE_REF_STR;
+}
+
+function buildRecord(gateType: GateType): GateOpen {
+  const generation = GENERATIONS[gateType];
+  const issueRef = issueRefFor(gateType);
+  const gateKey = deriveGateKey(issueRef, gateType, generation);
   const gateId = deriveGateId(gateKey);
   return {
+    type: 'gate-open',
     gateId,
     gateKey,
     gateType,
-    epicRef: EPIC_REF,
-    issueRef: ISSUE_REF,
+    epicRef: EPIC_REF_STR,
+    issueRef,
     issueTitle: `Issue #${ISSUE_REF.number}: cockpit remote gates`,
     issueUrl: `https://github.com/${ISSUE_REF.owner}/${ISSUE_REF.repo}/issues/${ISSUE_REF.number}`,
     title: `${gateType} gate`,
@@ -104,7 +86,7 @@ function buildRecord(gateType: GateType): GateRecord {
   };
 }
 
-export const VALID_FIXTURES: Record<GateType, GateRecord> = {
+export const VALID_FIXTURES: Record<GateType, GateOpen> = {
   clarification: buildRecord('clarification'),
   'artifact-review': buildRecord('artifact-review'),
   'implementation-review': buildRecord('implementation-review'),
@@ -118,22 +100,24 @@ export const VALID_FIXTURES: Record<GateType, GateRecord> = {
 // Assert every valid fixture parses at module load — fixture drift fails the build,
 // not a test run.
 for (const gateType of Object.keys(VALID_FIXTURES) as GateType[]) {
-  GateRecordSchema.parse(VALID_FIXTURES[gateType]);
+  GateOpenSchema.parse(VALID_FIXTURES[gateType]);
 }
 
 interface AnswerSpec {
   optionId: string | null;
-  freeText?: string;
+  freeText: string | null;
 }
 
+// optionId XOR free-text is NOT enforced on the wire (the cloud sends the unused
+// side as an explicit null); every fixture therefore carries both fields.
 const ANSWER_SPECS: Record<GateType, AnswerSpec> = {
-  clarification: { optionId: 'opt-a' },
+  clarification: { optionId: 'opt-a', freeText: null },
   'artifact-review': { optionId: null, freeText: 'approve with concerns' },
-  'implementation-review': { optionId: 'opt-a' },
+  'implementation-review': { optionId: 'opt-a', freeText: null },
   'manual-validation': { optionId: null, freeText: 'verified manually on 2026-07-21' },
-  escalation: { optionId: 'opt-a' },
+  escalation: { optionId: 'opt-a', freeText: null },
   'phase-queue': { optionId: null, freeText: 'proceed with next phase' },
-  filing: { optionId: 'opt-a' },
+  filing: { optionId: 'opt-a', freeText: null },
   'scope-drained': { optionId: null, freeText: 'confirmed scope drained' },
 };
 
@@ -145,7 +129,7 @@ function buildAnswer(gateType: GateType): GateAnswer {
     gateId: record.gateId,
     gateKey: record.gateKey,
     optionId: spec.optionId,
-    ...(spec.freeText !== undefined ? { freeText: spec.freeText } : {}),
+    freeText: spec.freeText,
     actor: { ...ACTOR },
     answeredAt: ANSWERED_AT,
     deliveryId: `delivery-${gateType}-1`,
@@ -167,28 +151,32 @@ for (const gateType of Object.keys(VALID_ANSWER_FIXTURES) as GateType[]) {
   GateAnswerSchema.parse(VALID_ANSWER_FIXTURES[gateType]);
 }
 
-export const VALID_ACK_FIXTURES: Record<'applied' | 'superseded' | 'failed', GateOutcomeAck> = {
+// gate-outcome (the ACK) fixtures — one per closed outcome enum value.
+export const VALID_ACK_FIXTURES: Record<'applied' | 'superseded' | 'failed', GateOutcome> = {
   applied: {
+    type: 'gate-outcome',
     gateId: VALID_FIXTURES.clarification.gateId,
     outcome: 'applied',
-    at: ACK_AT,
+    at: OUTCOME_AT,
   },
   superseded: {
+    type: 'gate-outcome',
     gateId: VALID_FIXTURES['artifact-review'].gateId,
     outcome: 'superseded',
     detail: 'A newer answer arrived first',
-    at: ACK_AT,
+    at: OUTCOME_AT,
   },
   failed: {
+    type: 'gate-outcome',
     gateId: VALID_FIXTURES.escalation.gateId,
     outcome: 'failed',
     detail: 'Label mutation returned 422',
-    at: ACK_AT,
+    at: OUTCOME_AT,
   },
 };
 
 for (const key of Object.keys(VALID_ACK_FIXTURES) as Array<keyof typeof VALID_ACK_FIXTURES>) {
-  GateOutcomeAckSchema.parse(VALID_ACK_FIXTURES[key]);
+  GateOutcomeSchema.parse(VALID_ACK_FIXTURES[key]);
 }
 
 const BASE_RECORD_UNKNOWN = VALID_FIXTURES.clarification as unknown as Record<string, unknown>;
@@ -197,32 +185,43 @@ const BASE_ANSWER_UNKNOWN = VALID_ANSWER_FIXTURES.clarification as unknown as Re
   unknown
 >;
 
-function withoutKey<T extends Record<string, unknown>>(obj: T, key: string): Record<string, unknown> {
+function withoutKey<T extends Record<string, unknown>>(
+  obj: T,
+  key: string,
+): Record<string, unknown> {
   const clone: Record<string, unknown> = { ...obj };
   delete clone[key];
   return clone;
 }
 
 export const MALFORMED_FIXTURES: Record<string, unknown> = {
-  'missing-description': {
+  // Wrong up-path discriminator (must be the 'gate-open' literal).
+  'wrong-type-literal': {
     ...BASE_RECORD_UNKNOWN,
-    options: [{ id: 'opt-a', label: 'Approve' }],
+    type: 'gate-ack',
   },
-  'allow-free-text-false': {
+  // Option missing its required `id` (description is OPTIONAL in the frozen shape).
+  'option-missing-id': {
     ...BASE_RECORD_UNKNOWN,
-    allowFreeText: false,
+    options: [{ label: 'Approve' }],
   },
+  // allowFreeText is a REQUIRED boolean — a non-boolean must reject.
+  'allow-free-text-non-boolean': {
+    ...BASE_RECORD_UNKNOWN,
+    allowFreeText: 'yes',
+  },
+  // gateId is pinned to exactly 24 chars.
   'empty-gate-id': {
     ...BASE_RECORD_UNKNOWN,
     gateId: '',
   },
+  'wrong-length-gate-id': {
+    ...BASE_RECORD_UNKNOWN,
+    gateId: '0123456789abcdef0123', // 20 chars
+  },
   'unknown-gate-type': {
     ...BASE_RECORD_UNKNOWN,
     gateType: 'not-a-real-gate-type',
-  },
-  'non-hex-gate-id-prefix': {
-    ...BASE_RECORD_UNKNOWN,
-    gateId: 'ZZZZZZZZZZZZZZZZZZZZZZZZ',
   },
   'invalid-issue-url': {
     ...BASE_RECORD_UNKNOWN,
@@ -232,15 +231,15 @@ export const MALFORMED_FIXTURES: Record<string, unknown> = {
     ...BASE_RECORD_UNKNOWN,
     askedAt: 'Tue Jul 21 2026 12:00:00 GMT+0000',
   },
-  'answer-null-option-empty-free-text': {
-    ...BASE_ANSWER_UNKNOWN,
-    optionId: null,
-    freeText: '',
-  },
-  // Additional coverage: missing required field, invalid actor email.
   'record-missing-title': withoutKey(BASE_RECORD_UNKNOWN, 'title'),
+  // Down-path: actor.email must be a valid email OR null; a malformed string rejects.
   'answer-invalid-email': {
     ...BASE_ANSWER_UNKNOWN,
     actor: { ...ACTOR, email: 'not-an-email' },
+  },
+  // Down-path: wrong discriminator (must be the 'gate-answer' literal).
+  'answer-wrong-type-literal': {
+    ...BASE_ANSWER_UNKNOWN,
+    type: 'gate-open',
   },
 };

--- a/packages/cockpit/src/gates/gate-id.ts
+++ b/packages/cockpit/src/gates/gate-id.ts
@@ -1,18 +1,10 @@
-import { createHash } from 'node:crypto';
-import type { IssueRef } from './schemas.js';
-import type { GateType } from './types.js';
-
-export interface DeriveGateKeyInput {
-  issueRef: IssueRef;
-  gateType: GateType;
-  generation: string;
-}
-
-export function deriveGateKey(input: DeriveGateKeyInput): string {
-  const { issueRef, gateType, generation } = input;
-  return `${issueRef.owner}/${issueRef.repo}#${issueRef.number}:${gateType}:${generation}`;
-}
-
-export function deriveGateId(gateKey: string): string {
-  return createHash('sha256').update(gateKey, 'utf8').digest('hex').slice(0, 24);
-}
+/**
+ * Back-compat shim. Canonical gateKey/gateId derivation now lives in
+ * `./schema.ts` — the single source. Prefer importing `deriveGateKey` /
+ * `deriveGateId` from `./schema.js` (or the package index).
+ *
+ * NOTE the signature moved: `deriveGateKey(issueRef: string, gateType, generation)`
+ * now takes the FLAT `owner/repo#N` ref string, not an object. Use
+ * `issueRefToString` (schemas.ts) to convert an object ref first.
+ */
+export { deriveGateKey, deriveGateId } from './schema.js';

--- a/packages/cockpit/src/gates/index.ts
+++ b/packages/cockpit/src/gates/index.ts
@@ -1,41 +1,40 @@
-export {
-  GateOpenSchema,
-  GateAckSchema,
-  GateAnswerEnvelopeSchema,
-  type GateOpen,
-  type GateAck,
-  type GateAnswerEnvelope,
-} from './schema.js';
+// Canonical cockpit gate wire contract — single source is ./schema.ts.
+// See tetrad-development/docs/cockpit-remote-gates-plan.md § "Wire contracts".
 
 export {
-  GateRecordSchema,
-  GateAnswerSchema,
-  GateOutcomeAckSchema,
-  GateOptionSchema,
-  IssueRefSchema,
-  ActorSchema,
-  GateTypeSchema,
-  GATE_TYPES,
-  ArtifactReviewKindSchema,
-  ARTIFACT_REVIEW_KINDS,
+  // Wire shapes (the frozen contract, Shapes 1/2/3)
+  GateOpenSchema,
   GateOutcomeSchema,
-  GATE_OUTCOMES,
-  type GateType,
-  type ArtifactReviewKind,
+  GateAnswerSchema,
+  type GateOpen,
   type GateOutcome,
-  type GateOption,
-  type IssueRef,
-  type Actor,
-  type GateRecord,
   type GateAnswer,
-  type GateOutcomeAck,
+  // Enum + option
+  GateTypeSchema,
+  GateOptionSchema,
+  type GateType,
+  type GateOption,
+  // gateKey/gateId derivation
+  deriveGateKey,
+  deriveGateId,
+} from './schema.js';
+
+import { GateTypeSchema } from './schema.js';
+
+/** The 8 gate-type values as a readonly tuple (single source: GateTypeSchema). */
+export const GATE_TYPES = GateTypeSchema.options;
+
+export {
+  IssueRefSchema,
+  issueRefToString,
+  type IssueRef,
 } from './schemas.js';
 
 export {
-  deriveGateKey,
-  deriveGateId,
-  type DeriveGateKeyInput,
-} from './gate-id.js';
+  ArtifactReviewKindSchema,
+  ARTIFACT_REVIEW_KINDS,
+  type ArtifactReviewKind,
+} from './types.js';
 
 export {
   deriveClarificationGeneration,
@@ -65,12 +64,12 @@ export {
 
 export {
   gateOpenFixture,
-  gateAckFixture,
+  gateOutcomeFixture,
   answerLineFixture,
   DEFAULT_WIRE_SCOPE,
   DEFAULT_WIRE_EPIC_REF,
   type WireScope,
   type GateOpenFixtureOverrides,
-  type GateAckFixtureOverrides,
+  type GateOutcomeFixtureOverrides,
   type AnswerLineFixtureOverrides,
 } from './wire-fixtures.js';

--- a/packages/cockpit/src/gates/schema.ts
+++ b/packages/cockpit/src/gates/schema.ts
@@ -1,36 +1,126 @@
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 
-export const GateOpenSchema = z
-  .object({
-    kind: z.literal('gate-open'),
-    gateId: z.string().min(1),
-    generation: z.number().int().nonnegative(),
-    scope: z.object({}).passthrough(),
-    openedAt: z.string().datetime(),
-  })
-  .passthrough();
+/**
+ * Canonical cockpit gate wire schemas — the cluster (generacy) side of the
+ * frozen contract in tetrad-development/docs/cockpit-remote-gates-plan.md
+ * § "Wire contracts" and generacy-cloud/specs/843-part-cockpit-remote-gates/
+ * contracts/gates-wire.md (Shapes 1/2/3).
+ *
+ * The cloud is the authoritative RECEIVER; these schemas MUST stay
+ * field-for-field compatible with generacy-cloud:
+ *   - services/api/src/services/relay/message-handler.ts
+ *       gateOpenPayloadSchema / gateOutcomePayloadSchema
+ *   - packages/db/src/collections/cockpit-gates.ts
+ *       cockpitGateTypeEnum / cockpitGateOptionSchema / cockpitGateAnswerSchema
+ *
+ * Wire values are JSON, so all timestamps are ISO-8601 strings here; the cloud
+ * ingests them with `z.coerce.date()`.
+ */
 
-export const GateAckSchema = z
-  .object({
-    kind: z.literal('gate-ack'),
-    gateId: z.string().min(1),
-    generation: z.number().int().nonnegative(),
-    outcome: z.string().min(1),
-    ackedAt: z.string().datetime(),
-  })
-  .passthrough();
+// ---------------------------------------------------------------------------
+// Gate type enum — mirrors cloud `cockpitGateTypeEnum` exactly (8 values, order preserved).
+// ---------------------------------------------------------------------------
+export const GateTypeSchema = z.enum([
+  'clarification',
+  'artifact-review',
+  'implementation-review',
+  'manual-validation',
+  'escalation',
+  'phase-queue',
+  'filing',
+  'scope-drained',
+]);
+export type GateType = z.infer<typeof GateTypeSchema>;
 
-export const GateAnswerEnvelopeSchema = z
-  .object({
-    kind: z.literal('gate-answer'),
-    deliveryId: z.string().min(1),
-    gateId: z.string().min(1),
-    generation: z.number().int().nonnegative(),
-    answeredAt: z.string().datetime(),
-    answer: z.unknown(),
-  })
-  .passthrough();
+// ---------------------------------------------------------------------------
+// Option — mirrors cloud `cockpitGateOptionSchema`.
+// ---------------------------------------------------------------------------
+export const GateOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  recommended: z.boolean().optional(),
+});
+export type GateOption = z.infer<typeof GateOptionSchema>;
 
+// ---------------------------------------------------------------------------
+// Shape 1 — gate-open (cluster → cloud, up-path).
+// Mirrors cloud `gateOpenPayloadSchema` (message-handler.ts).
+// Flat, type-literal 'gate-open'. gateId/gateKey are DERIVED by the MCP tool
+// (cockpit_gate_open) — the plugin/LLM never hand-builds a sha256.
+// ---------------------------------------------------------------------------
+export const GateOpenSchema = z.object({
+  type: z.literal('gate-open'),
+  gateId: z.string().length(24),
+  gateKey: z.string().min(1),
+  gateType: GateTypeSchema,
+  epicRef: z.string().min(1),
+  issueRef: z.string().min(1),
+  issueTitle: z.string(),
+  issueUrl: z.string().url(),
+  branch: z.string().optional(),
+  prNumber: z.number().int().positive().optional(),
+  title: z.string(),
+  body: z.string(),
+  options: z.array(GateOptionSchema).min(0).max(20),
+  allowFreeText: z.boolean(),
+  sessionId: z.string().min(1),
+  askedAt: z.string().datetime(),
+});
 export type GateOpen = z.infer<typeof GateOpenSchema>;
-export type GateAck = z.infer<typeof GateAckSchema>;
-export type GateAnswerEnvelope = z.infer<typeof GateAnswerEnvelopeSchema>;
+
+// ---------------------------------------------------------------------------
+// Shape 2 — gate-outcome (cluster → cloud, up-path). THE ACK.
+// Replaces the invented GateAckSchema. Mirrors cloud `gateOutcomePayloadSchema`.
+// ---------------------------------------------------------------------------
+export const GateOutcomeSchema = z.object({
+  type: z.literal('gate-outcome'),
+  gateId: z.string().length(24),
+  outcome: z.enum(['applied', 'superseded', 'failed']),
+  detail: z.string().optional(),
+  at: z.string().datetime(),
+});
+export type GateOutcome = z.infer<typeof GateOutcomeSchema>;
+
+// ---------------------------------------------------------------------------
+// Shape 3 — gate-answer (cloud → cluster, down-path).
+// Consumed by the orchestrator `POST /cockpit/answers` route + doorbell parser.
+// Mirrors cloud stored `cockpitGateAnswerSchema` (nullable optionId/freeText and
+// nullable actor.email/displayName) plus the wire-only type/gateId/gateKey.
+// ---------------------------------------------------------------------------
+export const GateAnswerSchema = z.object({
+  type: z.literal('gate-answer'),
+  gateId: z.string().length(24),
+  gateKey: z.string().min(1),
+  optionId: z.string().nullable(), // null on pure free-text
+  freeText: z.string().nullable(),
+  actor: z.object({
+    userId: z.string(),
+    email: z.string().email().nullable(),
+    displayName: z.string().nullable(),
+  }),
+  answeredAt: z.string().datetime(),
+  deliveryId: z.string(), // unique per delivery attempt; cluster dedups on this
+});
+export type GateAnswer = z.infer<typeof GateAnswerSchema>;
+
+// ---------------------------------------------------------------------------
+// Gate identity derivation.
+//   gateKey = "<owner>/<repo>#<issue>:<gateType>:<generation>"
+//           = `${issueRef}:${gateType}:${generation}`  (issueRef is owner/repo#N)
+//   gateId  = sha256(gateKey) hex, first 24 chars.
+// `generation` is gateType-specific (batch id, head SHA, phase number, drain
+// counter, …); coerced to string so numeric discriminators (phase 2) are stable.
+// ---------------------------------------------------------------------------
+export function deriveGateKey(
+  issueRef: string,
+  gateType: GateType,
+  generation: string | number,
+): string {
+  return `${issueRef}:${gateType}:${String(generation)}`;
+}
+
+export function deriveGateId(gateKey: string): string {
+  return createHash('sha256').update(gateKey, 'utf8').digest('hex').slice(0, 24);
+}

--- a/packages/cockpit/src/gates/schemas.ts
+++ b/packages/cockpit/src/gates/schemas.ts
@@ -1,16 +1,15 @@
 import { z } from 'zod';
-import {
-  ArtifactReviewKindSchema,
-  ARTIFACT_REVIEW_KINDS,
-  GateOutcomeSchema,
-  GATE_OUTCOMES,
-  GateTypeSchema,
-  GATE_TYPES,
-  type ArtifactReviewKind,
-  type GateOutcome,
-  type GateType,
-} from './types.js';
 
+/**
+ * Object form of an issue reference. This is a cluster-local convenience shape
+ * used by the gate-generation helpers (`deriveScopeDrainedGeneration`) and by
+ * MCP callers before they format it to the flat `owner/repo#N` wire string.
+ *
+ * The WIRE shapes in `./schema.ts` carry `issueRef` / `epicRef` as plain
+ * strings (Shapes 1/3, mirroring the cloud); this object shape never crosses
+ * the wire. Format it with {@link issueRefToString} before calling
+ * `deriveGateKey`.
+ */
 export const IssueRefSchema = z.object({
   owner: z.string().min(1).regex(/^[a-zA-Z0-9-_.]+$/),
   repo: z.string().min(1).regex(/^[a-zA-Z0-9-_.]+$/),
@@ -18,76 +17,7 @@ export const IssueRefSchema = z.object({
 });
 export type IssueRef = z.infer<typeof IssueRefSchema>;
 
-export const ActorSchema = z.object({
-  userId: z.string().min(1),
-  email: z.string().email(),
-  displayName: z.string().min(1),
-});
-export type Actor = z.infer<typeof ActorSchema>;
-
-export const GateOptionSchema = z.object({
-  id: z.string().min(1),
-  label: z.string().min(1),
-  description: z.string().min(1),
-  recommended: z.boolean().optional(),
-});
-export type GateOption = z.infer<typeof GateOptionSchema>;
-
-export const GateRecordSchema = z.object({
-  gateId: z.string().regex(/^[0-9a-f]{24}$/),
-  gateKey: z.string().min(1),
-  gateType: GateTypeSchema,
-
-  epicRef: IssueRefSchema,
-  issueRef: IssueRefSchema,
-  issueTitle: z.string().min(1),
-  issueUrl: z.string().url(),
-  branch: z.string().min(1).optional(),
-  prNumber: z.number().int().positive().optional(),
-
-  title: z.string().min(1),
-  body: z.string(),
-  options: z.array(GateOptionSchema).min(0),
-  allowFreeText: z.literal(true),
-
-  sessionId: z.string().min(1),
-  askedAt: z.string().datetime({ offset: true }),
-});
-export type GateRecord = z.infer<typeof GateRecordSchema>;
-
-export const GateAnswerSchema = z
-  .object({
-    type: z.literal('gate-answer'),
-    gateId: z.string().regex(/^[0-9a-f]{24}$/),
-    gateKey: z.string().min(1),
-    optionId: z.string().min(1).nullable(),
-    freeText: z.string().optional(),
-    actor: ActorSchema,
-    answeredAt: z.string().datetime({ offset: true }),
-    deliveryId: z.string().min(1),
-  })
-  .refine(
-    (v) => v.optionId !== null || (v.freeText !== undefined && v.freeText.length > 0),
-    { message: 'optionId=null requires a non-empty freeText' },
-  );
-export type GateAnswer = z.infer<typeof GateAnswerSchema>;
-
-export const GateOutcomeAckSchema = z.object({
-  gateId: z.string().regex(/^[0-9a-f]{24}$/),
-  outcome: GateOutcomeSchema,
-  detail: z.string().min(1).optional(),
-  at: z.string().datetime({ offset: true }),
-});
-export type GateOutcomeAck = z.infer<typeof GateOutcomeAckSchema>;
-
-export {
-  ArtifactReviewKindSchema,
-  ARTIFACT_REVIEW_KINDS,
-  GateOutcomeSchema,
-  GATE_OUTCOMES,
-  GateTypeSchema,
-  GATE_TYPES,
-  type ArtifactReviewKind,
-  type GateOutcome,
-  type GateType,
-};
+/** Format an object {@link IssueRef} to the canonical `owner/repo#N` wire ref. */
+export function issueRefToString(ref: IssueRef): string {
+  return `${ref.owner}/${ref.repo}#${ref.number}`;
+}

--- a/packages/cockpit/src/gates/types.ts
+++ b/packages/cockpit/src/gates/types.ts
@@ -1,19 +1,15 @@
 import { z } from 'zod';
 
-export const GATE_TYPES = [
-  'clarification',
-  'artifact-review',
-  'implementation-review',
-  'manual-validation',
-  'escalation',
-  'phase-queue',
-  'filing',
-  'scope-drained',
-] as const;
-
-export const GateTypeSchema = z.enum(GATE_TYPES);
-export type GateType = z.infer<typeof GateTypeSchema>;
-
+/**
+ * Artifact-review kinds — a cluster-local enumeration used only by the
+ * `deriveArtifactReviewGeneration` helper (generation.ts) to build the
+ * `<kind>:<headSha>` discriminator. It is NOT a wire type: the gate-open
+ * record carries `gateType: 'artifact-review'`, and the kind is folded into
+ * `gateKey`'s generation slot.
+ *
+ * The wire enum (`GateTypeSchema`), the gate option/answer/outcome shapes and
+ * the gateKey/gateId derivation all live in `./schema.ts` — the single source.
+ */
 export const ARTIFACT_REVIEW_KINDS = [
   'spec-review',
   'plan-review',
@@ -23,7 +19,3 @@ export const ARTIFACT_REVIEW_KINDS = [
 
 export const ArtifactReviewKindSchema = z.enum(ARTIFACT_REVIEW_KINDS);
 export type ArtifactReviewKind = z.infer<typeof ArtifactReviewKindSchema>;
-
-export const GATE_OUTCOMES = ['applied', 'superseded', 'failed'] as const;
-export const GateOutcomeSchema = z.enum(GATE_OUTCOMES);
-export type GateOutcome = z.infer<typeof GateOutcomeSchema>;

--- a/packages/cockpit/src/gates/wire-fixtures.ts
+++ b/packages/cockpit/src/gates/wire-fixtures.ts
@@ -1,37 +1,37 @@
 /**
  * Wire-envelope fixture builders for the cluster-side transport contracts
- * (#1024). These are distinct from the operator-inbox record fixtures in
- * `fixtures.ts` (`VALID_FIXTURES` etc.): the records describe the rich gate
- * shown in the cloud inbox, whereas the *envelopes* here are the exact bytes
- * that cross the cluster-side wire —
+ * (#1024). These build the exact JSON frames that cross the cluster-side wire,
+ * all validated against the canonical schemas in `./schema.ts`:
  *
- *   - `gateOpenFixture()`   → body of `POST /cockpit/gates`   (`GateOpenSchema`)
- *   - `gateAckFixture()`    → body of `POST /cockpit/gates/:id/ack` (`GateAckSchema`)
- *   - `answerLineFixture()` → body of `POST /cockpit/answers` AND the NDJSON
- *                             line the doorbell tails (`GateAnswerEnvelopeSchema`
- *                             on the route + `GateAnswerLineSchema` in the
- *                             doorbell — the returned object satisfies both).
+ *   - `gateOpenFixture()`    → body of `POST /cockpit/gates`        (`GateOpenSchema`, Shape 1)
+ *   - `gateOutcomeFixture()` → body of `POST /cockpit/gates/:id/ack` (`GateOutcomeSchema`, Shape 2 — THE ACK)
+ *   - `answerLineFixture()`  → body of `POST /cockpit/answers` AND the NDJSON
+ *                              line the doorbell tails               (`GateAnswerSchema`, Shape 3)
  *
  * The #1024 integration harness single-sources every wire body through these
  * builders (FR-009 / SC-004) so a drift in the transport shape fails the
  * harness in one place rather than silently passing an inline literal.
  *
- * See `specs/1024-part-cockpit-remote-gates/contracts/fake-peer-protocol.md`
- * and the `packages/cockpit/src/gates/README.md` wire-shape table.
+ * NB: the frozen frames are FLAT with a `type` discriminator ('gate-open' |
+ * 'gate-outcome' | 'gate-answer'); there is no `kind`, no `scope` wrapper and no
+ * top-level `generation` (generation is folded into `gateKey`). gateId/gateKey
+ * are DERIVED, so the default frame carries a real 24-hex gateId.
  */
 import {
+  GateAnswerSchema,
   GateOpenSchema,
-  GateAckSchema,
-  GateAnswerEnvelopeSchema,
+  GateOutcomeSchema,
+  deriveGateId,
+  deriveGateKey,
+  type GateAnswer,
   type GateOpen,
-  type GateAck,
-  type GateAnswerEnvelope,
+  type GateOutcome,
 } from './schema.js';
+import { issueRefToString, type IssueRef } from './schemas.js';
 
-/** Epic/issue scope carried on gate-open and answer envelopes. The doorbell's
- *  `GateAnswerLineSchema` requires `{ owner, repo, number }` on the answer
- *  line, so the default scope here matches that shape and the harness's bound
- *  epic ref (`generacy-ai/generacy#1024`). */
+/** Epic/issue scope the harness binds the doorbell to. The wire carries the ref
+ *  as the flat `owner/repo#N` string ({@link DEFAULT_WIRE_EPIC_REF}); this object
+ *  form is a convenience for callers that need the parts. */
 export interface WireScope {
   owner: string;
   repo: string;
@@ -46,97 +46,118 @@ export const DEFAULT_WIRE_SCOPE: WireScope = {
 
 /** `owner/repo#number` for the default scope — the epic ref the harness binds
  *  the doorbell to. Kept in lockstep with {@link DEFAULT_WIRE_SCOPE}. */
-export const DEFAULT_WIRE_EPIC_REF = `${DEFAULT_WIRE_SCOPE.owner}/${DEFAULT_WIRE_SCOPE.repo}#${DEFAULT_WIRE_SCOPE.number}`;
+export const DEFAULT_WIRE_EPIC_REF = issueRefToString(DEFAULT_WIRE_SCOPE as IssueRef);
 
-const DEFAULT_GATE_ID = 'g_1024_default';
-const DEFAULT_OPENED_AT = '2026-07-21T12:00:00.000Z';
+const DEFAULT_GATE_TYPE = 'phase-queue' as const;
+const DEFAULT_GENERATION = '2';
+const DEFAULT_GATE_KEY = deriveGateKey(DEFAULT_WIRE_EPIC_REF, DEFAULT_GATE_TYPE, DEFAULT_GENERATION);
+const DEFAULT_GATE_ID = deriveGateId(DEFAULT_GATE_KEY);
+const DEFAULT_SESSION_ID = 'sess-1024-default';
+const DEFAULT_ASKED_AT = '2026-07-21T12:00:00.000Z';
 const DEFAULT_ANSWERED_AT = '2026-07-21T12:05:00.000Z';
-const DEFAULT_ACKED_AT = '2026-07-21T12:05:01.000Z';
+const DEFAULT_OUTCOME_AT = '2026-07-21T12:05:01.000Z';
+
+const DEFAULT_ACTOR = {
+  userId: 'user-1024',
+  email: 'operator@example.com',
+  displayName: 'Operator One',
+} as const;
 
 export interface GateOpenFixtureOverrides {
   gateId?: string;
-  generation?: number;
-  scope?: WireScope;
-  openedAt?: string;
-  payload?: unknown;
+  gateKey?: string;
+  gateType?: GateOpen['gateType'];
+  epicRef?: string;
+  issueRef?: string;
+  issueTitle?: string;
+  issueUrl?: string;
+  title?: string;
+  body?: string;
+  options?: GateOpen['options'];
+  allowFreeText?: boolean;
+  sessionId?: string;
+  askedAt?: string;
 }
 
 /**
- * Build a `POST /cockpit/gates` body. Validated against `GateOpenSchema` before
- * return so a builder that drifts from the transport contract throws at the
- * call site (the SC-003 breakage surface for the #1020 contracts sibling).
+ * Build a `POST /cockpit/gates` body (Shape 1). Validated against
+ * `GateOpenSchema` before return so a builder that drifts from the transport
+ * contract throws at the call site.
  */
 export function gateOpenFixture(overrides: GateOpenFixtureOverrides = {}): GateOpen {
   const body = {
-    kind: 'gate-open' as const,
+    type: 'gate-open' as const,
     gateId: overrides.gateId ?? DEFAULT_GATE_ID,
-    generation: overrides.generation ?? 0,
-    scope: overrides.scope ?? { ...DEFAULT_WIRE_SCOPE },
-    openedAt: overrides.openedAt ?? DEFAULT_OPENED_AT,
-    payload: overrides.payload ?? { question: 'Proceed with the phase?' },
+    gateKey: overrides.gateKey ?? DEFAULT_GATE_KEY,
+    gateType: overrides.gateType ?? DEFAULT_GATE_TYPE,
+    epicRef: overrides.epicRef ?? DEFAULT_WIRE_EPIC_REF,
+    issueRef: overrides.issueRef ?? DEFAULT_WIRE_EPIC_REF,
+    issueTitle: overrides.issueTitle ?? 'Phase 2: cockpit remote gates',
+    issueUrl:
+      overrides.issueUrl ??
+      `https://github.com/${DEFAULT_WIRE_SCOPE.owner}/${DEFAULT_WIRE_SCOPE.repo}/issues/${DEFAULT_WIRE_SCOPE.number}`,
+    title: overrides.title ?? 'Queue phase 2?',
+    body: overrides.body ?? 'Proceed with the next phase?',
+    options: overrides.options ?? [
+      { id: 'proceed', label: 'Proceed', recommended: true },
+      { id: 'hold', label: 'Hold' },
+    ],
+    allowFreeText: overrides.allowFreeText ?? true,
+    sessionId: overrides.sessionId ?? DEFAULT_SESSION_ID,
+    askedAt: overrides.askedAt ?? DEFAULT_ASKED_AT,
   };
   return GateOpenSchema.parse(body);
 }
 
-export interface GateAckFixtureOverrides {
+export interface GateOutcomeFixtureOverrides {
   gateId?: string;
-  generation?: number;
-  outcome?: string;
-  ackedAt?: string;
-  answer?: unknown;
+  outcome?: GateOutcome['outcome'];
+  detail?: string;
+  at?: string;
 }
 
 /**
- * Build a `POST /cockpit/gates/:id/ack` body. The route also injects the path
- * `:id` as `gateId`; the fixture carries a matching `gateId` so a direct POST
- * with `body.gateId === :id` passes the route's equality guard.
+ * Build a `POST /cockpit/gates/:id/ack` body (Shape 2, the gate-outcome ACK).
+ * The route injects the path `:id` as `gateId`; the fixture carries a matching
+ * `gateId` so a direct POST with `body.gateId === :id` passes any equality guard.
  */
-export function gateAckFixture(overrides: GateAckFixtureOverrides = {}): GateAck {
+export function gateOutcomeFixture(overrides: GateOutcomeFixtureOverrides = {}): GateOutcome {
   const body = {
-    kind: 'gate-ack' as const,
+    type: 'gate-outcome' as const,
     gateId: overrides.gateId ?? DEFAULT_GATE_ID,
-    generation: overrides.generation ?? 0,
-    outcome: overrides.outcome ?? 'answered',
-    ackedAt: overrides.ackedAt ?? DEFAULT_ACKED_AT,
-    answer: overrides.answer ?? { choice: 'proceed' },
+    outcome: overrides.outcome ?? 'applied',
+    ...(overrides.detail !== undefined ? { detail: overrides.detail } : {}),
+    at: overrides.at ?? DEFAULT_OUTCOME_AT,
   };
-  return GateAckSchema.parse(body);
+  return GateOutcomeSchema.parse(body);
 }
 
 export interface AnswerLineFixtureOverrides {
   deliveryId?: string;
   gateId?: string;
-  generation?: number;
-  scope?: WireScope;
+  gateKey?: string;
+  optionId?: string | null;
+  freeText?: string | null;
+  actor?: GateAnswer['actor'];
   answeredAt?: string;
-  answeredBy?: string;
-  answer?: unknown;
 }
 
 /**
- * Build a gate-answer line. The returned object satisfies BOTH the orchestrator
- * route schema (`GateAnswerEnvelopeSchema`) and the doorbell tail schema
- * (`GateAnswerLineSchema`): it carries `kind`/`generation`/`answeredAt` for the
- * envelope and `scope`/`answeredBy` for the line. This is the single wire shape
- * that flows peer → `POST /cockpit/answers` → answers file → doorbell tail
- * (FR-005) — the seam the #1024 harness exists to pin.
+ * Build a gate-answer line (Shape 3, down-path). This is the single wire shape
+ * that flows peer/cloud → `POST /cockpit/answers` → answers file → doorbell
+ * tail (FR-005) — the seam the #1024 harness exists to pin. Validated against
+ * `GateAnswerSchema`.
  */
-export function answerLineFixture(
-  overrides: AnswerLineFixtureOverrides = {},
-): GateAnswerEnvelope & { scope: WireScope; answeredBy: string } {
+export function answerLineFixture(overrides: AnswerLineFixtureOverrides = {}): GateAnswer {
   const body = {
-    kind: 'gate-answer' as const,
-    deliveryId: overrides.deliveryId ?? 'dlv_1024_default',
+    type: 'gate-answer' as const,
     gateId: overrides.gateId ?? DEFAULT_GATE_ID,
-    generation: overrides.generation ?? 0,
+    gateKey: overrides.gateKey ?? DEFAULT_GATE_KEY,
+    optionId: overrides.optionId !== undefined ? overrides.optionId : 'proceed',
+    freeText: overrides.freeText !== undefined ? overrides.freeText : null,
+    actor: overrides.actor ?? { ...DEFAULT_ACTOR },
     answeredAt: overrides.answeredAt ?? DEFAULT_ANSWERED_AT,
-    scope: overrides.scope ?? { ...DEFAULT_WIRE_SCOPE },
-    answeredBy: overrides.answeredBy ?? 'operator@example.com',
-    answer: overrides.answer ?? { choice: 'proceed' },
+    deliveryId: overrides.deliveryId ?? 'dlv_1024_default',
   };
-  // Validate against the transport (route) schema. The additional `scope` and
-  // `answeredBy` keys survive `.passthrough()` and satisfy the doorbell's
-  // `GateAnswerLineSchema` at runtime.
-  GateAnswerEnvelopeSchema.parse(body);
-  return body;
+  return GateAnswerSchema.parse(body);
 }

--- a/packages/cockpit/src/index.ts
+++ b/packages/cockpit/src/index.ts
@@ -83,43 +83,34 @@ export {
   type RateLimitProbeResult,
 } from './gh/rate-limit-scheduler.js';
 
-// Wire contracts — see specs/1020-part-cockpit-remote-gates/
-// NB: gates' `IssueRef` type collides with resolver's `IssueRef` (different shapes:
-// resolver = { owner, repo, issueNumber }; gates = { owner, repo, number }).
+// Wire contracts — the frozen cockpit remote-gate contract (Shapes 1/2/3).
+// See tetrad-development/docs/cockpit-remote-gates-plan.md § "Wire contracts".
+// The single source is packages/cockpit/src/gates/schema.ts.
+// NB: gates' object `IssueRef` type collides with resolver's `IssueRef`
+// (resolver = { owner, repo, issueNumber }; gates = { owner, repo, number }).
 // We re-export the gates version as `GateIssueRef`. `IssueRefSchema` is unique so
-// it stays unaliased.
+// it stays unaliased. The wire shapes carry issueRef/epicRef as flat strings.
 export {
-  // Wire-envelope schemas (transport contracts)
+  // Wire shapes (Shapes 1/2/3)
   GateOpenSchema,
-  GateAckSchema,
-  GateAnswerEnvelopeSchema,
-  type GateOpen,
-  type GateAck,
-  type GateAnswerEnvelope,
-  // Schemas
-  GateRecordSchema,
+  GateOutcomeSchema,
   GateAnswerSchema,
-  GateOutcomeAckSchema,
-  GateOptionSchema,
-  IssueRefSchema,
-  ActorSchema,
-  // Enums
+  type GateOpen,
+  type GateOutcome,
+  type GateAnswer,
+  // Enum + option
   GateTypeSchema,
   GATE_TYPES,
+  GateOptionSchema,
   ArtifactReviewKindSchema,
   ARTIFACT_REVIEW_KINDS,
-  GateOutcomeSchema,
-  GATE_OUTCOMES,
-  // Types
   type GateType,
   type ArtifactReviewKind,
-  type GateOutcome,
   type GateOption,
+  // Object ref helper (cluster-local; not a wire type)
+  IssueRefSchema,
+  issueRefToString,
   type IssueRef as GateIssueRef,
-  type Actor,
-  type GateRecord,
-  type GateAnswer,
-  type GateOutcomeAck,
   // Derivation
   deriveGateKey,
   deriveGateId,
@@ -136,14 +127,14 @@ export {
   MALFORMED_FIXTURES,
   VALID_ANSWER_FIXTURES,
   VALID_ACK_FIXTURES,
-  // Wire-envelope fixture builders (#1024 integration harness)
+  // Wire-frame fixture builders (#1024 integration harness)
   gateOpenFixture,
-  gateAckFixture,
+  gateOutcomeFixture,
   answerLineFixture,
   DEFAULT_WIRE_SCOPE,
   DEFAULT_WIRE_EPIC_REF,
   type WireScope,
   type GateOpenFixtureOverrides,
-  type GateAckFixtureOverrides,
+  type GateOutcomeFixtureOverrides,
   type AnswerLineFixtureOverrides,
 } from './gates/index.js';

--- a/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/answers-file-source.replay.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/answers-file-source.replay.test.ts
@@ -47,14 +47,19 @@ function makeFacade(content: string): FsFacade {
   };
 }
 
+// FROZEN down-path gate-answer line (Shape 3). Default gateKey issue-ref shares
+// the bound epic owner/repo (owner/repo#5) so it passes the repo-scope filter.
 function goodLine(gateId: string, extra: Record<string, unknown> = {}): string {
   return (
     JSON.stringify({
+      type: 'gate-answer',
       gateId,
-      deliveryId: `d-${gateId}`,
-      scope: { owner: 'owner', repo: 'repo', number: 5 },
-      answer: {},
+      gateKey: 'owner/repo#5:clarification:batch-abc',
+      optionId: 'opt-1',
+      freeText: null,
+      actor: { userId: 'u1', email: 'op@example.com', displayName: 'Op' },
       answeredAt: '2027-01-14T12:00:00.000Z',
+      deliveryId: `d-${gateId}`,
       ...extra,
     }) + '\n'
   );

--- a/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/answers-file-source.tail.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/answers-file-source.tail.test.ts
@@ -33,14 +33,19 @@ function makeLogger(): { warn: ReturnType<typeof vi.fn>; info: ReturnType<typeof
   return { warn: vi.fn(), info: vi.fn() };
 }
 
+// FROZEN down-path gate-answer line (Shape 3). Default gateKey issue-ref shares
+// the bound epic owner/repo (owner/repo#5) so it passes the repo-scope filter.
 function goodLine(overrides: Record<string, unknown> = {}): string {
   return (
     JSON.stringify({
+      type: 'gate-answer',
       gateId: 'g1',
-      deliveryId: 'd1',
-      scope: { owner: 'owner', repo: 'repo', number: 5 },
-      answer: { text: 'yes' },
+      gateKey: 'owner/repo#5:clarification:batch-abc',
+      optionId: 'opt-1',
+      freeText: null,
+      actor: { userId: 'u1', email: 'op@example.com', displayName: 'Op' },
       answeredAt: '2027-01-14T12:00:00.000Z',
+      deliveryId: 'd1',
       ...overrides,
     }) + '\n'
   );

--- a/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/answers-file-source.unit.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/doorbell/__tests__/answers-file-source.unit.test.ts
@@ -105,14 +105,23 @@ function baseOptions(
   };
 }
 
+/**
+ * A well-formed FROZEN down-path gate-answer line (Shape 3). Default gateKey
+ * issue-ref shares the bound epic's owner/repo so it passes the repo-scope
+ * filter. `gateId` is a short opaque label (the tailer pins it `min(1)`, not
+ * `length(24)` — format is validated upstream at the /cockpit/answers route).
+ */
 function goodLine(overrides: Record<string, unknown> = {}): string {
   return (
     JSON.stringify({
+      type: 'gate-answer',
       gateId: 'g1',
-      deliveryId: 'd1',
-      scope: { owner: 'owner', repo: 'repo', number: 5 },
-      answer: { text: 'yes' },
+      gateKey: 'owner/repo#5:clarification:batch-abc',
+      optionId: 'opt-1',
+      freeText: null,
+      actor: { userId: 'u1', email: 'op@example.com', displayName: 'Op' },
       answeredAt: '2027-01-14T12:00:00.000Z',
+      deliveryId: 'd1',
       ...overrides,
     }) + '\n'
   );
@@ -166,7 +175,7 @@ describe('AnswersFileSource — constructor validation', () => {
 });
 
 describe('AnswersFileSource — line pipeline (unit)', () => {
-  it('happy path: valid line matching epicRef emits one event with correct shape', async () => {
+  it('happy path: valid frozen line matching epicRef emits one event with flat answer fields', async () => {
     const mem = makeMemFs();
     mem.setContent(goodLine());
     const onEvent = vi.fn();
@@ -182,8 +191,52 @@ describe('AnswersFileSource — line pipeline (unit)', () => {
     expect(event.gateId).toBe('g1');
     expect(event.deliveryId).toBe('d1');
     expect(event.epic).toBe('owner/repo#5');
-    expect(event.line.scope).toEqual({ owner: 'owner', repo: 'repo', number: 5 });
+    // Flat frozen answer fields survive on line.* (no scope / nested-answer).
+    expect(event.line.type).toBe('gate-answer');
+    expect(event.line.gateKey).toBe('owner/repo#5:clarification:batch-abc');
+    expect(event.line.optionId).toBe('opt-1');
+    expect(event.line.freeText).toBeNull();
+    expect(event.line.actor).toEqual({
+      userId: 'u1',
+      email: 'op@example.com',
+      displayName: 'Op',
+    });
     expect(event.ts).toBe(new Date(1_800_000_000_000).toISOString());
+  });
+
+  it('accepts a pure free-text answer (optionId null, freeText string)', async () => {
+    const mem = makeMemFs();
+    mem.setContent(goodLine({ optionId: null, freeText: 'do the other thing' }));
+    const onEvent = vi.fn();
+    const src = new AnswersFileSource(
+      baseOptions({ fs: mem.fs, onEvent }),
+    );
+    await src.start();
+    await src.stop();
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    const event = onEvent.mock.calls[0]![0] as GateAnswerEvent;
+    expect(event.line.optionId).toBeNull();
+    expect(event.line.freeText).toBe('do the other thing');
+  });
+
+  it('accepts a null-email / null-displayName actor (anonymous / partial profile)', async () => {
+    const mem = makeMemFs();
+    mem.setContent(
+      goodLine({ actor: { userId: 'u9', email: null, displayName: null } }),
+    );
+    const onEvent = vi.fn();
+    const src = new AnswersFileSource(
+      baseOptions({ fs: mem.fs, onEvent }),
+    );
+    await src.start();
+    await src.stop();
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    const event = onEvent.mock.calls[0]![0] as GateAnswerEvent;
+    expect(event.line.actor.userId).toBe('u9');
+    expect(event.line.actor.email).toBeNull();
+    expect(event.line.actor.displayName).toBeNull();
   });
 
   it('emitted event survives round-trip through CockpitStreamEventSchema + lineForEvent', async () => {
@@ -226,14 +279,46 @@ describe('AnswersFileSource — line pipeline (unit)', () => {
     expect(event.line.another).toBe(42);
   });
 
+  it('missing type discriminator → skipped with logger.warn (guards the kind→type fix)', async () => {
+    const mem = makeMemFs();
+    // The OLD wrong shape used `kind:'gate-answer'` with no `type`; it must now
+    // fail schema validation and be dropped as malformed.
+    mem.setContent(
+      JSON.stringify({
+        kind: 'gate-answer',
+        gateId: 'g1',
+        gateKey: 'owner/repo#5:clarification:b',
+        optionId: 'opt-1',
+        freeText: null,
+        actor: { userId: 'u1', email: 'op@example.com', displayName: 'Op' },
+        answeredAt: '2027-01-14T12:00:00.000Z',
+        deliveryId: 'd1',
+      }) + '\n',
+    );
+    const logger = makeLogger();
+    const onEvent = vi.fn();
+    const src = new AnswersFileSource(
+      baseOptions({ fs: mem.fs, onEvent, logger }),
+    );
+    await src.start();
+    await src.stop();
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+    expect(logger.warn.mock.calls[0]![0]).toMatch(/malformed line/);
+  });
+
   it('missing gateId → skipped with logger.warn, no onEvent', async () => {
     const mem = makeMemFs();
     mem.setContent(
       JSON.stringify({
-        deliveryId: 'd1',
-        scope: { owner: 'owner', repo: 'repo', number: 5 },
-        answer: 'x',
+        type: 'gate-answer',
+        gateKey: 'owner/repo#5:clarification:b',
+        optionId: 'opt-1',
+        freeText: null,
+        actor: { userId: 'u1', email: 'op@example.com', displayName: 'Op' },
         answeredAt: '2027-01-14T12:00:00.000Z',
+        deliveryId: 'd1',
       }) + '\n',
     );
     const logger = makeLogger();
@@ -264,15 +349,17 @@ describe('AnswersFileSource — line pipeline (unit)', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
-  it('missing scope.number → skipped with warn', async () => {
+  it('missing gateKey → skipped with warn', async () => {
     const mem = makeMemFs();
     mem.setContent(
       JSON.stringify({
+        type: 'gate-answer',
         gateId: 'g1',
-        deliveryId: 'd1',
-        scope: { owner: 'owner', repo: 'repo' },
-        answer: 'x',
+        optionId: 'opt-1',
+        freeText: null,
+        actor: { userId: 'u1', email: 'op@example.com', displayName: 'Op' },
         answeredAt: '2027-01-14T12:00:00.000Z',
+        deliveryId: 'd1',
       }) + '\n',
     );
     const logger = makeLogger();
@@ -287,17 +374,34 @@ describe('AnswersFileSource — line pipeline (unit)', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
-  it('scope.number as string → skipped with warn', async () => {
+  it('missing actor → skipped with warn', async () => {
     const mem = makeMemFs();
     mem.setContent(
       JSON.stringify({
+        type: 'gate-answer',
         gateId: 'g1',
-        deliveryId: 'd1',
-        scope: { owner: 'owner', repo: 'repo', number: '5' },
-        answer: 'x',
+        gateKey: 'owner/repo#5:clarification:b',
+        optionId: 'opt-1',
+        freeText: null,
         answeredAt: '2027-01-14T12:00:00.000Z',
+        deliveryId: 'd1',
       }) + '\n',
     );
+    const logger = makeLogger();
+    const onEvent = vi.fn();
+    const src = new AnswersFileSource(
+      baseOptions({ fs: mem.fs, onEvent, logger }),
+    );
+    await src.start();
+    await src.stop();
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('optionId wrong type (number) → skipped with warn', async () => {
+    const mem = makeMemFs();
+    mem.setContent(goodLine({ optionId: 5 }));
     const logger = makeLogger();
     const onEvent = vi.fn();
     const src = new AnswersFileSource(
@@ -330,10 +434,10 @@ describe('AnswersFileSource — line pipeline (unit)', () => {
     expect(warnMsg).toMatch(/malformed line/);
   });
 
-  it('cross-epic line → dropped with logger.info naming gateId + scope + boundEpic', async () => {
+  it('cross-repo line (foreign owner in gateKey) → dropped with logger.info naming gateId + scope + boundEpic', async () => {
     const mem = makeMemFs();
     mem.setContent(
-      goodLine({ scope: { owner: 'other', repo: 'repo', number: 99 } }),
+      goodLine({ gateKey: 'other/repo#99:clarification:batch-x' }),
     );
     const logger = makeLogger();
     const onEvent = vi.fn();
@@ -353,6 +457,45 @@ describe('AnswersFileSource — line pipeline (unit)', () => {
     expect(infoMsg).toMatch(/gateId=g1/);
     expect(infoMsg).toMatch(/scope=other\/repo#99/);
     expect(infoMsg).toMatch(/boundEpic=owner\/repo#5/);
+  });
+
+  it('same-repo child-issue answer (different issue number) is NOT dropped', async () => {
+    const mem = makeMemFs();
+    // Bound epic is owner/repo#5; a gate opened on child issue owner/repo#42
+    // must still be delivered (repo-scope, not issue-number, matching).
+    mem.setContent(
+      goodLine({ gateKey: 'owner/repo#42:implementation-review:abc123' }),
+    );
+    const logger = makeLogger();
+    const onEvent = vi.fn();
+    const src = new AnswersFileSource(
+      baseOptions({ fs: mem.fs, onEvent, logger }),
+    );
+    await src.start();
+    await src.stop();
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    const infoDrops = logger.info.mock.calls.filter((c) =>
+      (c[0] as string).includes('cross-epic drop'),
+    );
+    expect(infoDrops).toHaveLength(0);
+  });
+
+  it('non-issue gateKey target (filing/scope-drained tracking ref) is emitted, not scope-dropped', async () => {
+    const mem = makeMemFs();
+    // A gateKey whose issue-ref does not parse as owner/repo#N (e.g. a filing
+    // draft target). The tailer cannot determine scope, so it emits.
+    mem.setContent(
+      goodLine({ gateKey: 'tracking-thread-7:filing:draft-hash-9' }),
+    );
+    const onEvent = vi.fn();
+    const src = new AnswersFileSource(
+      baseOptions({ fs: mem.fs, onEvent }),
+    );
+    await src.start();
+    await src.stop();
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
   });
 
   it('event.ts uses injected now() clock (deterministic)', async () => {

--- a/packages/generacy/src/cli/commands/cockpit/doorbell/answers-file-source.ts
+++ b/packages/generacy/src/cli/commands/cockpit/doorbell/answers-file-source.ts
@@ -53,7 +53,19 @@ export interface AnswersFileSourceLogger {
 }
 
 export interface AnswersFileSourceOptions {
-  /** Bound epic ref in "owner/repo#number" form. Used to filter GateAnswerLine.scope. */
+  /**
+   * Bound epic ref in "owner/repo#number" form. The frozen down-path
+   * gate-answer carries no `scope`; the repo-scope filter compares this epic's
+   * owner/repo against the owner/repo parsed from each answer's `gateKey`
+   * issue-ref (see `parseIssueRefFromGateKey`).
+   *
+   * KNOWN LIMITATION (cross-repo epics): the filter matches owner/repo only, so
+   * an answer for a child issue that lives in a DIFFERENT repo than the epic is
+   * dropped as cross-epic. Cross-repo remote gates are not yet exercised (the
+   * dogfood is single-repo); tracked as a follow-up — thread the epic's child
+   * ref-set into the tailer, or drop the repo filter and rely on downstream
+   * gateId matching (no open gate ⇒ no match ⇒ harmless over-delivery).
+   */
   epicRef: string;
   /** Absolute path to the answers NDJSON file. */
   filePath?: string;
@@ -150,22 +162,23 @@ function extractGateIdBestEffort(line: string): string | undefined {
   return undefined;
 }
 
-function stringifyScope(scope: unknown): string {
-  if (scope != null && typeof scope === 'object') {
-    const rec = scope as Record<string, unknown>;
-    if (
-      typeof rec.owner === 'string' &&
-      typeof rec.repo === 'string' &&
-      typeof rec.number === 'number'
-    ) {
-      return `${rec.owner}/${rec.repo}#${rec.number}`;
-    }
-  }
-  try {
-    return JSON.stringify(scope);
-  } catch {
-    return String(scope);
-  }
+/**
+ * Parse the issue-ref portion of a frozen gate-answer `gateKey`
+ * (`<owner>/<repo>#<issue>:<gateType>:<generation>`) into owner/repo/number.
+ * The issue-ref is the substring up to the FIRST `:` — `gateType` and
+ * `generation` may themselves contain `:` (e.g. escalation
+ * `subtype:state:occurrence`), but the issue-ref never does. Returns null for a
+ * non-issue target (filing / scope-drained may key on a tracking ref that is
+ * not an `owner/repo#N` issue); such lines skip the scope filter and are
+ * emitted (downstream keys on gateId).
+ */
+function parseIssueRefFromGateKey(
+  gateKey: string,
+): { owner: string; repo: string; number: number } | null {
+  const issueRef = gateKey.split(':', 1)[0] ?? '';
+  const m = issueRef.match(/^([^/]+)\/([^/]+)#(\d+)$/);
+  if (m == null) return null;
+  return { owner: m[1]!, repo: m[2]!, number: Number(m[3]!) };
 }
 
 export class AnswersFileSource {
@@ -620,14 +633,23 @@ export class AnswersFileSource {
     }
     const gateLine: GateAnswerLine = parsed.data;
 
-    // (c) Epic scope filter
+    // (c) Repo-scope filter. The frozen down-path gate-answer carries no
+    // `scope`; the bound epic is compared against the owner/repo parsed out of
+    // the answer's `gateKey` issue-ref. Per-issue gates (a child issue of the
+    // epic, or the epic itself for a phase-queue gate) share the epic's
+    // owner/repo, so the filter matches on owner/repo only — NOT the issue
+    // number — so legitimate child-issue answers are not dropped. A gateKey
+    // whose issue-ref cannot be parsed (a non-issue filing / scope-drained
+    // target) is emitted; downstream matches on gateId. Foreign-repo answers
+    // are dropped + logged.
+    const gateScope = parseIssueRefFromGateKey(gateLine.gateKey);
     if (
-      gateLine.scope.owner !== this.epicScope.owner ||
-      gateLine.scope.repo !== this.epicScope.repo ||
-      gateLine.scope.number !== this.epicScope.number
+      gateScope != null &&
+      (gateScope.owner !== this.epicScope.owner ||
+        gateScope.repo !== this.epicScope.repo)
     ) {
       this.logger.info?.(
-        `cockpit doorbell: answers file: cross-epic drop file=${this.filePath} byteOffset=${byteOffset} gateId=${gateLine.gateId} scope=${stringifyScope(gateLine.scope)} boundEpic=${this.epicRef}`,
+        `cockpit doorbell: answers file: cross-epic drop file=${this.filePath} byteOffset=${byteOffset} gateId=${gateLine.gateId} scope=${gateScope.owner}/${gateScope.repo}#${gateScope.number} boundEpic=${this.epicRef}`,
       );
       return;
     }

--- a/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-ack.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-ack.test.ts
@@ -1,7 +1,13 @@
 /**
- * Parity tests for `cockpit_gate_ack` (#1022) — 13 rows in
- * contracts/cockpit_gate_ack.md § "Test surface".
+ * Parity tests for `cockpit_gate_ack` (#1022 / #843) — the FROZEN wire contract.
+ *
+ * The tool now emits a gate-outcome record (Shape 2, THE ACK): a flat
+ * { type:'gate-outcome', gateId, outcome, detail?, at } frame with a CLOSED
+ * outcome enum ('applied' | 'superseded' | 'failed'). These tests pin that
+ * frozen shape — they REPLACE the prior #1033/#1035 pins that asserted the WRONG
+ * gate-ack (`kind`/`ackedAt`/`generation`, free-string `outcome`).
  */
+import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { cockpitGateAck } from '../tools/cockpit_gate_ack.js';
 
@@ -12,42 +18,101 @@ function jsonResponse(status: number, body: unknown, text?: string): Response {
   });
 }
 
+function bodyOf(spy: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const init = spy.mock.calls[0]?.[1] as RequestInit;
+  return JSON.parse(String(init.body)) as Record<string, unknown>;
+}
+
 const BASE_DEPS = {
   orchestratorUrl: 'http://mock.local',
   orchestratorTimeoutMs: 5000,
 };
 
+// A real 24-char hex gateId (as `deriveGateId` would produce).
+const GATE_ID = createHash('sha256')
+  .update('generacy-ai/generacy#1022:clarification:batch-1', 'utf8')
+  .digest('hex')
+  .slice(0, 24);
+
 const CANONICAL_INPUT = {
-  gateId: 'gate_01HK7Z',
-  outcome: 'approved',
+  gateId: GATE_ID,
+  outcome: 'applied' as const,
 };
 
-describe('cockpit_gate_ack parity (#1022)', () => {
-  it('happy 200 with JSON body → ok envelope with orchestrator body', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { ackId: 'a_1', accepted: true }));
+describe('cockpit_gate_ack parity — frozen gate-outcome (#1022/#843)', () => {
+  it('emits a gate-outcome frame to /ack and returns the orchestrator body', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { ok: true }));
     const result = await cockpitGateAck(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
     expect(result.status).toBe('ok');
     if (result.status !== 'ok') return;
-    expect(result.data).toEqual({ ackId: 'a_1', accepted: true });
+    expect(result.data).toEqual({ ok: true });
+
+    expect(spy.mock.calls[0]?.[0]).toBe(`http://mock.local/cockpit/gates/${GATE_ID}/ack`);
+
+    const body = bodyOf(spy);
+    expect(body.type).toBe('gate-outcome');
+    expect(body.gateId).toBe(GATE_ID);
+    expect(body.outcome).toBe('applied');
+    expect(typeof body.at).toBe('string');
+    expect(Number.isNaN(Date.parse(body.at as string))).toBe(false);
+    expect(body).not.toHaveProperty('detail');
+
+    // The old WRONG gate-ack shape must NOT leak onto the wire.
+    expect(body).not.toHaveProperty('kind');
+    expect(body).not.toHaveProperty('generation');
+    expect(body).not.toHaveProperty('ackedAt');
   });
 
-  it('2xx with non-JSON body → class: internal', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, undefined, 'not-json {'));
-    const result = await cockpitGateAck(CANONICAL_INPUT, {
+  it('forwards detail + explicit at verbatim', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { ok: true }));
+    const input = {
+      gateId: GATE_ID,
+      outcome: 'superseded' as const,
+      detail: 're-opened as a new generation',
+      at: '2026-07-22T12:00:00.000Z',
+    };
+    const result = await cockpitGateAck(input, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
+    expect(result.status).toBe('ok');
+    expect(bodyOf(spy)).toEqual({
+      type: 'gate-outcome',
+      gateId: GATE_ID,
+      outcome: 'superseded',
+      detail: 're-opened as a new generation',
+      at: '2026-07-22T12:00:00.000Z',
+    });
+  });
+
+  it("accepts outcome 'failed'", async () => {
+    const spy = vi.fn(async () => jsonResponse(200, {}));
+    const result = await cockpitGateAck(
+      { gateId: GATE_ID, outcome: 'failed' },
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
+    expect(result.status).toBe('ok');
+    expect(bodyOf(spy).outcome).toBe('failed');
+  });
+
+  it('rejects an off-enum outcome (e.g. legacy "approved") → class: invalid-args', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, {}));
+    const result = await cockpitGateAck(
+      { gateId: GATE_ID, outcome: 'approved' } as unknown,
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
     expect(result.status).toBe('error');
     if (result.status !== 'error') return;
-    expect(result.class).toBe('internal');
+    expect(result.class).toBe('invalid-args');
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it('missing gateId → class: invalid-args', async () => {
     const spy = vi.fn(async () => jsonResponse(200, {}));
-    const result = await cockpitGateAck({ outcome: 'approved' } as unknown, {
+    const result = await cockpitGateAck({ outcome: 'applied' } as unknown, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -59,7 +124,7 @@ describe('cockpit_gate_ack parity (#1022)', () => {
 
   it('missing outcome → class: invalid-args', async () => {
     const spy = vi.fn(async () => jsonResponse(200, {}));
-    const result = await cockpitGateAck({ gateId: 'g_1' } as unknown, {
+    const result = await cockpitGateAck({ gateId: GATE_ID } as unknown, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -69,9 +134,9 @@ describe('cockpit_gate_ack parity (#1022)', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('empty gateId → class: invalid-args', async () => {
+  it('gateId not 24 hex chars → class: invalid-args', async () => {
     const spy = vi.fn(async () => jsonResponse(200, {}));
-    const result = await cockpitGateAck({ gateId: '', outcome: 'approved' }, {
+    const result = await cockpitGateAck({ gateId: 'g_1', outcome: 'applied' } as unknown, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -84,13 +149,24 @@ describe('cockpit_gate_ack parity (#1022)', () => {
   it('extra key (strict-mode rejection) → class: invalid-args', async () => {
     const spy = vi.fn(async () => jsonResponse(200, {}));
     const result = await cockpitGateAck(
-      { ...CANONICAL_INPUT, gate_id: 'g_typo' } as unknown,
+      { ...CANONICAL_INPUT, generation: 3 } as unknown,
       { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
     );
     expect(result.status).toBe('error');
     if (result.status !== 'error') return;
     expect(result.class).toBe('invalid-args');
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('2xx with non-JSON body → class: internal', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, undefined, 'not-json {'));
+    const result = await cockpitGateAck(CANONICAL_INPUT, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('internal');
   });
 
   it('HTTP 400 → class: invalid-args', async () => {
@@ -124,6 +200,17 @@ describe('cockpit_gate_ack parity (#1022)', () => {
     expect(result.status).toBe('error');
     if (result.status !== 'error') return;
     expect(result.class).toBe('invalid-args');
+  });
+
+  it('HTTP 401 → class: internal', async () => {
+    const spy = vi.fn(async () => jsonResponse(401, undefined, 'unauth'));
+    const result = await cockpitGateAck(CANONICAL_INPUT, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('internal');
   });
 
   it('HTTP 500 → class: transport', async () => {
@@ -168,30 +255,5 @@ describe('cockpit_gate_ack parity (#1022)', () => {
     if (result.status !== 'error') return;
     expect(result.class).toBe('transport');
     expect(result.detail).toMatch(/timed out after 15ms/);
-  });
-
-  it('detail present + happy path → wire body contains {outcome, detail} verbatim', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { ok: true }));
-    const input = { gateId: 'g_5', outcome: 'approved', detail: 'batch 1 answers look correct' };
-    const result = await cockpitGateAck(input, {
-      ...BASE_DEPS,
-      fetchImpl: spy as unknown as typeof fetch,
-    });
-    expect(result.status).toBe('ok');
-    // Verify the URL includes the encoded gateId.
-    expect(spy.mock.calls[0]?.[0]).toBe('http://mock.local/cockpit/gates/g_5/ack');
-    // Verify the wire body carries {outcome, detail}, not gateId.
-    const init = spy.mock.calls[0]?.[1] as RequestInit;
-    const body = JSON.parse(String(init.body));
-    expect(body).toEqual({ outcome: 'approved', detail: 'batch 1 answers look correct' });
-  });
-
-  it('encodes gateId in URL path', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, {}));
-    await cockpitGateAck({ gateId: 'g/with spaces', outcome: 'approved' }, {
-      ...BASE_DEPS,
-      fetchImpl: spy as unknown as typeof fetch,
-    });
-    expect(spy.mock.calls[0]?.[0]).toBe('http://mock.local/cockpit/gates/g%2Fwith%20spaces/ack');
   });
 });

--- a/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-open.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-open.test.ts
@@ -1,11 +1,17 @@
 /**
- * Parity tests for `cockpit_gate_open` (#1022) — MCP-boundary coverage of the
- * 11 rows in contracts/cockpit_gate_open.md § "Test surface".
+ * Parity tests for `cockpit_gate_open` (#1022 / #843) — the FROZEN wire contract.
+ *
+ * The tool now takes SEMANTIC fields and DERIVES gateKey + gateId, assembling
+ * the flat frozen gate-open record (type:'gate-open', presentation fields at top
+ * level) that the orchestrator relays verbatim to the cloud. These tests pin
+ * that frozen shape and the derivation — they REPLACE the prior #1033/#1035 pins
+ * that asserted the WRONG { kind, scope, generation, openedAt } shape.
  *
  * Injection pattern mirrors parity-claim.test.ts: build the tool with a spy
  * `fetchImpl` so no real HTTP call is made and no `global.fetch` monkey-patch
  * is needed.
  */
+import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { cockpitGateOpen } from '../tools/cockpit_gate_open.js';
 
@@ -16,36 +22,169 @@ function jsonResponse(status: number, body: unknown, text?: string): Response {
   });
 }
 
+function gateIdFor(key: string): string {
+  return createHash('sha256').update(key, 'utf8').digest('hex').slice(0, 24);
+}
+
+function bodyOf(spy: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const init = spy.mock.calls[0]?.[1] as RequestInit;
+  return JSON.parse(String(init.body)) as Record<string, unknown>;
+}
+
 const BASE_DEPS = {
   orchestratorUrl: 'http://mock.local',
   orchestratorTimeoutMs: 5000,
 };
 
-const CANONICAL_GATE: Record<string, unknown> = {
-  kind: 'clarification-review',
-  scope: 'generacy-ai/generacy#1022',
-  phase: 'clarify',
-  generation: 1,
+const ISSUE_REF = 'generacy-ai/generacy#1022';
+const GATE_TYPE = 'clarification';
+const GENERATION = 'batch-7f3a2b';
+const EXPECTED_KEY = `${ISSUE_REF}:${GATE_TYPE}:${GENERATION}`;
+const EXPECTED_ID = gateIdFor(EXPECTED_KEY);
+
+const CANONICAL_INPUT: Record<string, unknown> = {
+  issueRef: ISSUE_REF,
+  gateType: GATE_TYPE,
+  generation: GENERATION,
+  epicRef: 'generacy-ai/generacy#1000',
+  issueTitle: 'Remote gates wire contract',
+  issueUrl: 'https://github.com/generacy-ai/generacy/issues/1022',
+  title: 'Answer the open clarifications',
+  body: 'Two questions are outstanding.',
+  options: [
+    { id: 'approve', label: 'Approve drafted answers', recommended: true },
+    { id: 'revise', label: 'Make changes' },
+  ],
+  allowFreeText: true,
+  sessionId: 'sess-abcdef0123456789',
+  askedAt: '2026-07-22T12:00:00.000Z',
 };
 
-describe('cockpit_gate_open parity (#1022)', () => {
-  it('happy 200 → ok envelope with gateId + status', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: 'g_1', status: 'open' }));
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
+  it('derives gateKey + gateId and forwards the flat frozen record', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
     expect(result.status).toBe('ok');
     if (result.status !== 'ok') return;
-    expect(result.data.gateId).toBe('g_1');
+    expect(result.data.gateId).toBe(EXPECTED_ID);
     expect(result.data.status).toBe('open');
+
+    // POSTs to the gate-open route.
+    expect(spy.mock.calls[0]?.[0]).toBe('http://mock.local/cockpit/gates');
+
+    const body = bodyOf(spy);
+    expect(body.type).toBe('gate-open');
+    expect(body.gateKey).toBe(EXPECTED_KEY);
+    expect(body.gateId).toBe(EXPECTED_ID);
+    expect(String(body.gateId)).toHaveLength(24);
+    expect(body.gateType).toBe('clarification');
+    expect(body.issueRef).toBe(ISSUE_REF);
+    expect(body.epicRef).toBe('generacy-ai/generacy#1000');
+    expect(body.issueTitle).toBe(CANONICAL_INPUT.issueTitle);
+    expect(body.issueUrl).toBe(CANONICAL_INPUT.issueUrl);
+    expect(body.title).toBe(CANONICAL_INPUT.title);
+    expect(body.body).toBe(CANONICAL_INPUT.body);
+    expect(body.options).toEqual(CANONICAL_INPUT.options);
+    expect(body.allowFreeText).toBe(true);
+    expect(body.sessionId).toBe(CANONICAL_INPUT.sessionId);
+    expect(body.askedAt).toBe('2026-07-22T12:00:00.000Z');
+
+    // The old WRONG shape must NOT leak onto the wire.
+    expect(body).not.toHaveProperty('kind');
+    expect(body).not.toHaveProperty('scope');
+    expect(body).not.toHaveProperty('generation');
+    expect(body).not.toHaveProperty('openedAt');
   });
 
-  it('passthrough field forwarded (e.g. inboxUrl)', async () => {
-    const spy = vi.fn(async () =>
-      jsonResponse(200, { gateId: 'g_2', status: 'open', inboxUrl: 'https://app.example/inbox/g_2' }),
+  it('coerces a numeric generation into gateKey (phase-queue on the epic ref)', async () => {
+    const epicRef = 'generacy-ai/generacy#1000';
+    const key = `${epicRef}:phase-queue:2`;
+    const id = gateIdFor(key);
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: id, status: 'open' }));
+    const result = await cockpitGateOpen(
+      {
+        ...CANONICAL_INPUT,
+        issueRef: epicRef,
+        gateType: 'phase-queue',
+        generation: 2,
+        options: [],
+      },
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
     );
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    expect(result.status).toBe('ok');
+    const body = bodyOf(spy);
+    expect(body.gateType).toBe('phase-queue');
+    expect(body.gateKey).toBe(key);
+    expect(body.gateId).toBe(id);
+  });
+
+  it('forwards branch + prNumber when supplied (implementation-review)', async () => {
+    const key = `${ISSUE_REF}:implementation-review:deadbeefcafe`;
+    const id = gateIdFor(key);
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: id, status: 'open' }));
+    const result = await cockpitGateOpen(
+      {
+        ...CANONICAL_INPUT,
+        gateType: 'implementation-review',
+        generation: 'deadbeefcafe',
+        branch: 'feat/1022-gates',
+        prNumber: 42,
+      },
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
+    expect(result.status).toBe('ok');
+    const body = bodyOf(spy);
+    expect(body.branch).toBe('feat/1022-gates');
+    expect(body.prNumber).toBe(42);
+  });
+
+  it('omits optional wire fields (branch/prNumber) when absent', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    await cockpitGateOpen(CANONICAL_INPUT, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    const body = bodyOf(spy);
+    expect(body).not.toHaveProperty('branch');
+    expect(body).not.toHaveProperty('prNumber');
+  });
+
+  it('defaults askedAt to a fresh ISO timestamp when omitted', async () => {
+    const { askedAt: _drop, ...noAskedAt } = CANONICAL_INPUT;
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const result = await cockpitGateOpen(noAskedAt, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(result.status).toBe('ok');
+    const body = bodyOf(spy);
+    expect(typeof body.askedAt).toBe('string');
+    expect(() => new Date(body.askedAt as string).toISOString()).not.toThrow();
+    expect(Number.isNaN(Date.parse(body.askedAt as string))).toBe(false);
+  });
+
+  it('defaults allowFreeText to true when omitted', async () => {
+    const { allowFreeText: _drop, ...noFreeText } = CANONICAL_INPUT;
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    await cockpitGateOpen(noFreeText, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(bodyOf(spy).allowFreeText).toBe(true);
+  });
+
+  it('passthrough response field forwarded (e.g. inboxUrl)', async () => {
+    const spy = vi.fn(async () =>
+      jsonResponse(200, {
+        gateId: EXPECTED_ID,
+        status: 'open',
+        inboxUrl: 'https://app.example/inbox/g_2',
+      }),
+    );
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -54,8 +193,8 @@ describe('cockpit_gate_open parity (#1022)', () => {
     expect(result.data['inboxUrl']).toBe('https://app.example/inbox/g_2');
   });
 
-  it('input not an object → class: invalid-args', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: 'g', status: 'open' }));
+  it('input not an object → class: invalid-args (no HTTP call)', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
     const result = await cockpitGateOpen('not-an-object' as unknown, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -66,9 +205,58 @@ describe('cockpit_gate_open parity (#1022)', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('missing required field (sessionId) → class: invalid-args (no HTTP call)', async () => {
+    const { sessionId: _drop, ...noSession } = CANONICAL_INPUT;
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const result = await cockpitGateOpen(noSession, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('invalid-args');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('unknown gateType → class: invalid-args (no HTTP call)', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const result = await cockpitGateOpen(
+      { ...CANONICAL_INPUT, gateType: 'not-a-gate-type' },
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('invalid-args');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('extra/unknown key (strict) → class: invalid-args (no HTTP call)', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const result = await cockpitGateOpen(
+      { ...CANONICAL_INPUT, gateId: 'hand-built-should-be-rejected' },
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('invalid-args');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('non-URL issueUrl → class: invalid-args (no HTTP call)', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const result = await cockpitGateOpen(
+      { ...CANONICAL_INPUT, issueUrl: 'generacy-ai/generacy#1022' },
+      { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
+    );
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('invalid-args');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it('HTTP 400 → class: invalid-args', async () => {
     const spy = vi.fn(async () => jsonResponse(400, undefined, 'bad shape'));
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -79,7 +267,7 @@ describe('cockpit_gate_open parity (#1022)', () => {
 
   it('HTTP 404 → class: unknown-gate', async () => {
     const spy = vi.fn(async () => jsonResponse(404, undefined, 'gate not found'));
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -90,7 +278,7 @@ describe('cockpit_gate_open parity (#1022)', () => {
 
   it('HTTP 409 → class: invalid-args', async () => {
     const spy = vi.fn(async () => jsonResponse(409, undefined, 'conflict'));
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -101,7 +289,7 @@ describe('cockpit_gate_open parity (#1022)', () => {
 
   it('HTTP 401 → class: internal', async () => {
     const spy = vi.fn(async () => jsonResponse(401, undefined, 'unauth'));
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -112,7 +300,7 @@ describe('cockpit_gate_open parity (#1022)', () => {
 
   it('HTTP 500 → class: transport', async () => {
     const spy = vi.fn(async () => jsonResponse(500, undefined, 'boom'));
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -125,7 +313,7 @@ describe('cockpit_gate_open parity (#1022)', () => {
     const spy = vi.fn(async () => {
       throw new Error('ECONNREFUSED 127.0.0.1:3100');
     });
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });
@@ -143,7 +331,7 @@ describe('cockpit_gate_open parity (#1022)', () => {
       });
       throw new Error('unreachable');
     });
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       orchestratorUrl: 'http://mock.local',
       orchestratorTimeoutMs: 10,
       fetchImpl: spy as unknown as typeof fetch,
@@ -156,7 +344,7 @@ describe('cockpit_gate_open parity (#1022)', () => {
 
   it('2xx with missing gateId → class: internal', async () => {
     const spy = vi.fn(async () => jsonResponse(200, { status: 'open' /* no gateId */ }));
-    const result = await cockpitGateOpen(CANONICAL_GATE, {
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
     });

--- a/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
@@ -1,47 +1,178 @@
 /**
- * Local Zod schemas for the two remote-gate MCP tools (#1022).
+ * Local Zod mirrors for the two remote-gate MCP tools (#1022 / #843).
  *
- * Wire contracts (`GateRecord` shape, `gateId`/`generation` rules,
- * `status`/`outcome` enums, NDJSON answer line) are owned by the epic:
- *   contracts/cockpit_gate_open.md
- *   docs/cockpit-remote-gates-plan.md (agency-repo epic doc)
+ * These are the CLUSTER-side (generacy) mirror of the frozen wire contract in
+ * tetrad-development/docs/cockpit-remote-gates-plan.md § "Wire contracts" and
+ * generacy-cloud/specs/843-part-cockpit-remote-gates/contracts/gates-wire.md
+ * (Shapes 1 & 2). The cloud is the authoritative RECEIVER; these mirrors MUST
+ * stay field-for-field compatible with it.
  *
- * The schemas below are LOCAL MIRRORS for input validation and response
- * typing. `.passthrough()` on the record shape means unknown caller fields
- * are forwarded to the orchestrator verbatim — contract drift on the epic
- * side never causes a local schema-strip bug.
+ * DESIGN (approved): `cockpit_gate_open` DERIVES gateKey + gateId in TypeScript
+ * from (issueRef, gateType, generation-discriminator). The plugin/LLM NEVER
+ * hand-builds a sha256 or the gateKey string — it passes semantic + presentation
+ * fields only, and the tool assembles the flat frozen record and sets
+ * type:'gate-open'. `cockpit_gate_ack` emits a gate-outcome record (Shape 2,
+ * THE ACK) — NOT the old invented gate-ack.
+ *
+ * The derivation helpers are duplicated here (rather than imported from
+ * `@generacy-ai/cockpit`) so the MCP boundary stays insulated from cross-package
+ * export churn — the same insulation rationale as the prior passthrough mirror,
+ * and it keeps the tool's input a FLAT `z.object` (the MCP `inputSchema` needs a
+ * `.shape`; the prior `z.record().and()` intersection had none — gen#1032/#1033).
  *
  * Data-model reference: specs/1022-part-cockpit-remote-gates/data-model.md
  * § "Core types" and § "MCP-boundary schemas".
  */
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 
-/**
- * Caller-supplied gate record. Local schema is a passthrough object so the
- * orchestrator remains the sole authority on `GateRecord` shape.
- */
-export const GateRecordSchema = z
-  .record(z.unknown())
-  .and(z.object({}).passthrough());
-export type GateRecord = z.infer<typeof GateRecordSchema>;
+// ---------------------------------------------------------------------------
+// Enums — mirror the cloud `cockpitGateTypeEnum` / gate-outcome enum exactly.
+// ---------------------------------------------------------------------------
+
+/** 8-value gate-type enum (order preserved to match the cloud enum). */
+export const GateTypeSchema = z.enum([
+  'clarification',
+  'artifact-review',
+  'implementation-review',
+  'manual-validation',
+  'escalation',
+  'phase-queue',
+  'filing',
+  'scope-drained',
+]);
+export type GateType = z.infer<typeof GateTypeSchema>;
+
+/** Closed gate-outcome enum (replaces the old free-string outcome). */
+export const GateOutcomeSchema = z.enum(['applied', 'superseded', 'failed']);
+export type GateOutcome = z.infer<typeof GateOutcomeSchema>;
+
+/** Presentation option — mirrors cloud `cockpitGateOptionSchema`. */
+export const GateOptionSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  recommended: z.boolean().optional(),
+});
+export type GateOption = z.infer<typeof GateOptionSchema>;
+
+// ---------------------------------------------------------------------------
+// Gate identity derivation (frozen contract).
+//   gateKey = `${issueRef}:${gateType}:${generation}`  (issueRef is owner/repo#N)
+//   gateId  = sha256(gateKey) hex, first 24 chars.
+// `generation` is the gateType-specific discriminator (batch id, head SHA,
+// phase number, draft hash, occurrence counter, drain counter, …); coerced to
+// a string so numeric discriminators (phase 2) are stable.
+// ---------------------------------------------------------------------------
+export function deriveGateKey(
+  issueRef: string,
+  gateType: GateType,
+  generation: string | number,
+): string {
+  return `${issueRef}:${gateType}:${String(generation)}`;
+}
+
+export function deriveGateId(gateKey: string): string {
+  return createHash('sha256').update(gateKey, 'utf8').digest('hex').slice(0, 24);
+}
+
+// ---------------------------------------------------------------------------
+// `cockpit_gate_open` — SEMANTIC input (what the plugin passes).
+// The tool derives gateKey/gateId and assembles the frozen record. `.strict()`
+// surfaces caller typos at the MCP boundary as `invalid-args`.
+// ---------------------------------------------------------------------------
+export const GateOpenInputSchema = z
+  .object({
+    /** owner/repo#N (for G.5 the epic ref; for G.6/G.7 the tracking/filing target). */
+    issueRef: z.string().min(1),
+    gateType: GateTypeSchema,
+    /** gateType-specific discriminator (batch id / head SHA / phase number / …). */
+    generation: z.union([z.string().min(1), z.number()]),
+    epicRef: z.string().min(1),
+    issueTitle: z.string(),
+    /** Fully-qualified https issue URL — the cloud pins z.string().url(). */
+    issueUrl: z.string().url(),
+    branch: z.string().min(1).optional(),
+    prNumber: z.number().int().positive().optional(),
+    title: z.string(),
+    body: z.string(),
+    options: z.array(GateOptionSchema).min(0).max(20).default([]),
+    /** Every gate keeps an "Other"-style escape hatch; defaults to true. */
+    allowFreeText: z.boolean().default(true),
+    sessionId: z.string().min(1),
+    /** ISO-8601; defaulted to now() by the tool when omitted. */
+    askedAt: z.string().datetime().optional(),
+  })
+  .strict();
+export type GateOpenInput = z.infer<typeof GateOpenInputSchema>;
 
 /**
- * Strict three-field ack input. `.strict()` catches typos (`gate_id` vs
- * `gateId`) at the tool boundary with a clear `invalid-args` error.
+ * Frozen gate-open wire record (Shape 1) — the flat record the tool forwards to
+ * the orchestrator, which relays it verbatim to the cloud. Field-for-field
+ * mirror of cloud `gateOpenPayloadSchema` (message-handler.ts). The tool
+ * self-validates its assembled record against this before it leaves the cluster.
+ */
+export const GateOpenWireSchema = z.object({
+  type: z.literal('gate-open'),
+  gateId: z.string().length(24),
+  gateKey: z.string().min(1),
+  gateType: GateTypeSchema,
+  epicRef: z.string().min(1),
+  issueRef: z.string().min(1),
+  issueTitle: z.string(),
+  issueUrl: z.string().url(),
+  branch: z.string().optional(),
+  prNumber: z.number().int().positive().optional(),
+  title: z.string(),
+  body: z.string(),
+  options: z.array(GateOptionSchema).min(0).max(20),
+  allowFreeText: z.boolean(),
+  sessionId: z.string().min(1),
+  askedAt: z.string().datetime(),
+});
+export type GateOpenWire = z.infer<typeof GateOpenWireSchema>;
+
+// ---------------------------------------------------------------------------
+// `cockpit_gate_ack` — SEMANTIC input + frozen gate-outcome wire record.
+// ---------------------------------------------------------------------------
+
+/**
+ * Strict ack input. `outcome` is the closed frozen enum (NOT a free string);
+ * `at` defaults to now() in the tool when omitted. `.strict()` catches typos
+ * (`gate_id`, `ackedAt`, a stray `generation`, …) at the boundary.
  */
 export const GateAckInputSchema = z
   .object({
-    gateId: z.string().min(1),
-    outcome: z.string().min(1),
+    gateId: z.string().length(24),
+    outcome: GateOutcomeSchema,
     detail: z.string().optional(),
+    at: z.string().datetime().optional(),
   })
   .strict();
 export type GateAckInput = z.infer<typeof GateAckInputSchema>;
 
 /**
- * Orchestrator response envelope for `POST /cockpit/gates`. Asserts the two
- * fields the tool contract promises callers; additional fields (e.g.
- * `coalescedWith`, `inboxUrl`) pass through opaquely.
+ * Frozen gate-outcome wire record (Shape 2, THE ACK) — mirror of cloud
+ * `gateOutcomePayloadSchema`. Replaces the invented gate-ack: `type` (not
+ * `kind`), `at` (not `ackedAt`), closed `outcome` enum, and NO `generation`.
+ */
+export const GateOutcomeWireSchema = z.object({
+  type: z.literal('gate-outcome'),
+  gateId: z.string().length(24),
+  outcome: GateOutcomeSchema,
+  detail: z.string().optional(),
+  at: z.string().datetime(),
+});
+export type GateOutcomeWire = z.infer<typeof GateOutcomeWireSchema>;
+
+// ---------------------------------------------------------------------------
+// Orchestrator response envelopes.
+// ---------------------------------------------------------------------------
+
+/**
+ * Response envelope for `POST /cockpit/gates`. Asserts the two fields the tool
+ * contract promises callers; additional fields (e.g. `coalescedWith`,
+ * `inboxUrl`) pass through opaquely.
  */
 export const GateOpenResponseSchema = z
   .object({ gateId: z.string(), status: z.string() })
@@ -49,9 +180,9 @@ export const GateOpenResponseSchema = z
 export type GateOpenResponse = z.infer<typeof GateOpenResponseSchema>;
 
 /**
- * Opaque response envelope for `POST /cockpit/gates/:id/ack`. The body shape
- * is not asserted at this boundary — whatever JSON the orchestrator returns
- * is forwarded verbatim inside `ToolOkResult.data`.
+ * Opaque response envelope for `POST /cockpit/gates/:id/ack`. The body shape is
+ * not asserted at this boundary — whatever JSON the orchestrator returns is
+ * forwarded verbatim inside `ToolOkResult.data`.
  */
 export const GateAckResponseSchema = z.record(z.unknown());
 export type GateAckResponse = z.infer<typeof GateAckResponseSchema>;

--- a/packages/generacy/src/cli/commands/cockpit/mcp/schemas.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/schemas.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { listGates } from '../gate-vocabulary.js';
 import { SESSION_ID_REGEX } from './claim/payload.js';
 import {
-  GateRecordSchema as InternalGateRecordSchema,
+  GateOpenInputSchema as InternalGateOpenInputSchema,
   GateAckInputSchema as InternalGateAckInputSchema,
 } from './gates/schemas.js';
 
@@ -188,12 +188,17 @@ export type CockpitRelayClarifyAnswersInput = z.infer<
 >;
 
 /**
- * #1022 — remote-gate MCP-boundary schemas. Re-exported from
+ * #1022 / #843 — remote-gate MCP-boundary schemas. Re-exported from
  * `./gates/schemas.ts` so the tool handlers (and the parity/audit tests)
- * consume a stable public-import surface. Wire contracts owned by the epic —
- * see `contracts/cockpit_gate_open.md`.
+ * consume a stable public-import surface. These are the SEMANTIC inputs: the
+ * plugin passes semantic + presentation fields and `cockpit_gate_open` derives
+ * gateKey/gateId and assembles the frozen `type:'gate-open'` record; the ack
+ * input carries the closed `outcome` enum and the tool emits `gate-outcome`.
+ * Both are flat `z.object`s so the MCP `inputSchema` has a `.shape`
+ * (gen#1032/#1033). Wire contract: cockpit-remote-gates-plan.md § "Wire
+ * contracts".
  */
-export const CockpitGateOpenInputSchema = InternalGateRecordSchema;
+export const CockpitGateOpenInputSchema = InternalGateOpenInputSchema;
 export type CockpitGateOpenInput = z.infer<typeof CockpitGateOpenInputSchema>;
 
 export const CockpitGateAckInputSchema = InternalGateAckInputSchema;

--- a/packages/generacy/src/cli/commands/cockpit/mcp/server.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/server.ts
@@ -216,7 +216,7 @@ export function buildMcpServer(deps: BuildMcpServerDeps = {}): McpServer {
     'cockpit_gate_ack',
     {
       description:
-        "Ack a previously-opened gate with an outcome (e.g. 'approved'/'rejected'). Thin HTTP client over POST /cockpit/gates/:id/ack.",
+        "Ack a previously-opened gate with a terminal outcome ('applied' | 'superseded' | 'failed'). Emits the frozen gate-outcome record over POST /cockpit/gates/:id/ack.",
       inputSchema: CockpitGateAckInputSchema,
     },
     async (args) => toCallToolResult(await cockpitGateAck(args, deps)),

--- a/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_ack.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_ack.ts
@@ -1,15 +1,19 @@
 /**
- * `cockpit_gate_ack` MCP tool (#1022).
+ * `cockpit_gate_ack` MCP tool (#1022 / #843).
  *
- * Thin HTTP client: validates `{gateId, outcome, detail?}` (strict), POSTs to
- * `POST /cockpit/gates/:id/ack`, forwards the orchestrator's opaque response
- * inside the `ToolResult` envelope. Response body shape is NOT asserted at
- * this boundary (contracts/cockpit_gate_ack.md § "Output — success").
+ * Assembles the frozen gate-outcome wire record (Shape 2, THE ACK) and POSTs it
+ * to `POST /cockpit/gates/:id/ack`, which relays it verbatim to the cloud. The
+ * caller passes `{gateId, outcome, detail?, at?}`; the tool sets
+ * `type:'gate-outcome'` and defaults `at` to now() when omitted. This REPLACES
+ * the old invented gate-ack (`kind`/`ackedAt`/`generation`, free-string
+ * outcome). Response body shape is NOT asserted at this boundary
+ * (contracts/cockpit_gate_ack.md § "Output — success").
  */
 import { wrapToolBoundary, type ToolResult } from '../errors.js';
 import { CockpitGateAckInputSchema } from '../schemas.js';
 import { invokeGate } from '../gates/client.js';
 import { resolveGateOptions } from '../gates/options.js';
+import { GateOutcomeWireSchema, type GateOutcomeWire } from '../gates/schemas.js';
 import type { BuildMcpServerDeps } from '../server.js';
 
 export type CockpitGateAckData = Record<string, unknown>;
@@ -28,15 +32,32 @@ export function cockpitGateAck(
       };
     }
 
-    const options = resolveGateOptions(deps);
-    const body: { outcome: string; detail?: string } = { outcome: parsed.data.outcome };
-    if (parsed.data.detail !== undefined) body.detail = parsed.data.detail;
+    const s = parsed.data;
+    const record: GateOutcomeWire = {
+      type: 'gate-outcome',
+      gateId: s.gateId,
+      outcome: s.outcome,
+      ...(s.detail !== undefined ? { detail: s.detail } : {}),
+      at: s.at ?? new Date().toISOString(),
+    };
 
+    const wire = GateOutcomeWireSchema.safeParse(record);
+    if (!wire.success) {
+      return {
+        status: 'error',
+        class: 'internal',
+        detail: `assembled gate-outcome record failed frozen-shape validation: ${wire.error.issues
+          .map((i) => i.message)
+          .join('; ')}`,
+      };
+    }
+
+    const options = resolveGateOptions(deps);
     return invokeGate<CockpitGateAckData>(
       {
         method: 'POST',
-        path: `/cockpit/gates/${encodeURIComponent(parsed.data.gateId)}/ack`,
-        body,
+        path: `/cockpit/gates/${encodeURIComponent(s.gateId)}/ack`,
+        body: wire.data,
       },
       options,
     );

--- a/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_open.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_open.ts
@@ -1,19 +1,30 @@
 /**
- * `cockpit_gate_open` MCP tool (#1022).
+ * `cockpit_gate_open` MCP tool (#1022 / #843).
  *
- * Thin HTTP client: validates the caller's gate record, POSTs to the
- * orchestrator's `POST /cockpit/gates` route, returns the response inside the
- * standard `ToolResult` envelope. No local business logic, no persistence,
- * no CLI-verb twin.
+ * DERIVES the gate identity and assembles the frozen gate-open wire record:
+ * the plugin/LLM passes SEMANTIC + presentation fields (issueRef, gateType,
+ * generation discriminator, title/body/options/allowFreeText, epicRef,
+ * issueTitle, issueUrl, branch?, prNumber?, sessionId, askedAt?); this tool
+ * computes gateKey + gateId, sets `type:'gate-open'`, self-validates against the
+ * frozen shape, and POSTs the flat record to the orchestrator's
+ * `POST /cockpit/gates` route (which relays it verbatim to the cloud). The
+ * plugin never hand-builds a sha256.
  *
  * Contract: contracts/cockpit_gate_open.md
- * Error mapping: contracts/error-mapping.md (mirror of `gates/client.ts`)
+ * Wire: tetrad-development/docs/cockpit-remote-gates-plan.md § "Wire contracts".
+ * Error mapping: contracts/error-mapping.md (mirror of `gates/client.ts`).
  */
 import { wrapToolBoundary, type ToolResult } from '../errors.js';
 import { CockpitGateOpenInputSchema } from '../schemas.js';
 import { invokeGate } from '../gates/client.js';
 import { resolveGateOptions } from '../gates/options.js';
-import { GateOpenResponseSchema } from '../gates/schemas.js';
+import {
+  deriveGateId,
+  deriveGateKey,
+  GateOpenResponseSchema,
+  GateOpenWireSchema,
+  type GateOpenWire,
+} from '../gates/schemas.js';
 import type { BuildMcpServerDeps } from '../server.js';
 
 export interface CockpitGateOpenData {
@@ -36,9 +47,46 @@ export function cockpitGateOpen(
       };
     }
 
+    const s = parsed.data;
+    const gateKey = deriveGateKey(s.issueRef, s.gateType, s.generation);
+    const gateId = deriveGateId(gateKey);
+
+    // Assemble the FLAT frozen record. Optional wire fields are omitted (not
+    // set to `undefined`) so the serialized frame matches the cloud schema.
+    const record: GateOpenWire = {
+      type: 'gate-open',
+      gateId,
+      gateKey,
+      gateType: s.gateType,
+      epicRef: s.epicRef,
+      issueRef: s.issueRef,
+      issueTitle: s.issueTitle,
+      issueUrl: s.issueUrl,
+      ...(s.branch !== undefined ? { branch: s.branch } : {}),
+      ...(s.prNumber !== undefined ? { prNumber: s.prNumber } : {}),
+      title: s.title,
+      body: s.body,
+      options: s.options,
+      allowFreeText: s.allowFreeText,
+      sessionId: s.sessionId,
+      askedAt: s.askedAt ?? new Date().toISOString(),
+    };
+
+    // Self-check: never emit a frame the cloud would warn-drop as malformed.
+    const wire = GateOpenWireSchema.safeParse(record);
+    if (!wire.success) {
+      return {
+        status: 'error',
+        class: 'internal',
+        detail: `assembled gate-open record failed frozen-shape validation: ${wire.error.issues
+          .map((i) => i.message)
+          .join('; ')}`,
+      };
+    }
+
     const options = resolveGateOptions(deps);
     const result = await invokeGate<CockpitGateOpenData>(
-      { method: 'POST', path: '/cockpit/gates', body: parsed.data },
+      { method: 'POST', path: '/cockpit/gates', body: wire.data },
       options,
     );
 

--- a/packages/generacy/src/cli/commands/cockpit/watch/gate-answer.ts
+++ b/packages/generacy/src/cli/commands/cockpit/watch/gate-answer.ts
@@ -1,25 +1,53 @@
 /**
- * `gate-answer` — new `CockpitStreamEvent` variant + wire schema for operator
+ * `gate-answer` — the `CockpitStreamEvent` variant + wire schema for operator
  * gate answers tailed from `/workspaces/.generacy/cockpit/answers.ndjson`.
  *
- * Contract: `specs/1023-part-cockpit-remote-gates/contracts/gate-answer-event.md`,
- * `specs/1023-part-cockpit-remote-gates/contracts/gate-answer-line.md`.
+ * The NDJSON line is the FROZEN down-path Shape 3 (cloud → cluster). See
+ * `tetrad-development/docs/cockpit-remote-gates-plan.md` § "Wire contracts" and
+ * `generacy-cloud/specs/843-part-cockpit-remote-gates/contracts/gates-wire.md`.
+ * The cloud is the authoritative SENDER; this schema must stay field-compatible
+ * with what `services/api/src/services/cockpit-gate-delivery.ts` POSTs to
+ * `POST /cockpit/answers` (the orchestrator route appends it verbatim).
+ *
+ * Frozen shape (flat — NOT the old `kind`/`scope`/nested-`answer`/`generation`
+ * envelope):
+ *   { type:'gate-answer', gateId, gateKey, optionId(string|null),
+ *     freeText(string|null), actor:{userId,email(string|null),
+ *     displayName(string|null)}, answeredAt(ISO), deliveryId }
+ *
+ * Nullability mirrors the cloud stored answer exactly: the cloud sends
+ * `freeText:null` explicitly on option-only answers, and `actor.email` /
+ * `actor.displayName` may be null for anonymous / partial-profile actors — so
+ * the parser must NOT tighten these to non-null / required, or a legitimate
+ * delivery is dropped as "malformed".
+ *
+ * `gateId` is pinned only `min(1)` here (not `length(24)`): the orchestrator
+ * `POST /cockpit/answers` route already validates the full frozen
+ * `GateAnswerSchema` (24-char hex) before appending, so the tailer treats the
+ * gateId as an opaque identity string it hoists + logs. The reconciliation this
+ * schema fixes is the STRUCTURE (kind→type, scope→gateKey, nested-answer→flat
+ * optionId/freeText/actor), which IS pinned strictly below.
  */
 import { z } from 'zod';
 
+/** Down-path actor. `email`/`displayName` nullable — see cloud stored answer. */
+export const GateAnswerActorSchema = z.object({
+  userId: z.string().min(1),
+  email: z.string().email().nullable(),
+  displayName: z.string().nullable(),
+});
+export type GateAnswerActor = z.infer<typeof GateAnswerActorSchema>;
+
 export const GateAnswerLineSchema = z
   .object({
+    type: z.literal('gate-answer'),
     gateId: z.string().min(1),
-    deliveryId: z.string().min(1),
-    scope: z.object({
-      owner: z.string().min(1),
-      repo: z.string().min(1),
-      number: z.number().int().positive(),
-    }),
-    answer: z.unknown(),
+    gateKey: z.string().min(1),
+    optionId: z.string().nullable(), // null on a pure free-text answer
+    freeText: z.string().nullable(), // present-and-null on an option-only answer
+    actor: GateAnswerActorSchema,
     answeredAt: z.string().datetime(),
-    answeredBy: z.string().optional(),
-    generation: z.number().int().nonnegative().optional(),
+    deliveryId: z.string().min(1), // unique per delivery attempt; session dedups on this
   })
   .passthrough();
 

--- a/packages/orchestrator/src/__tests__/cockpit-gates-integration.integration.test.ts
+++ b/packages/orchestrator/src/__tests__/cockpit-gates-integration.integration.test.ts
@@ -20,8 +20,12 @@
  *
  * SC-004 (wire-shape single-sourcing): every wire body is built through the
  * fixture builders exported by `@generacy-ai/cockpit` (`gateOpenFixture`,
- * `gateAckFixture`, `answerLineFixture`) — never an inline schema literal.
+ * `gateOutcomeFixture`, `answerLineFixture`) — never an inline schema literal.
  * Invalid-body scenarios (F2) derive from a fixture, then drop a field.
+ *
+ * Wire shape is the FROZEN contract (`type`-keyed; `gate-outcome` ack; 24-hex
+ * gateId). Scenario gateIds are 24-char hex (the routes validate `.length(24)`);
+ * `gid()` pads a short hex tag — correlation only, not `sha256(gateKey)`.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { once } from 'node:events';
@@ -29,7 +33,7 @@ import { readFile, appendFile, rename, writeFile } from 'node:fs/promises';
 import { WebSocket as WsWebSocket } from 'ws';
 import {
   gateOpenFixture,
-  gateAckFixture,
+  gateOutcomeFixture,
   answerLineFixture,
 } from '@generacy-ai/cockpit';
 import {
@@ -39,6 +43,18 @@ import {
 } from './cockpit-gates/scenario-helpers.js';
 
 const JSON_HEADERS = { 'content-type': 'application/json' };
+
+/** 24-char hex gate id from a short hex tag (test correlation only). */
+const gid = (hexTag: string): string => hexTag.padEnd(24, '0');
+const GID_S1A = gid('a51a');
+const GID_S1B = gid('a51b');
+const GID_S3 = gid('a530');
+const GID_F2 = gid('af20');
+const GID_S2 = gid('a520');
+const GID_S4 = gid('a540');
+const GID_S5 = gid('a550');
+const GID_F1 = gid('af10');
+const GID_F3 = gid('af30');
 
 // A synthetic doorbell child that stands in for the real answers-file tail in
 // the driver plumbing self-tests. Emits one `{ type: 'ready', ... }` JSON line
@@ -178,7 +194,7 @@ describe('Cockpit gates integration', () => {
 
     // S1a — Gate open → cluster.cockpit event (FR-003).
     it('S1a — gate-open POST emits a cluster.cockpit event equal to the wire body', async () => {
-      const body = gateOpenFixture({ gateId: 'g_s1a' });
+      const body = gateOpenFixture({ gateId: GID_S1A });
       const res = await fetch(`${ctx.orchestratorUrl}/cockpit/gates`, {
         method: 'POST',
         headers: JSON_HEADERS,
@@ -189,7 +205,7 @@ describe('Cockpit gates integration', () => {
 
       const event = await ctx.peer.waitForEvent(
         'cluster.cockpit',
-        (d) => (d as { gateId?: string }).gateId === 'g_s1a',
+        (d) => (d as { gateId?: string }).gateId === GID_S1A,
       );
       expect(event.data).toMatchObject(body);
     });
@@ -203,7 +219,7 @@ describe('Cockpit gates integration', () => {
         'relay client never observed the disconnect',
       );
 
-      const body = gateOpenFixture({ gateId: 'g_s1b' });
+      const body = gateOpenFixture({ gateId: GID_S1B });
       const res = await fetch(`${ctx.orchestratorUrl}/cockpit/gates`, {
         method: 'POST',
         headers: JSON_HEADERS,
@@ -216,20 +232,22 @@ describe('Cockpit gates integration', () => {
       // On reconnect the retainer drains; the event lands on the new socket.
       const event = await ctx.peer.waitForEvent(
         'cluster.cockpit',
-        (d) => (d as { gateId?: string }).gateId === 'g_s1b',
+        (d) => (d as { gateId?: string }).gateId === GID_S1B,
         8000,
       );
       expect(event.data).toMatchObject(body);
 
       // Exactly once — no duplicate from a double-drain.
       await new Promise((r) => setTimeout(r, 300));
-      expect(cockpitEvents(ctx, 'g_s1b')).toHaveLength(1);
+      expect(cockpitEvents(ctx, GID_S1B)).toHaveLength(1);
     });
 
-    // S3 — Ack → outcome relay event (FR-006).
-    it('S3 — ack POST emits a cluster.cockpit gate-ack event carrying the path gateId', async () => {
-      const gateId = 'g_s3';
-      const ack = gateAckFixture({ gateId, outcome: 'answered' });
+    // S3 — Ack → gate-outcome relay event (FR-006).
+    it('S3 — ack POST emits a cluster.cockpit gate-outcome event carrying the path gateId', async () => {
+      const gateId = GID_S3;
+      // The MCP client POSTs the semantic ack ({ outcome, detail? }); the route
+      // stamps type:'gate-outcome' + the path gateId + defaults `at`.
+      const ack = gateOutcomeFixture({ gateId, outcome: 'applied' });
       const res = await fetch(
         `${ctx.orchestratorUrl}/cockpit/gates/${gateId}/ack`,
         { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(ack) },
@@ -239,18 +257,18 @@ describe('Cockpit gates integration', () => {
       const event = await ctx.peer.waitForEvent(
         'cluster.cockpit',
         (d) =>
-          (d as { kind?: string }).kind === 'gate-ack' &&
+          (d as { type?: string }).type === 'gate-outcome' &&
           (d as { gateId?: string }).gateId === gateId,
       );
       expect((event.data as { gateId: string }).gateId).toBe(gateId);
-      expect((event.data as { outcome: string }).outcome).toBe('answered');
+      expect((event.data as { outcome: string }).outcome).toBe('applied');
     });
 
     // F2 — Invalid gate-open body → 4xx + no relay event (FR-014).
     it('F2 — invalid gate-open body → 400 and no cluster.cockpit event leaks to the peer', async () => {
-      // Derive from the fixture (SC-004), then drop a required field.
-      const invalid = gateOpenFixture({ gateId: 'g_f2' }) as Record<string, unknown>;
-      delete invalid['openedAt'];
+      // Derive from the fixture (SC-004), then drop a required frozen field.
+      const invalid = gateOpenFixture({ gateId: GID_F2 }) as Record<string, unknown>;
+      delete invalid['askedAt'];
 
       const res = await fetch(`${ctx.orchestratorUrl}/cockpit/gates`, {
         method: 'POST',
@@ -298,7 +316,7 @@ describe('Cockpit gates integration', () => {
 
     // S2 — Answer down-path: peer api_request → file + doorbell (FR-005).
     it('S2 — peer POST /cockpit/answers writes one file line and surfaces a doorbell gate-answer', async () => {
-      const answer = answerLineFixture({ deliveryId: 'dlv_s2', gateId: 'g_s2' });
+      const answer = answerLineFixture({ deliveryId: 'dlv_s2', gateId: GID_S2 });
       const res = await ctx.peer.sendApiRequest('POST', '/cockpit/answers', answer);
       expect(res.status).toBe(200);
 
@@ -314,12 +332,12 @@ describe('Cockpit gates integration', () => {
       const emitted = await ctx.doorbell!.waitForEvent(
         (e) => e.type === 'gate-answer' && e['deliveryId'] === 'dlv_s2',
       );
-      expect(emitted).toMatchObject({ type: 'gate-answer', gateId: 'g_s2' });
+      expect(emitted).toMatchObject({ type: 'gate-answer', gateId: GID_S2 });
     });
 
     // S4 — Restart replay of unacked answers exactly once (FR-007).
     it('S4 — doorbell kill+restart mid-flow re-emits the unacked answer exactly once', async () => {
-      const answer = answerLineFixture({ deliveryId: 'dlv_s4', gateId: 'g_s4' });
+      const answer = answerLineFixture({ deliveryId: 'dlv_s4', gateId: GID_S4 });
       await ctx.peer.sendApiRequest('POST', '/cockpit/answers', answer);
       await ctx.doorbell!.waitForEvent(
         (e) => e.type === 'gate-answer' && e['deliveryId'] === 'dlv_s4',
@@ -342,8 +360,8 @@ describe('Cockpit gates integration', () => {
 
     // S5 — deliveryId dedup end-to-end (FR-008).
     it('S5 — the same deliveryId twice yields one file line and one doorbell event', async () => {
-      const first = answerLineFixture({ deliveryId: 'dlv_dup', gateId: 'g_s5' });
-      const second = answerLineFixture({ deliveryId: 'dlv_dup', gateId: 'g_s5' });
+      const first = answerLineFixture({ deliveryId: 'dlv_dup', gateId: GID_S5 });
+      const second = answerLineFixture({ deliveryId: 'dlv_dup', gateId: GID_S5 });
       const r1 = await ctx.peer.sendApiRequest('POST', '/cockpit/answers', first);
       const r2 = await ctx.peer.sendApiRequest('POST', '/cockpit/answers', second);
       expect(r1.status).toBe(200);
@@ -377,7 +395,7 @@ describe('Cockpit gates integration', () => {
       await appendFile(ctx.answersFilePath, 'this is not valid json\n');
       const answer = answerLineFixture({
         deliveryId: 'dlv_after_garbage',
-        gateId: 'g_f1',
+        gateId: GID_F1,
       });
       await ctx.peer.sendApiRequest('POST', '/cockpit/answers', answer);
 
@@ -401,7 +419,7 @@ describe('Cockpit gates integration', () => {
 
     // F3 — Answers-file rotation preserves the tail (FR-015).
     it('F3 — rename+recreate the answers file mid-flow; subsequent lines still surface', async () => {
-      const first = answerLineFixture({ deliveryId: 'dlv_pre_rot', gateId: 'g_f3' });
+      const first = answerLineFixture({ deliveryId: 'dlv_pre_rot', gateId: GID_F3 });
       await ctx.peer.sendApiRequest('POST', '/cockpit/answers', first);
       await ctx.doorbell!.waitForEvent(
         (e) => e.type === 'gate-answer' && e['deliveryId'] === 'dlv_pre_rot',
@@ -412,14 +430,14 @@ describe('Cockpit gates integration', () => {
       await writeFile(ctx.answersFilePath, '', 'utf8');
 
       // A post-rotation line appended to the fresh file must still be tailed.
-      const second = answerLineFixture({ deliveryId: 'dlv_post_rot', gateId: 'g_f3' });
+      const second = answerLineFixture({ deliveryId: 'dlv_post_rot', gateId: GID_F3 });
       await appendFile(ctx.answersFilePath, `${JSON.stringify(second)}\n`);
 
       const emitted = await ctx.doorbell!.waitForEvent(
         (e) => e.type === 'gate-answer' && e['deliveryId'] === 'dlv_post_rot',
         6000,
       );
-      expect(emitted).toMatchObject({ type: 'gate-answer', gateId: 'g_f3' });
+      expect(emitted).toMatchObject({ type: 'gate-answer', gateId: GID_F3 });
     });
   });
 });

--- a/packages/orchestrator/src/routes/__tests__/cockpit-answers.test.ts
+++ b/packages/orchestrator/src/routes/__tests__/cockpit-answers.test.ts
@@ -25,13 +25,19 @@ function makeFakeWriter(overrides: Partial<FakeWriter> = {}): FakeWriter {
   };
 }
 
+const GATE_ID = 'a1b2c3d4e5f6a7b8c9d0e1f2';
+
+// Frozen down-path Shape 3 — gate-answer. Flat, type:'gate-answer', with
+// gateKey, nullable optionId/freeText, and actor{userId,email?,displayName?}.
 const validAnswer = {
-  kind: 'gate-answer',
-  deliveryId: 'dlv_1',
-  gateId: 'g_1',
-  generation: 0,
+  type: 'gate-answer' as const,
+  gateId: GATE_ID,
+  gateKey: 'generacy-ai/generacy#1021:clarification:batch-1',
+  optionId: 'proceed',
+  freeText: null,
+  actor: { userId: 'u_1', email: 'ada@example.com', displayName: 'Ada' },
   answeredAt: '2026-07-21T15:04:11.100Z',
-  answer: { choice: 'proceed' },
+  deliveryId: 'dlv_1',
 };
 
 describe('POST /cockpit/answers', () => {
@@ -41,7 +47,7 @@ describe('POST /cockpit/answers', () => {
     server = Fastify();
   });
 
-  it('fresh delivery — appends and returns deduped:false', async () => {
+  it('fresh delivery — appends the frozen answer and returns deduped:false', async () => {
     const writer = makeFakeWriter();
     setupCockpitAnswersRoute(server, {
       writer: writer as unknown as CockpitAnswersWriter,
@@ -58,9 +64,58 @@ describe('POST /cockpit/answers', () => {
     expect(JSON.parse(res.body)).toEqual({ accepted: true, deduped: false });
     expect(writer.append).toHaveBeenCalledTimes(1);
     expect(writer.append).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'gate-answer',
       deliveryId: 'dlv_1',
-      gateId: 'g_1',
+      gateId: GATE_ID,
+      gateKey: 'generacy-ai/generacy#1021:clarification:batch-1',
+      optionId: 'proceed',
     }));
+  });
+
+  it('accepts a pure free-text answer (optionId:null, freeText set)', async () => {
+    const writer = makeFakeWriter();
+    setupCockpitAnswersRoute(server, {
+      writer: writer as unknown as CockpitAnswersWriter,
+      logger: silentLogger,
+    });
+    await server.ready();
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/cockpit/answers',
+      payload: {
+        ...validAnswer,
+        optionId: null,
+        freeText: 'do the other thing',
+        deliveryId: 'dlv_free',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(writer.append).toHaveBeenCalledWith(expect.objectContaining({
+      optionId: null,
+      freeText: 'do the other thing',
+    }));
+  });
+
+  it('accepts an actor with null email / displayName (partial profile)', async () => {
+    const writer = makeFakeWriter();
+    setupCockpitAnswersRoute(server, {
+      writer: writer as unknown as CockpitAnswersWriter,
+      logger: silentLogger,
+    });
+    await server.ready();
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/cockpit/answers',
+      payload: {
+        ...validAnswer,
+        deliveryId: 'dlv_anon',
+        actor: { userId: 'u_2', email: null, displayName: null },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(writer.append).toHaveBeenCalledTimes(1);
   });
 
   it('duplicate deliveryId — returns deduped:true and does not append', async () => {
@@ -92,11 +147,35 @@ describe('POST /cockpit/answers', () => {
     const res = await server.inject({
       method: 'POST',
       url: '/cockpit/answers',
-      payload: { kind: 'gate-answer' /* missing everything else */ },
+      payload: { type: 'gate-answer' /* missing everything else */ },
     });
     expect(res.statusCode).toBe(400);
     const body = JSON.parse(res.body);
     expect(body.code).toBe('VALIDATION');
+    expect(writer.append).not.toHaveBeenCalled();
+  });
+
+  it('400 on the old `kind`/nested-answer envelope shape', async () => {
+    const writer = makeFakeWriter();
+    setupCockpitAnswersRoute(server, {
+      writer: writer as unknown as CockpitAnswersWriter,
+      logger: silentLogger,
+    });
+    await server.ready();
+
+    const res = await server.inject({
+      method: 'POST',
+      url: '/cockpit/answers',
+      payload: {
+        kind: 'gate-answer',
+        deliveryId: 'dlv_old',
+        gateId: GATE_ID,
+        generation: 0,
+        answeredAt: '2026-07-21T15:04:11.100Z',
+        answer: { choice: 'proceed' },
+      },
+    });
+    expect(res.statusCode).toBe(400);
     expect(writer.append).not.toHaveBeenCalled();
   });
 

--- a/packages/orchestrator/src/routes/__tests__/cockpit-gates.test.ts
+++ b/packages/orchestrator/src/routes/__tests__/cockpit-gates.test.ts
@@ -23,21 +23,39 @@ function makeMockClient(overrides: Partial<ClusterRelayClient> = {}): ClusterRel
   };
 }
 
+// Frozen up-path Shape 1 — gate-open. gateId is a 24-char hex (derived from
+// gateKey by the cockpit_gate_open MCP tool); the route only validates + emits.
+const GATE_ID = 'a1b2c3d4e5f6a7b8c9d0e1f2';
 const validOpen = {
-  kind: 'gate-open',
-  gateId: 'g_test_1',
-  generation: 0,
-  scope: { owner: 'generacy-ai', repo: 'generacy', issueNumber: 1021 },
-  openedAt: '2026-07-21T15:04:05.123Z',
-  payload: { question: 'proceed?' },
+  type: 'gate-open' as const,
+  gateId: GATE_ID,
+  gateKey: 'generacy-ai/generacy#1021:clarification:batch-1',
+  gateType: 'clarification' as const,
+  epicRef: 'generacy-ai/generacy#1000',
+  issueRef: 'generacy-ai/generacy#1021',
+  issueTitle: 'Do the thing',
+  issueUrl: 'https://github.com/generacy-ai/generacy/issues/1021',
+  title: 'Clarification needed',
+  body: 'Please choose how to proceed.',
+  options: [
+    { id: 'proceed', label: 'Proceed' },
+    { id: 'hold', label: 'Hold', description: 'Wait for review' },
+  ],
+  allowFreeText: true,
+  sessionId: 'sess_1',
+  askedAt: '2026-07-21T15:04:05.123Z',
 };
 
+function openWithGateId(gateId: string) {
+  return { ...validOpen, gateId };
+}
+
+// Frozen up-path Shape 2 — gate-outcome (THE ACK). The MCP client posts only the
+// semantic ack; the route stamps type + path gateId and defaults `at`.
 const validAckBody = {
-  kind: 'gate-ack',
-  generation: 0,
-  outcome: 'answered',
-  ackedAt: '2026-07-21T15:04:11.900Z',
-  answer: { choice: 'proceed' },
+  outcome: 'applied' as const,
+  detail: 'answer applied to the issue',
+  at: '2026-07-21T15:04:11.900Z',
 };
 
 describe('cockpit gates routes', () => {
@@ -50,7 +68,7 @@ describe('cockpit gates routes', () => {
   });
 
   describe('POST /cockpit/gates (open)', () => {
-    it('happy path connected — sends on relay, returns retained:false', async () => {
+    it('happy path connected — sends the frozen gate-open on relay, retained:false', async () => {
       const client = makeMockClient();
       setupCockpitGatesRoute(server, {
         retainer,
@@ -70,12 +88,14 @@ describe('cockpit gates routes', () => {
       const call = (client.send as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
         type: string;
         event: string;
-        data: unknown;
+        data: { type: string; gateId: string; gateType: string };
         timestamp: string;
       };
       expect(call.type).toBe('event');
       expect(call.event).toBe('cluster.cockpit');
+      // The emitted relay data carries `type` as the cloud subtype discriminator.
       expect(call.data).toMatchObject(validOpen);
+      expect(call.data.type).toBe('gate-open');
       expect(typeof call.timestamp).toBe('string');
     });
 
@@ -119,7 +139,7 @@ describe('cockpit gates routes', () => {
       expect(retainer.size().count).toBe(1);
     });
 
-    it('400 on schema failure', async () => {
+    it('400 on schema failure (bare type is not a full gate-open)', async () => {
       setupCockpitGatesRoute(server, {
         retainer,
         getRelayClient: () => makeMockClient(),
@@ -130,12 +150,46 @@ describe('cockpit gates routes', () => {
       const res = await server.inject({
         method: 'POST',
         url: '/cockpit/gates',
-        payload: { kind: 'gate-open' /* missing everything else */ },
+        payload: { type: 'gate-open' /* missing everything else */ },
       });
       expect(res.statusCode).toBe(400);
       const body = JSON.parse(res.body);
       expect(body.code).toBe('VALIDATION');
       expect(Array.isArray(body.details)).toBe(true);
+    });
+
+    it('400 when gateType is not one of the 8 frozen enum values', async () => {
+      setupCockpitGatesRoute(server, {
+        retainer,
+        getRelayClient: () => makeMockClient(),
+        logger: silentLogger,
+      });
+      await server.ready();
+
+      const res = await server.inject({
+        method: 'POST',
+        url: '/cockpit/gates',
+        // 'clarification-batch' is the ledger original-action, NOT a gateType.
+        payload: { ...validOpen, gateType: 'clarification-batch' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).code).toBe('VALIDATION');
+    });
+
+    it('400 when issueUrl is a bare ref rather than a URL', async () => {
+      setupCockpitGatesRoute(server, {
+        retainer,
+        getRelayClient: () => makeMockClient(),
+        logger: silentLogger,
+      });
+      await server.ready();
+
+      const res = await server.inject({
+        method: 'POST',
+        url: '/cockpit/gates',
+        payload: { ...validOpen, issueUrl: 'generacy-ai/generacy#1021' },
+      });
+      expect(res.statusCode).toBe(400);
     });
 
     it('warn fires on overflow drops', async () => {
@@ -152,7 +206,7 @@ describe('cockpit gates routes', () => {
       const res = await server.inject({
         method: 'POST',
         url: '/cockpit/gates',
-        payload: { ...validOpen, gateId: 'g_test_2' },
+        payload: openWithGateId('a1b2c3d4e5f6a7b8c9d0e100'),
       });
       expect(res.statusCode).toBe(202);
       expect(warn).toHaveBeenCalled();
@@ -166,11 +220,16 @@ describe('cockpit gates routes', () => {
       });
       await server.ready();
 
-      for (let i = 0; i < 3; i += 1) {
+      const ids = [
+        'a1b2c3d4e5f6a7b8c9d0e1a0',
+        'a1b2c3d4e5f6a7b8c9d0e1a1',
+        'a1b2c3d4e5f6a7b8c9d0e1a2',
+      ];
+      for (const id of ids) {
         await server.inject({
           method: 'POST',
           url: '/cockpit/gates',
-          payload: { ...validOpen, gateId: `g_seq_${i}` },
+          payload: openWithGateId(id),
         });
       }
       expect(retainer.size().count).toBe(3);
@@ -180,12 +239,12 @@ describe('cockpit gates routes', () => {
       const seqs = (drainClient.send as ReturnType<typeof vi.fn>).mock.calls.map(
         (call) => ((call[0] as { data: { gateId: string } }).data.gateId),
       );
-      expect(seqs).toEqual(['g_seq_0', 'g_seq_1', 'g_seq_2']);
+      expect(seqs).toEqual(ids);
     });
   });
 
-  describe('POST /cockpit/gates/:id/ack', () => {
-    it('happy path — merges path gateId into body and emits', async () => {
+  describe('POST /cockpit/gates/:id/ack (gate-outcome)', () => {
+    it('happy path — stamps type:gate-outcome + path gateId and emits', async () => {
       const client = makeMockClient();
       setupCockpitGatesRoute(server, {
         retainer,
@@ -196,14 +255,44 @@ describe('cockpit gates routes', () => {
 
       const res = await server.inject({
         method: 'POST',
-        url: '/cockpit/gates/g_test_ack/ack',
+        url: `/cockpit/gates/${GATE_ID}/ack`,
         payload: validAckBody,
       });
       expect(res.statusCode).toBe(202);
       const call = (client.send as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
-        data: { gateId: string };
+        data: { type: string; gateId: string; outcome: string; detail?: string; at: string };
       };
-      expect(call.data.gateId).toBe('g_test_ack');
+      expect(call.data.type).toBe('gate-outcome');
+      expect(call.data.gateId).toBe(GATE_ID);
+      expect(call.data.outcome).toBe('applied');
+      expect(call.data.detail).toBe('answer applied to the issue');
+      // No leftover gate-ack fields on the wire.
+      expect(call.data).not.toHaveProperty('kind');
+      expect(call.data).not.toHaveProperty('generation');
+      expect(call.data).not.toHaveProperty('ackedAt');
+    });
+
+    it('defaults `at` when the client omits it', async () => {
+      const client = makeMockClient();
+      setupCockpitGatesRoute(server, {
+        retainer,
+        getRelayClient: () => client,
+        logger: silentLogger,
+      });
+      await server.ready();
+
+      const res = await server.inject({
+        method: 'POST',
+        url: `/cockpit/gates/${GATE_ID}/ack`,
+        payload: { outcome: 'superseded' },
+      });
+      expect(res.statusCode).toBe(202);
+      const call = (client.send as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+        data: { outcome: string; at: string };
+      };
+      expect(call.data.outcome).toBe('superseded');
+      expect(typeof call.data.at).toBe('string');
+      expect(Number.isNaN(Date.parse(call.data.at))).toBe(false);
     });
 
     it('400 when body.gateId differs from path :id', async () => {
@@ -216,13 +305,16 @@ describe('cockpit gates routes', () => {
 
       const res = await server.inject({
         method: 'POST',
-        url: '/cockpit/gates/g_path/ack',
-        payload: { ...validAckBody, gateId: 'g_body' },
+        url: `/cockpit/gates/${GATE_ID}/ack`,
+        payload: { ...validAckBody, gateId: 'b0b0b0b0b0b0b0b0b0b0b0b0' },
       });
       expect(res.statusCode).toBe(400);
       const body = JSON.parse(res.body);
       expect(body.code).toBe('VALIDATION');
-      expect(body.details).toEqual({ pathGateId: 'g_path', bodyGateId: 'g_body' });
+      expect(body.details).toEqual({
+        pathGateId: GATE_ID,
+        bodyGateId: 'b0b0b0b0b0b0b0b0b0b0b0b0',
+      });
     });
 
     it('accepts body.gateId when it matches path :id', async () => {
@@ -235,13 +327,13 @@ describe('cockpit gates routes', () => {
 
       const res = await server.inject({
         method: 'POST',
-        url: '/cockpit/gates/g_same/ack',
-        payload: { ...validAckBody, gateId: 'g_same' },
+        url: `/cockpit/gates/${GATE_ID}/ack`,
+        payload: { ...validAckBody, gateId: GATE_ID },
       });
       expect(res.statusCode).toBe(202);
     });
 
-    it('400 on ack schema failure', async () => {
+    it('400 on gate-outcome schema failure (missing outcome)', async () => {
       setupCockpitGatesRoute(server, {
         retainer,
         getRelayClient: () => makeMockClient(),
@@ -251,8 +343,25 @@ describe('cockpit gates routes', () => {
 
       const res = await server.inject({
         method: 'POST',
-        url: '/cockpit/gates/g_x/ack',
-        payload: { kind: 'gate-ack' /* missing outcome, generation, ackedAt */ },
+        url: `/cockpit/gates/${GATE_ID}/ack`,
+        payload: { detail: 'no outcome here' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).code).toBe('VALIDATION');
+    });
+
+    it('400 when outcome is outside the applied|superseded|failed enum', async () => {
+      setupCockpitGatesRoute(server, {
+        retainer,
+        getRelayClient: () => makeMockClient(),
+        logger: silentLogger,
+      });
+      await server.ready();
+
+      const res = await server.inject({
+        method: 'POST',
+        url: `/cockpit/gates/${GATE_ID}/ack`,
+        payload: { outcome: 'answered' }, // old free-string value, now rejected
       });
       expect(res.statusCode).toBe(400);
     });

--- a/packages/orchestrator/src/routes/cockpit-answers.ts
+++ b/packages/orchestrator/src/routes/cockpit-answers.ts
@@ -1,6 +1,10 @@
 import { ZodError } from 'zod';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { GateAnswerEnvelopeSchema } from '@generacy-ai/cockpit';
+// Canonical frozen down-path schema (Shape 3). type:'gate-answer', flat:
+// gateId, gateKey, optionId (nullable), freeText (nullable), actor
+// {userId,email?,displayName?}, answeredAt, deliveryId. Emitted verbatim by the
+// cloud (cockpit-gate-delivery.ts) and dedup-keyed here on deliveryId.
+import { GateAnswerSchema } from '@generacy-ai/cockpit';
 import type { CockpitAnswersWriter } from '../services/cockpit-answers-writer.js';
 
 interface Logger {
@@ -34,7 +38,7 @@ export function setupCockpitAnswersRoute(
       }
 
       try {
-        const parsed = GateAnswerEnvelopeSchema.parse(request.body);
+        const parsed = GateAnswerSchema.parse(request.body);
         // Fast path: avoid the mutex acquisition when we can already tell
         // this deliveryId is a duplicate. The authoritative check happens
         // inside append() under its mutex so concurrent redeliveries of the

--- a/packages/orchestrator/src/routes/cockpit-gates.ts
+++ b/packages/orchestrator/src/routes/cockpit-gates.ts
@@ -1,6 +1,12 @@
 import { ZodError } from 'zod';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { GateOpenSchema, GateAckSchema } from '@generacy-ai/cockpit';
+// Canonical frozen wire schemas (tetrad-development/docs/cockpit-remote-gates-plan.md
+// § "Wire contracts"; generacy-cloud specs/843 gates-wire.md Shapes 1 & 2).
+// GateOpenSchema  → up-path Shape 1 (type:'gate-open', flat, gateId/gateKey DERIVED
+//                   by the cockpit_gate_open MCP tool before the POST reaches here).
+// GateOutcomeSchema → up-path Shape 2, THE ACK (type:'gate-outcome', outcome enum,
+//                   detail?, at) — replaces the removed gate-ack.
+import { GateOpenSchema, GateOutcomeSchema } from '@generacy-ai/cockpit';
 import type {
   ClusterRelayClient,
   RelayMessage,
@@ -29,7 +35,8 @@ interface EmitContext {
   timestamp: string;
   approxBytes: number;
   gateId: string;
-  kind: string;
+  // Cloud sub-event discriminator (message-handler.ts:721): 'gate-open' | 'gate-outcome'.
+  type: string;
 }
 
 function tryEmitOrRetain(
@@ -45,7 +52,7 @@ function tryEmitOrRetain(
       timestamp: ctx.timestamp,
     } as unknown as RelayMessage);
     options.logger.info(
-      { gateId: ctx.gateId, kind: ctx.kind },
+      { gateId: ctx.gateId, type: ctx.type },
       'cockpit gate emitted',
     );
     return { retained: false, retainQueue: null };
@@ -63,7 +70,7 @@ function tryEmitOrRetain(
     );
   }
   options.logger.debug(
-    { gateId: ctx.gateId, kind: ctx.kind },
+    { gateId: ctx.gateId, type: ctx.type },
     'retained cockpit event queued',
   );
   return { retained: true, retainQueue: options.retainer.size() };
@@ -73,6 +80,9 @@ export function setupCockpitGatesRoute(
   server: FastifyInstance,
   options: SetupCockpitGatesRouteOptions,
 ): void {
+  // Up-path Shape 1 — gate-open. Body is the fully-assembled frozen record
+  // (type:'gate-open', derived gateId/gateKey, gateType, presentation fields);
+  // the route validates and forwards it verbatim onto the relay.
   server.post(
     '/cockpit/gates',
     async (request: FastifyRequest, reply: FastifyReply) => {
@@ -86,7 +96,7 @@ export function setupCockpitGatesRoute(
             timestamp,
             approxBytes,
             gateId: parsed.gateId,
-            kind: parsed.kind,
+            type: parsed.type,
           },
           options,
         );
@@ -115,6 +125,10 @@ export function setupCockpitGatesRoute(
     },
   );
 
+  // Up-path Shape 2 — gate-outcome (THE ACK). The MCP client (cockpit_gate_ack)
+  // POSTs the semantic ack ({ outcome, detail? }); the route stamps
+  // type:'gate-outcome' + the path gateId, defaults `at`, validates against the
+  // frozen GateOutcomeSchema, and emits it as the 'gate-outcome' cloud subtype.
   server.post<{ Params: { id: string } }>(
     '/cockpit/gates/:id/ack',
     async (request, reply) => {
@@ -139,8 +153,20 @@ export function setupCockpitGatesRoute(
       }
 
       try {
-        const merged = { ...(body ?? {}), gateId: pathGateId };
-        const parsed = GateAckSchema.parse(merged);
+        // Build the frozen gate-outcome record. Path `:id` is authoritative for
+        // gateId; `type` is always 'gate-outcome' (never client-supplied); `at`
+        // defaults to now when the client omits it. `kind`/`generation`/`ackedAt`
+        // from the old gate-ack shape are dropped — GateOutcomeSchema is closed.
+        const candidate = {
+          ...(body ?? {}),
+          type: 'gate-outcome' as const,
+          gateId: pathGateId,
+          at:
+            typeof body?.at === 'string' && body.at.length > 0
+              ? body.at
+              : new Date().toISOString(),
+        };
+        const parsed = GateOutcomeSchema.parse(candidate);
         const timestamp = new Date().toISOString();
         const approxBytes = JSON.stringify(parsed).length;
         const outcome = tryEmitOrRetain(
@@ -149,7 +175,7 @@ export function setupCockpitGatesRoute(
             timestamp,
             approxBytes,
             gateId: parsed.gateId,
-            kind: parsed.kind,
+            type: parsed.type,
           },
           options,
         );
@@ -165,10 +191,10 @@ export function setupCockpitGatesRoute(
         if (err instanceof ZodError) {
           options.logger.warn(
             { route: '/cockpit/gates/:id/ack', code: 'VALIDATION' },
-            'Invalid gate-ack payload',
+            'Invalid gate-outcome payload',
           );
           return reply.status(400).send({
-            error: 'Invalid gate-ack payload',
+            error: 'Invalid gate-outcome payload',
             code: 'VALIDATION',
             details: err.issues,
           });

--- a/packages/orchestrator/src/services/__tests__/cockpit-answers-writer.test.ts
+++ b/packages/orchestrator/src/services/__tests__/cockpit-answers-writer.test.ts
@@ -15,14 +15,19 @@ const silentLogger = {
   debug: () => {},
 };
 
+// The writer is shape-agnostic (dedups on deliveryId; persists opaquely), but
+// use the FROZEN down-path gate-answer shape so the fixture matches what the
+// /cockpit/answers route actually appends.
 function makeAnswer(deliveryId: string, extra: Record<string, unknown> = {}): CockpitAnswer {
   return {
-    kind: 'gate-answer',
+    type: 'gate-answer',
     deliveryId,
-    gateId: 'g_test',
-    generation: 0,
+    gateId: 'a1a1a1a1a1a1a1a1a1a1a1a1',
+    gateKey: 'owner/repo#5:clarification:b1',
+    optionId: 'proceed',
+    freeText: null,
+    actor: { userId: 'u1', email: 'op@example.com', displayName: 'Op' },
     answeredAt: '2026-07-21T15:04:11.100Z',
-    answer: { choice: 'proceed' },
     ...extra,
   };
 }

--- a/specs/1023-part-cockpit-remote-gates/contracts/gate-answer-event.md
+++ b/specs/1023-part-cockpit-remote-gates/contracts/gate-answer-event.md
@@ -15,18 +15,22 @@ Add a fourth discriminated-union member to `CockpitStreamEventSchema` so that op
 
 import { z } from 'zod';
 
+// FROZEN down-path Shape 3 (flat). No `scope` / nested `answer` / `generation`.
+export const GateAnswerActorSchema = z.object({
+  userId: z.string().min(1),
+  email: z.string().email().nullable(),
+  displayName: z.string().nullable(),
+});
+
 export const GateAnswerLineSchema = z.object({
+  type: z.literal('gate-answer'),
   gateId: z.string().min(1),
-  deliveryId: z.string().min(1),
-  scope: z.object({
-    owner: z.string().min(1),
-    repo: z.string().min(1),
-    number: z.number().int().positive(),
-  }),
-  answer: z.unknown(),
+  gateKey: z.string().min(1),
+  optionId: z.string().nullable(),
+  freeText: z.string().nullable(),
+  actor: GateAnswerActorSchema,
   answeredAt: z.string().datetime(),
-  answeredBy: z.string().optional(),
-  generation: z.number().int().nonnegative().optional(),
+  deliveryId: z.string().min(1),
 }).passthrough();
 
 export type GateAnswerLine = z.infer<typeof GateAnswerLineSchema>;

--- a/specs/1023-part-cockpit-remote-gates/contracts/gate-answer-line.md
+++ b/specs/1023-part-cockpit-remote-gates/contracts/gate-answer-line.md
@@ -8,28 +8,26 @@ The **wire shape** of a single line of `/workspaces/.generacy/cockpit/answers.nd
 
 This document captures the **minimum subset** the tailer parses locally to satisfy this feature's requirements:
 
-- Fields required for scope filtering (Q1).
+- Fields required for repo-scope filtering (Q1) — the `gateKey` issue-ref.
 - Fields required for cross-epic drop logging (Q1).
 - Fields required for `GateAnswerEvent` derivation (data-model §E-2).
 
 All other fields flow through the `GateAnswerLine.line` payload via Zod `.passthrough()` and reach downstream (D.12 dispatch) unchanged. This feature does not need to know them.
 
+The line is the FROZEN down-path Shape 3 (flat). There is **no** `scope`, nested `answer`, or top-level `generation` — `generation` is folded into `gateKey`.
+
 ## Required fields (tailer-side)
 
 | Field | Type | Consumer inside this feature |
 |---|---|---|
-| `gateId` | `string`, `min(1)` | Cross-epic drop info log; hoisted onto `GateAnswerEvent.gateId` for consumer convenience. |
+| `type` | `'gate-answer'` (literal) | Discriminator. A line lacking it (e.g. the old `kind`) fails schema and is dropped as malformed. |
+| `gateId` | `string`, `min(1)` | Cross-epic drop info log; hoisted onto `GateAnswerEvent.gateId`. Format (24-hex) is validated upstream at `POST /cockpit/answers`. |
+| `gateKey` | `string`, `min(1)` (`<owner>/<repo>#<issue>:<gateType>:<generation>`) | Repo-scope filter: owner/repo parsed from the issue-ref (up to first `:`) and compared to the bound `epicRef` on **owner/repo only** (child-issue numbers pass). Non-issue targets emit. |
+| `optionId` | `string \| null` | Pass-through. `null` on a pure free-text answer. |
+| `freeText` | `string \| null` | Pass-through. Present-and-`null` on an option-only answer — must be `.nullable()`, not `.optional()`. |
+| `actor` | `{ userId: string; email: string \| null; displayName: string \| null }` | Pass-through. `email`/`displayName` nullable for anonymous / partial-profile actors. |
 | `deliveryId` | `string`, `min(1)` | Hoisted onto `GateAnswerEvent.deliveryId`. Deduplication is the session's concern, not the tailer's. |
-| `scope` | `{ owner: string; repo: string; number: number (int, positive) }` | Compared against the bound `epicRef` (parsed as `owner/repo#number`). Cross-scope lines dropped + logged. |
-| `answer` | `unknown` | Opaque pass-through — the operator's payload; validated by the gate record, not the tailer. |
 | `answeredAt` | `string` (ISO 8601 datetime) | Opaque pass-through — used downstream for gate-currency checks. |
-
-## Optional fields (tailer-side)
-
-| Field | Type | Consumer inside this feature |
-|---|---|---|
-| `answeredBy` | `string` | Pass-through. |
-| `generation` | `number` (int, ≥ 0) | Pass-through. Required if the epic-plan doc's generation rules apply — the tailer neither enforces nor interprets. |
 
 ## Unknown fields
 
@@ -49,10 +47,11 @@ If the epic-plan doc's wire shape diverges from `GateAnswerLineSchema` in a way 
 
 The tailer's line-validation contract is exercised in `answers-file-source.unit.test.ts`:
 
-1. **Happy path**: a line matching the required-field set parses and emits.
-2. **Missing `gateId`**: skipped with `warn`.
-3. **Missing `scope.number`**: skipped with `warn`.
-4. **Malformed JSON**: skipped with `warn`; byte-offset field present.
-5. **Extra unknown fields**: preserved on `line.*` via `.passthrough()`.
-6. **`scope.number` type mismatch (string instead of int)**: skipped with `warn`.
-7. **Empty string `gateId`**: skipped with `warn` (`min(1)` violation).
+1. **Happy path**: a valid frozen line matching the bound epic's owner/repo parses and emits one event with flat answer fields.
+2. **Pure free-text answer** (`optionId: null`, `freeText` string) and **option-only answer** (`freeText: null`) both parse.
+3. **Null-`email` / null-`displayName` actor** (anonymous / partial profile): parses (guards against tightening `actor` to non-null).
+4. **Missing `type` discriminator** (e.g. the old `kind`): skipped with `warn` — guards the `kind`→`type` fix.
+5. **Missing `gateId` / empty-string `gateId` / missing `gateKey` / missing `actor` / `optionId` wrong type**: skipped with `warn`.
+6. **Malformed JSON**: skipped with `warn`; byte-offset named in the message.
+7. **Extra unknown fields**: preserved on `line.*` via `.passthrough()`.
+8. **Cross-repo line** (foreign owner/repo in `gateKey`): dropped with `info` naming gateId + scope + boundEpic. **Same-repo child-issue** (different issue number) and **non-issue `gateKey` target** (filing / scope-drained tracking ref): NOT dropped.


### PR DESCRIPTION
## The root cause (#1034)

`packages/cockpit/src/gates/` shipped an **invented** gate wire envelope — `kind`-discriminated, `scope`-wrapped, with a `gate-ack` sub-event and a nested-`answer` down-path — that matched **neither** the frozen authoritative contract (`tetrad-development/docs/cockpit-remote-gates-plan.md § "Wire contracts"`) **nor** the generacy-cloud receiver (`gates-wire.md` Shapes 1/2/3), which dispatches on `data.type` and log-drops any unknown subtype.

Two independent fatal consequences, both now fixed:
1. The orchestrator's own `GateOpenSchema` rejected the plugin's `cockpit_gate_open` call (the agent stuffed the ledger action `clarification-batch` into `kind`).
2. Even a patched frame would be **silently dropped cloud-side** (`data.type === undefined` → `"Unknown cluster.cockpit subtype"`). **No gate ever reached the operator inbox.**

This is why the agency#450 `--gates=ui` dogfood peeled off one latent bug per re-run (401 → bootstrap → gate-open schema → gate-ack) — each was a bug *inside the wrong contract*. This PR conforms generacy to the frozen contract (the cloud is the authoritative receiver/sender; these schemas mirror it field-for-field). **Supersedes the wire-envelope parts of #1033 (gate-open `scope`) and the gate-ack work (#1035).** #1031 (auth) is orthogonal and stays.

## Changes

- **Schema module** (`packages/cockpit/src/gates/schema.ts`): `GateOpenSchema` (`type:'gate-open'`, flat — `gateKey`, `gateType` enum, presentation fields, 24-hex `gateId`), `GateOutcomeSchema` (`type:'gate-outcome'`, **THE ACK**, replaces `GateAckSchema`), `GateAnswerSchema` (down-path `type:'gate-answer'`, flat, `freeText` + `actor.email`/`displayName` **nullable** to match what the cloud sends). Adds `deriveGateKey`/`deriveGateId` (`sha256(gateKey)[:24]`). Removes dead `GateAckSchema`/`GateAnswerEnvelopeSchema`; single-source barrel.
- **Orchestrator** (`routes/cockpit-gates.ts`, `routes/cockpit-answers.ts`): `/ack` stamps `type:'gate-outcome'` (path-authoritative `gateId`, defaulted `at`); emitted relay `data` carries `type` as the cloud sub-event discriminator; `/cockpit/answers` validates the frozen flat `GateAnswerSchema` (24-hex) before append.
- **MCP tools**: `cockpit_gate_open` **derives** `gateKey`+`gateId` in TS and self-validates the assembled frozen record before POSTing (the plugin/LLM never hand-builds a sha256); `cockpit_gate_ack` assembles a `gate-outcome`.
- **Doorbell**: answers tailer parses the frozen flat down-path line; repo-scope filter keys on the `gateKey` issue-ref.

## Tests
- `@generacy-ai/cockpit`: 433 pass (build clean). Orchestrator routes: typecheck + 22 tests. Doorbell + MCP parity: 67 pass. tsc clean across cockpit / orchestrator / generacy.
- Known env-flake: `doorbell/startup-retry` + `doorbell-source-branch` integration tests time out locally under load (unmodified by this PR; not on the gate-answer path) — expect green in CI.

## Known follow-up
Cross-repo child-issue answers are dropped by the tailer's owner/repo scope filter (documented inline; cross-repo remote gates not yet exercised).

## Must merge with
**generacy-ai/agency PR** for `@generacy-ai/claude-plugin-cockpit` — the plugin emits the frozen record shape these consume. The two are a pair.