### PR TITLE
fix(cluster): seed a per-container ~/.claude.json instead of sharing the host's

### DIFF
--- a/.changeset/fix-per-container-claude-json.md
+++ b/.changeset/fix-per-container-claude-json.md
@@ -1,0 +1,16 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+fix(cluster): give every container its own `~/.claude.json` instead of sharing the host's.
+
+Scaffolded clusters bound the operator's live `~/.claude.json` read-write into the orchestrator and every worker. Because that is one file per *host*, not per cluster, every cluster on a machine shared it — and `generacy setup build` writes an absolute, image-flavour-specific agency CLI path into `mcpServers.agency`. Whichever cluster bootstrapped last silently overwrote that entry for all the others, so a source-build cluster could inherit a `/shared-packages/...` path that does not exist in its containers and come up with a dead Agency MCP server.
+
+`claude.json` is now mounted read-only at `/seed/claude.json` and copied to `~/.claude.json` by the container entrypoint on first start (requires the matching cluster-base change; the copy is skipped when no seed is present, so an older image is unaffected). Containers write only to their private copy, which also removes orchestrator-and-N-workers concurrently writing one JSON file.
+
+The seed is a filtered copy rather than the host file itself, so host-specific state never reaches a container:
+
+- **dropped** — `mcpServers` (the flavour-specific paths above, regenerated per container by `setup build`), `projects` (per-directory history keyed by host paths, and most of the file's bulk), `machineID`, and the GrowthBook/experiment caches the CLI refetches anyway.
+- **kept** — `oauthAccount`, `userID`, `hasCompletedOnboarding`, `lastOnboardingVersion`, `installMethod`, `autoUpdates`, `theme`.
+
+Auth is unaffected: tokens live in `~/.claude/.credentials.json`, which is already a per-cluster named volume. An existing seed is never overwritten, so a hand-tuned one survives re-scaffolding.

--- a/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/__snapshots__/scaffolder.test.ts.snap
@@ -11,7 +11,7 @@ services:
       - \${ORCHESTRATOR_PORT:-3100}
     volumes:
       - workspace:/workspaces
-      - ~/.claude.json:/home/node/.claude.json
+      - ./claude.json:/seed/claude.json:ro
       - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy
@@ -58,7 +58,7 @@ services:
     deploy:
       replicas: \${WORKER_COUNT:-1}
     volumes:
-      - ~/.claude.json:/home/node/.claude.json
+      - ./claude.json:/seed/claude.json:ro
       - claude-config:/home/node/.claude
       - npm-cache:/home/node/.npm
       - generacy-data:/var/lib/generacy

--- a/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/cluster/__tests__/scaffolder.test.ts
@@ -311,14 +311,20 @@ describe('scaffoldDockerCompose', () => {
     expect(parsed.services.worker).not.toHaveProperty('ports');
   });
 
-  it('bind mode binds ~/.claude.json and shares the claude-config dir volume', () => {
+  it('bind mode seeds claude.json read-only and shares the claude-config dir volume', () => {
     scaffoldDockerCompose(dir, { ...baseInput, claudeConfigMode: 'bind' });
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     const orchVolumes = parsed.services.orchestrator.volumes as string[];
     const workerVolumes = parsed.services.worker.volumes as string[];
-    // ~/.claude.json is bind-mounted (account metadata file).
-    expect(orchVolumes).toContain('~/.claude.json:/home/node/.claude.json');
+    // The account metadata file is a read-only SEED. Binding the host's live
+    // ~/.claude.json made every cluster on a machine share one file, so
+    // `generacy setup build` in one cluster overwrote another's agency MCP
+    // path with one that does not exist in its containers.
+    expect(orchVolumes).toContain('./claude.json:/seed/claude.json:ro');
+    expect(workerVolumes).toContain('./claude.json:/seed/claude.json:ro');
+    expect(orchVolumes.some((v) => v.startsWith('~/.claude.json'))).toBe(false);
+    expect(orchVolumes.some((v) => v.endsWith(':/home/node/.claude.json'))).toBe(false);
     // The .claude DIRECTORY is a shared named volume so workers inherit the
     // orchestrator's Claude auth + speckit commands + conversations.
     expect(orchVolumes).toContain('claude-config:/home/node/.claude');
@@ -340,15 +346,19 @@ describe('scaffoldDockerCompose', () => {
   });
 
   // T002 [US1]: volume-mode contract per scaffolder-volume-mode.md Q2–Q5.
-  it('volume mode mounts ./claude.json on both orchestrator and worker (no named volume)', () => {
+  it('volume mode seeds ./claude.json read-only on both orchestrator and worker', () => {
     scaffoldDockerCompose(dir, { ...baseInput, claudeConfigMode: 'volume' });
     const parsed = parse(readFileSync(join(dir, 'docker-compose.yml'), 'utf-8'));
 
     const orchVolumes = parsed.services.orchestrator.volumes as string[];
     const workerVolumes = parsed.services.worker.volumes as string[];
 
-    expect(orchVolumes).toContain('./claude.json:/home/node/.claude.json');
-    expect(workerVolumes).toContain('./claude.json:/home/node/.claude.json');
+    expect(orchVolumes).toContain('./claude.json:/seed/claude.json:ro');
+    expect(workerVolumes).toContain('./claude.json:/seed/claude.json:ro');
+    // Containers copy the seed to ~/.claude.json; nothing writes through to it,
+    // so orchestrator and workers cannot clobber each other's MCP config.
+    expect(orchVolumes.some((v) => v.endsWith(':/home/node/.claude.json'))).toBe(false);
+    expect(workerVolumes.some((v) => v.endsWith(':/home/node/.claude.json'))).toBe(false);
     // #737 guard: the named volume must never mount onto the .claude.json FILE.
     expect(orchVolumes).not.toContain('claude-config:/home/node/.claude.json');
     expect(workerVolumes).not.toContain('claude-config:/home/node/.claude.json');

--- a/packages/generacy/src/cli/commands/cluster/scaffolder.ts
+++ b/packages/generacy/src/cli/commands/cluster/scaffolder.ts
@@ -3,7 +3,8 @@
  *
  * Used by both `launch` and `deploy` commands to ensure consistent file formats.
  */
-import { chownSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { chownSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { stringify } from 'yaml';
 import { getLogger } from '../../utils/logger.js';
@@ -128,13 +129,25 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
   const claudeConfigMode = input.claudeConfigMode ?? 'bind';
   const variant = input.variant;
 
-  // Claude config volume: host bind for local, compose-relative file bind for
-  // cloud/deploy. The `volume` branch used to mount a named volume onto a file
-  // path, which Docker rejects with "is not directory" — see #737.
-  const claudeConfigVolume =
-    claudeConfigMode === 'bind'
-      ? '~/.claude.json:/home/node/.claude.json'
-      : './claude.json:/home/node/.claude.json';
+  // Claude account config is mounted READ-ONLY as a seed, never as the live
+  // file. Every container copies it to ~/.claude.json on first start (see the
+  // cluster-base entrypoints) and writes only to its private copy.
+  //
+  // Mounting the live file was a cross-cluster hazard: every cluster on a host
+  // bound the same `~/.claude.json` read-write, and `generacy setup build`
+  // writes an absolute, image-flavour-specific agency CLI path into
+  // `mcpServers.agency`. Whichever cluster bootstrapped last clobbered that
+  // entry for every other cluster on the machine — a source-build cluster would
+  // inherit a `/shared-packages/...` path that does not exist in its
+  // containers, and its Agency MCP server would fail to start.
+  //
+  // The seed is a scaffolded, filtered copy rather than the host file itself so
+  // that host-specific state (`mcpServers`, the operator's `projects` history,
+  // `machineID`) never reaches a container. `bind` seeds from the host's
+  // `~/.claude.json`; `volume` (deploy) ships the seed alongside the compose
+  // file. The `volume` branch used to mount a named volume onto a file path,
+  // which Docker rejects with "is not directory" — see #737.
+  const claudeConfigVolume = './claude.json:/seed/claude.json:ro';
 
   // Port binding: ephemeral for local, fixed for cloud
   const orchestratorPorts =
@@ -298,25 +311,92 @@ export function scaffoldDockerCompose(dir: string, input: ScaffoldComposeInput):
 
   writeFileSync(join(dir, 'docker-compose.yml'), stringify(compose), 'utf-8');
 
-  if (claudeConfigMode === 'volume') {
-    const claudeJsonPath = join(dir, 'claude.json');
-    if (!existsSync(claudeJsonPath)) {
-      writeFileSync(claudeJsonPath, '{}\n', 'utf-8');
-      // 1000:1000 = the container's `node` user; best-effort, fails silently
-      // on non-root hosts where the scaffolder user lacks CAP_CHOWN.
-      try {
-        chownSync(claudeJsonPath, 1000, 1000);
-      } catch (err) {
-        const errno = (err as NodeJS.ErrnoException | undefined)?.code;
-        if (errno === 'EPERM' || errno === 'EACCES') {
-          getLogger().warn(
-            { path: claudeJsonPath, code: errno },
-            'chown 1000:1000 on claude.json failed; continuing',
-          );
-        } else {
-          throw err;
-        }
+  scaffoldClaudeSeed(dir, claudeConfigMode === 'bind');
+}
+
+/**
+ * Keys carried from the host's `~/.claude.json` into a cluster seed.
+ *
+ * Deliberately excludes:
+ * - `mcpServers` — absolute, image-flavour-specific paths that each container
+ *   regenerates via `generacy setup build`. Copying it is what let one
+ *   cluster's agency path break another's.
+ * - `projects` — the operator's per-directory history, keyed by host paths that
+ *   do not exist in a container (and the bulk of the file's size).
+ * - `machineID` — each container should identify as itself.
+ * - `cachedGrowthBookFeatures` / `cachedExperiment*` — stale caches the CLI
+ *   refetches on its own.
+ *
+ * Auth is NOT in this file: tokens live in `~/.claude/.credentials.json`, which
+ * is a separate per-cluster volume. Seeding a copy therefore cannot break login.
+ */
+const CLAUDE_SEED_KEYS = [
+  'oauthAccount',
+  'userID',
+  'hasCompletedOnboarding',
+  'lastOnboardingVersion',
+  'installMethod',
+  'autoUpdates',
+  'theme',
+] as const;
+
+/**
+ * Build the seed contents from a host `~/.claude.json`.
+ *
+ * Returns an empty object when the source is missing or unreadable — a cluster
+ * must still come up, it just starts from a blank account config.
+ */
+export function buildClaudeSeed(hostClaudeJsonPath: string): Record<string, unknown> {
+  if (!existsSync(hostClaudeJsonPath)) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(hostClaudeJsonPath, 'utf-8')) as Record<string, unknown>;
+    const seed: Record<string, unknown> = {};
+    for (const key of CLAUDE_SEED_KEYS) {
+      if (parsed[key] !== undefined) {
+        seed[key] = parsed[key];
       }
+    }
+    return seed;
+  } catch (err) {
+    getLogger().warn(
+      { path: hostClaudeJsonPath, error: String(err) },
+      'Could not read host ~/.claude.json; seeding an empty Claude config',
+    );
+    return {};
+  }
+}
+
+/**
+ * Write the per-cluster `claude.json` seed that containers copy on first start.
+ *
+ * Never overwrites an existing seed: operators may have hand-tuned it, and
+ * re-seeding on every scaffold would silently revert that.
+ */
+export function scaffoldClaudeSeed(dir: string, fromHost: boolean): void {
+  const claudeJsonPath = join(dir, 'claude.json');
+  if (existsSync(claudeJsonPath)) {
+    return;
+  }
+
+  const seed = fromHost ? buildClaudeSeed(join(homedir(), '.claude.json')) : {};
+  writeFileSync(claudeJsonPath, `${JSON.stringify(seed, null, 2)}\n`, 'utf-8');
+
+  // 1000:1000 = the container's `node` user; best-effort, fails silently
+  // on non-root hosts where the scaffolder user lacks CAP_CHOWN.
+  try {
+    chownSync(claudeJsonPath, 1000, 1000);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (errno === 'EPERM' || errno === 'EACCES') {
+      getLogger().warn(
+        { path: claudeJsonPath, code: errno },
+        'chown 1000:1000 on claude.json failed; continuing',
+      );
+    } else {
+      throw err;
     }
   }
 }

--- a/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
+++ b/packages/generacy/src/cli/commands/launch/__tests__/scaffolder.test.ts
@@ -220,7 +220,7 @@ describe('scaffoldProject', () => {
     expect(parsed.services).not.toHaveProperty('cluster');
   });
 
-  it('uses bind mode for claude config in launch', () => {
+  it('seeds claude config read-only rather than binding the host file', () => {
     const projectDir = join(tempDir, 'new-project');
     scaffoldProject(projectDir, mockConfig, 1);
 
@@ -228,7 +228,10 @@ describe('scaffoldProject', () => {
     const parsed = parse(raw);
 
     const orchVolumes = parsed.services.orchestrator.volumes as string[];
-    expect(orchVolumes).toContain('~/.claude.json:/home/node/.claude.json');
+    expect(orchVolumes).toContain('./claude.json:/seed/claude.json:ro');
+    // Local clusters used to share the host's ~/.claude.json, so launching a
+    // second cluster overwrote the first cluster's agency MCP path.
+    expect(orchVolumes.some((v) => v.startsWith('~/.claude.json'))).toBe(false);
   });
 
   it('sets DEPLOYMENT_MODE=local for launch', () => {

--- a/packages/generacy/tests/unit/cluster/claude-seed.test.ts
+++ b/packages/generacy/tests/unit/cluster/claude-seed.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildClaudeSeed,
+  scaffoldClaudeSeed,
+} from '../../../src/cli/commands/cluster/scaffolder.js';
+
+describe('buildClaudeSeed', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'claude-seed-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeHostConfig(contents: unknown): string {
+    const path = join(dir, '.claude.json');
+    writeFileSync(path, JSON.stringify(contents), 'utf-8');
+    return path;
+  }
+
+  it('carries account and onboarding state', () => {
+    const path = writeHostConfig({
+      oauthAccount: { emailAddress: 'operator@example.com' },
+      userID: 'user-1',
+      hasCompletedOnboarding: true,
+      lastOnboardingVersion: '2.1.211',
+    });
+
+    expect(buildClaudeSeed(path)).toEqual({
+      oauthAccount: { emailAddress: 'operator@example.com' },
+      userID: 'user-1',
+      hasCompletedOnboarding: true,
+      lastOnboardingVersion: '2.1.211',
+    });
+  });
+
+  it('drops mcpServers so one cluster cannot poison another', () => {
+    // The whole reason for seeding rather than sharing: this path is
+    // image-flavour-specific and does not exist in a source-build cluster.
+    const path = writeHostConfig({
+      userID: 'user-1',
+      mcpServers: {
+        agency: {
+          type: 'stdio',
+          command: 'node',
+          args: ['/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js'],
+        },
+      },
+    });
+
+    expect(buildClaudeSeed(path)).not.toHaveProperty('mcpServers');
+  });
+
+  it('drops host-specific project history and machine identity', () => {
+    const path = writeHostConfig({
+      userID: 'user-1',
+      projects: { '/home/operator/work/repo': { history: ['...'] } },
+      machineID: 'host-machine',
+      cachedGrowthBookFeatures: { flag: true },
+    });
+
+    const seed = buildClaudeSeed(path);
+    expect(seed).not.toHaveProperty('projects');
+    expect(seed).not.toHaveProperty('machineID');
+    expect(seed).not.toHaveProperty('cachedGrowthBookFeatures');
+  });
+
+  it('returns an empty seed when the host config is missing', () => {
+    expect(buildClaudeSeed(join(dir, 'does-not-exist.json'))).toEqual({});
+  });
+
+  it('returns an empty seed rather than throwing on malformed JSON', () => {
+    const path = join(dir, '.claude.json');
+    writeFileSync(path, '{ not json', 'utf-8');
+
+    expect(buildClaudeSeed(path)).toEqual({});
+  });
+});
+
+describe('scaffoldClaudeSeed', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'claude-seed-dir-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes an empty seed when not seeding from the host', () => {
+    scaffoldClaudeSeed(dir, false);
+
+    expect(JSON.parse(readFileSync(join(dir, 'claude.json'), 'utf-8'))).toEqual({});
+  });
+
+  it('does not overwrite an existing seed', () => {
+    // Operators may hand-tune the seed; re-scaffolding must not revert it.
+    writeFileSync(join(dir, 'claude.json'), '{"userID":"hand-tuned"}', 'utf-8');
+
+    scaffoldClaudeSeed(dir, false);
+
+    expect(JSON.parse(readFileSync(join(dir, 'claude.json'), 'utf-8'))).toEqual({
+      userID: 'hand-tuned',
+    });
+  });
+});

--- a/packages/generacy/tests/unit/deploy/scaffolder.test.ts
+++ b/packages/generacy/tests/unit/deploy/scaffolder.test.ts
@@ -110,15 +110,31 @@ describe('scaffoldBundle', () => {
       expect(content.services.orchestrator.environment).toContain('DEPLOYMENT_MODE=cloud');
     });
 
-    it('uses compose-relative ./claude.json bind for volume mode (no named volume)', () => {
+    it('mounts claude.json read-only as a seed, never as the live config', () => {
       const dir = callScaffold();
       const content = parse(readFileSync(join(dir, '.generacy', 'docker-compose.yml'), 'utf-8'));
 
       const orchVolumes = content.services.orchestrator.volumes as string[];
       const workerVolumes = content.services.worker.volumes as string[];
-      expect(orchVolumes).toContain('./claude.json:/home/node/.claude.json');
-      expect(workerVolumes).toContain('./claude.json:/home/node/.claude.json');
+      expect(orchVolumes).toContain('./claude.json:/seed/claude.json:ro');
+      expect(workerVolumes).toContain('./claude.json:/seed/claude.json:ro');
+      // Binding the live file made every cluster on a host share one config,
+      // so `generacy setup build` in one cluster clobbered another's agency
+      // MCP path. Containers must copy the seed, not write through to it.
+      expect(orchVolumes.some((v) => v.endsWith(':/home/node/.claude.json'))).toBe(false);
+      expect(workerVolumes.some((v) => v.endsWith(':/home/node/.claude.json'))).toBe(false);
       expect(orchVolumes).not.toContain('claude-config:/home/node/.claude.json');
+    });
+
+    it('never binds the host ~/.claude.json into a container', () => {
+      const dir = callScaffold();
+      const content = parse(readFileSync(join(dir, '.generacy', 'docker-compose.yml'), 'utf-8'));
+
+      const allVolumes = [
+        ...(content.services.orchestrator.volumes as string[]),
+        ...(content.services.worker.volumes as string[]),
+      ];
+      expect(allVolumes.some((v) => v.startsWith('~/.claude.json'))).toBe(false);
     });
 
     it('mounts docker socket at /var/run/docker-host.sock', () => {


### PR DESCRIPTION
## Problem

Scaffolded clusters bound the operator's live `~/.claude.json` **read-write** into the orchestrator and every worker:

```yaml
- ~/.claude.json:/home/node/.claude.json      # local
- ./claude.json:/home/node/.claude.json       # cloud
```

That is one file per **host**, not per cluster. Confirmed on a machine running two clusters — both bind the identical source:

```
tetrad-development-worker-1: bind C:\Users\<user>\.claude.json -> /home/node/.claude.json (rw=true)
snappoll-worker-1:           bind C:\Users\<user>\.claude.json -> /home/node/.claude.json (rw=true)
```

`generacy setup build` writes an absolute, **image-flavour-specific** agency CLI path into `mcpServers.agency`. Whichever cluster bootstrapped last therefore clobbered that entry for every other cluster on the machine. In practice a source-build cluster inherited `/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js` — a path that does not exist in its containers — and its Agency MCP server failed to start, so speckit commands silently degraded to bash.

## Change

`claude.json` is now mounted **read-only** at `/seed/claude.json` and copied to `~/.claude.json` by the container entrypoint on first start. Containers write only to their private copy, which also removes orchestrator-and-N-workers concurrently writing one JSON file.

The seed is a **filtered** copy rather than the host file itself, so host-specific state never reaches a container:

- **dropped** — `mcpServers` (the flavour-specific paths above, regenerated per container by `setup build`), `projects` (per-directory history keyed by host paths, and most of the file's 80 KB), `machineID`, GrowthBook/experiment caches
- **kept** — `oauthAccount`, `userID`, `hasCompletedOnboarding`, `lastOnboardingVersion`, `installMethod`, `autoUpdates`, `theme`

Seeding happens **only when `~/.claude.json` is missing**.

## Auth is not affected

Worth stating explicitly, since "copy instead of share" sounds like it should break login: tokens are **not** in this file. They live in `~/.claude/.credentials.json`, which is already a separate per-cluster named volume (verified present in a running worker). Only account metadata and onboarding flags are in `.claude.json`.

## Ordering

Requires the matching cluster-base entrypoint change. The copy **no-ops when no seed is mounted**, so merging cluster-base first is safe and merging this first only means containers keep using whatever config they already have. Existing clusters do not regenerate their compose file on restart, so this takes effect on next scaffold.

## Tests

New `tests/unit/cluster/claude-seed.test.ts` covers the filter (including that `mcpServers` is dropped), missing/malformed sources, and no-overwrite. Existing scaffolder assertions updated in both test trees, plus the bind-mode YAML snapshot.

11 failures remain in the package suite — all `cockpit/doorbell` and `deploy/activation`, all confirmed pre-existing on a clean `develop` and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)