### PR TITLE
feat(cli): register agency MCP server in speckit mode for cluster containers

### DIFF
--- a/.changeset/agency-speckit-mode.md
+++ b/.changeset/agency-speckit-mode.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/generacy": patch
+---
+
+`generacy setup build` now registers the agency MCP server with `--mode speckit`, scoping worker sessions to the 11 tools the speckit playbooks actually use (~6 KB of tool definitions per session instead of ~26 KB / 49 tools in agency's default coding mode). The mode and flag ship in agency ≥ the PR pairing this change; older agency CLIs ignore unknown argv, so mixed versions degrade gracefully to today's behavior.

--- a/packages/generacy/src/__tests__/setup/build.test.ts
+++ b/packages/generacy/src/__tests__/setup/build.test.ts
@@ -758,7 +758,7 @@ describe('setup build command', () => {
       expect(written.mcpServers.agency).toEqual({
         type: 'stdio',
         command: 'node',
-        args: ['/workspaces/agency/packages/agency/dist/cli.js'],
+        args: ['/workspaces/agency/packages/agency/dist/cli.js', '--mode', 'speckit'],
         cwd: '/workspaces/agency',
       });
     });
@@ -784,7 +784,7 @@ describe('setup build command', () => {
       expect(written.mcpServers.agency).toEqual({
         type: 'stdio',
         command: 'node',
-        args: ['/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js'],
+        args: ['/shared-packages/node_modules/@generacy-ai/agency/dist/cli.js', '--mode', 'speckit'],
       });
     });
 

--- a/packages/generacy/src/cli/commands/setup/build.ts
+++ b/packages/generacy/src/cli/commands/setup/build.ts
@@ -469,10 +469,14 @@ function installClaudeCodeIntegration(config: BuildConfig): void {
     }
 
     const mcpServers = (claudeJson['mcpServers'] ?? {}) as Record<string, unknown>;
+    // --mode speckit scopes the advertised tool surface to the 11 tools the
+    // speckit playbooks use (~6 KB of definitions vs ~26 KB in coding mode).
+    // Agency CLIs that predate the flag ignore unknown argv, so this is safe
+    // against older shared-package builds.
     const mcpEntry: Record<string, unknown> = {
       type: 'stdio',
       command: 'node',
-      args: [agencyCli],
+      args: [agencyCli, '--mode', 'speckit'],
     };
     if (agencyCwd) {
       mcpEntry['cwd'] = agencyCwd;


### PR DESCRIPTION
Companion to generacy-ai/agency#494 (part 4 of the agency MCP token-efficiency work).

`generacy setup build` Phase 4 now writes the agency `mcpServers` entry with `--mode speckit`:

```json
{ "type": "stdio", "command": "node", "args": ["<agencyCli>", "--mode", "speckit"], "cwd": "<agencyDir?>" }
```

Agency's new `speckit` mode advertises only the 11 tools the speckit playbooks actually use (six `spec_kit.*` workflow tools + the terse `build.compile`/`build.validate`/`test.run_*` checks) — measured **5,969 chars of tool definitions vs 26,178 chars / 49 tools** in the default coding mode, a ~5k-token saving loaded into every worker phase session.

Version-skew safety, both directions:
- **New generacy + old agency**: the agency CLI historically parses no argv, so the flag is ignored and the server starts in coding mode (today's behavior).
- **New agency + old generacy**: no flag written → coding mode (today's behavior).

An unknown mode name (should agency and generacy ever drift) makes agency log a stderr warning and keep its configured default rather than serving zero tools.

Test plan: the two pinned `mcpEntry` shape assertions in `src/__tests__/setup/build.test.ts` updated; all 60 tests in that file pass; package build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)