### PR TITLE
fix(cockpit-mcp): cockpit_gate_open parses the real orchestrator ack (#450 blocker #6)

### DIFF
--- a/.changeset/cockpit-gate-open-response-shape.md
+++ b/.changeset/cockpit-gate-open-response-shape.md
@@ -1,0 +1,23 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+fix(cockpit-mcp): cockpit_gate_open parses the real orchestrator ack (fixes "malformed gate-open response").
+
+Follow-up to the #1034 wire-contract reconciliation, found in the agency#450
+`--gates=ui` dogfood re-run: with the frozen up-path now correct, the gate-open
+POST succeeds — but the tool then reported `internal: orchestrator returned
+malformed gate-open response` and fell back to a local `AskUserQuestion`.
+
+Root cause: `GateOpenResponseSchema` still asserted a fictional `{ gateId, status }`
+echo, but the orchestrator `/cockpit/gates` route is fire-and-forget — it emits the
+gate on the `cluster.cockpit` relay and replies `202 { accepted, retained,
+retainQueue? }`, never echoing a gateId (the inbox URL is assigned cloud-side,
+async). The parity tests mocked the fictional shape, so the route↔tool response
+mismatch was never exercised.
+
+Fix: `GateOpenResponseSchema` now validates the real `{ accepted, retained }` ack,
+and the tool maps it to the caller-facing `{ gateId, status }` using the gateId it
+DERIVED (`retained` → queued/relay-down, else `open`). Adds parity pins for the
+real ack (open + retained) and a regression pin that the old `{ gateId, status }`
+echo is now rejected as malformed. Cluster-only; no wire-contract or cloud change.

--- a/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-open.test.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/__tests__/parity-gate-open.test.ts
@@ -62,7 +62,7 @@ const CANONICAL_INPUT: Record<string, unknown> = {
 
 describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
   it('derives gateKey + gateId and forwards the flat frozen record', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -103,7 +103,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
     const epicRef = 'generacy-ai/generacy#1000';
     const key = `${epicRef}:phase-queue:2`;
     const id = gateIdFor(key);
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: id, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(
       {
         ...CANONICAL_INPUT,
@@ -124,7 +124,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
   it('forwards branch + prNumber when supplied (implementation-review)', async () => {
     const key = `${ISSUE_REF}:implementation-review:deadbeefcafe`;
     const id = gateIdFor(key);
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: id, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(
       {
         ...CANONICAL_INPUT,
@@ -142,7 +142,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
   });
 
   it('omits optional wire fields (branch/prNumber) when absent', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     await cockpitGateOpen(CANONICAL_INPUT, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -154,7 +154,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
 
   it('defaults askedAt to a fresh ISO timestamp when omitted', async () => {
     const { askedAt: _drop, ...noAskedAt } = CANONICAL_INPUT;
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(noAskedAt, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -168,7 +168,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
 
   it('defaults allowFreeText to true when omitted', async () => {
     const { allowFreeText: _drop, ...noFreeText } = CANONICAL_INPUT;
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     await cockpitGateOpen(noFreeText, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -179,8 +179,8 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
   it('passthrough response field forwarded (e.g. inboxUrl)', async () => {
     const spy = vi.fn(async () =>
       jsonResponse(200, {
-        gateId: EXPECTED_ID,
-        status: 'open',
+        accepted: true,
+        retained: false,
         inboxUrl: 'https://app.example/inbox/g_2',
       }),
     );
@@ -193,8 +193,54 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
     expect(result.data['inboxUrl']).toBe('https://app.example/inbox/g_2');
   });
 
-  it('input not an object → class: invalid-args (no HTTP call)', async () => {
+  // Regression pins for the orchestrator response contract (#1036 follow-up):
+  // the route is fire-and-forget and replies `{ accepted, retained }` — NOT a
+  // `{ gateId, status }` echo. The tool maps that ack to `{ gateId (derived),
+  // status }`. The old fictional `{ gateId, status }` mock hid this mismatch.
+  it('maps the real orchestrator ack { accepted, retained:false } → status "open" + derived gateId', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.data.gateId).toBe(EXPECTED_ID);
+    expect(result.data.status).toBe('open');
+  });
+
+  it('retained ack { accepted, retained:true } → status "retained" (relay down; queued)', async () => {
+    const spy = vi.fn(async () =>
+      jsonResponse(200, {
+        accepted: true,
+        retained: true,
+        retainQueue: { count: 1, bytes: 512 },
+      }),
+    );
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.data.gateId).toBe(EXPECTED_ID);
+    expect(result.data.status).toBe('retained');
+  });
+
+  it('a response missing accepted/retained (e.g. the old { gateId, status } echo) → internal error', async () => {
     const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const result = await cockpitGateOpen(CANONICAL_INPUT, {
+      ...BASE_DEPS,
+      fetchImpl: spy as unknown as typeof fetch,
+    });
+    expect(result.status).toBe('error');
+    if (result.status !== 'error') return;
+    expect(result.class).toBe('internal');
+    expect(result.detail).toMatch(/malformed gate-open response/);
+  });
+
+  it('input not an object → class: invalid-args (no HTTP call)', async () => {
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen('not-an-object' as unknown, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -207,7 +253,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
 
   it('missing required field (sessionId) → class: invalid-args (no HTTP call)', async () => {
     const { sessionId: _drop, ...noSession } = CANONICAL_INPUT;
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(noSession, {
       ...BASE_DEPS,
       fetchImpl: spy as unknown as typeof fetch,
@@ -219,7 +265,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
   });
 
   it('unknown gateType → class: invalid-args (no HTTP call)', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(
       { ...CANONICAL_INPUT, gateType: 'not-a-gate-type' },
       { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
@@ -231,7 +277,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
   });
 
   it('extra/unknown key (strict) → class: invalid-args (no HTTP call)', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(
       { ...CANONICAL_INPUT, gateId: 'hand-built-should-be-rejected' },
       { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },
@@ -243,7 +289,7 @@ describe('cockpit_gate_open parity — frozen contract (#1022/#843)', () => {
   });
 
   it('non-URL issueUrl → class: invalid-args (no HTTP call)', async () => {
-    const spy = vi.fn(async () => jsonResponse(200, { gateId: EXPECTED_ID, status: 'open' }));
+    const spy = vi.fn(async () => jsonResponse(200, { accepted: true, retained: false }));
     const result = await cockpitGateOpen(
       { ...CANONICAL_INPUT, issueUrl: 'generacy-ai/generacy#1022' },
       { ...BASE_DEPS, fetchImpl: spy as unknown as typeof fetch },

--- a/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/gates/schemas.ts
@@ -170,12 +170,16 @@ export type GateOutcomeWire = z.infer<typeof GateOutcomeWireSchema>;
 // ---------------------------------------------------------------------------
 
 /**
- * Response envelope for `POST /cockpit/gates`. Asserts the two fields the tool
- * contract promises callers; additional fields (e.g. `coalescedWith`,
- * `inboxUrl`) pass through opaquely.
+ * Response envelope for `POST /cockpit/gates`. The orchestrator route is
+ * fire-and-forget: it validates the frozen gate-open, EMITS it on the
+ * `cluster.cockpit` relay channel (or retains it when the relay is down), and
+ * replies `202 { accepted, retained, retainQueue? }` — it does NOT echo a
+ * `gateId` (the cluster already knows it; the inbox URL is assigned cloud-side,
+ * asynchronously). The tool maps this ack to the caller-facing `{ gateId, status }`
+ * using the `gateId` IT derived. Extra fields (`retainQueue`, …) pass through.
  */
 export const GateOpenResponseSchema = z
-  .object({ gateId: z.string(), status: z.string() })
+  .object({ accepted: z.boolean(), retained: z.boolean() })
   .passthrough();
 export type GateOpenResponse = z.infer<typeof GateOpenResponseSchema>;
 

--- a/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_open.ts
+++ b/packages/generacy/src/cli/commands/cockpit/mcp/tools/cockpit_gate_open.ts
@@ -100,6 +100,17 @@ export function cockpitGateOpen(
         detail: 'orchestrator returned malformed gate-open response',
       };
     }
-    return { status: 'ok', data: envelope.data as CockpitGateOpenData };
+    // The orchestrator ack is `{ accepted, retained }` (fire-and-forget; no
+    // echoed gateId). Return the caller-facing `{ gateId, status }` using the
+    // gateId the tool derived: `retained` (relay down → queued) vs `open`
+    // (emitted to the cloud). Pass through any extra ack fields (retainQueue…).
+    return {
+      status: 'ok',
+      data: {
+        ...envelope.data,
+        gateId,
+        status: envelope.data.retained ? 'retained' : 'open',
+      },
+    };
   });
 }


### PR DESCRIPTION
## Symptom (agency#450 `--gates=ui` dogfood re-run, post-#1034)

With the #1034 wire-contract reconciliation merged + published, the up-path is now correct — the plugin computes a content-derived clarification generation discriminator, derives the gateId, and the gate-open POST **succeeds**. But the tool then returns:

```
{"status":"error","class":"internal","detail":"orchestrator returned malformed gate-open response"}
```

…and falls back to a local `AskUserQuestion` (defeating `--gates=ui`). This is the next blocker in the #450 chain, exposed only now that blockers #1–#5 are cleared.

## Root cause — route↔tool response contract mismatch

`cockpit_gate_open`'s `GateOpenResponseSchema` asserted a fictional `{ gateId, status }` echo. But `POST /cockpit/gates` is **fire-and-forget**: it validates the frozen gate-open, **emits it on the `cluster.cockpit` relay** (or retains it when the relay is down), and replies `202 { accepted, retained, retainQueue? }` — it never echoes a gateId (the inbox URL is assigned cloud-side, asynchronously). So `{accepted, retained}` failed the `{gateId, status}` schema → "malformed".

The parity tests mocked the fictional `{gateId, status}` response, so this mismatch was never exercised (same "never run e2e" gap as the earlier blockers).

**Note:** the orchestrator emits to the relay *before* replying, so the frozen gate-open is already reaching the cloud on this path — the plugin just couldn't parse the ack and wrongly degraded to local.

## Fix (cluster-only; no wire-contract or cloud change)

- `GateOpenResponseSchema` now validates the real `{ accepted, retained }` ack.
- The tool maps it to the caller-facing `{ gateId, status }` using the gateId it **derived** (`retained` → queued/relay-down, else `open`); passthrough keeps extras (`retainQueue`, …).
- Parity pins: real ack → `open`; retained ack → `retained`; and a regression pin that the old `{ gateId, status }` echo is now rejected as malformed.

## Tests
`tsc` clean; 39 parity tests pass (36 + 3 new pins).

Follow-up to #1034 / #1036. No agency change.