### PR TITLE
feat(cockpit): cockpit.auto model/effort config + effort on conversation launches

### DIFF
--- a/.changeset/cockpit-auto-agent-config.md
+++ b/.changeset/cockpit-auto-agent-config.md
@@ -1,0 +1,24 @@
+---
+"@generacy-ai/cockpit": minor
+"@generacy-ai/orchestrator": minor
+"@generacy-ai/generacy-plugin-claude-code": minor
+---
+
+Cockpit auto model/effort configuration + effort on conversation launches.
+
+`@generacy-ai/cockpit`: `CockpitConfigSchema` gains an optional `auto` block
+(`cockpit.auto` in `.generacy/config.yaml`) for the `/cockpit:auto` run loop —
+`loop` (model/effort for the loop session, consumed by headless launchers),
+`heartbeatSeconds` (base heartbeat interval, 60–3600), `quiet` (suppress
+transcript narration for headless runs), and `agents` (per-role
+`{ provider?, model?, effort? }` selectors for the clarifier / reviewer /
+validator / fixer / diagnoser analysis subagents, mirroring the orchestrator's
+`AgentEntrySchema`). An invalid `auto` block degrades to a loader warning and
+is ignored, so it can never break `owner`/`assignee` consumers.
+
+`@generacy-ai/orchestrator` + `@generacy-ai/generacy-plugin-claude-code`:
+`ConversationTurnIntent` / `POST /conversations` gain an optional `effort`
+field, threaded through `ConversationManager`/`ConversationSpawner` to
+`claude --effort <level>` — the phase path already supported effort; the
+conversation path (used for headless slash-command launches like
+`/cockpit:auto`) now does too.

--- a/packages/cockpit/src/__tests__/config-loader.test.ts
+++ b/packages/cockpit/src/__tests__/config-loader.test.ts
@@ -116,4 +116,79 @@ describe('loadCockpitConfig', () => {
         .stuckThresholdMinutes,
     ).toBeUndefined();
   });
+
+  it('parses a full cockpit.auto block (loop, heartbeatSeconds, quiet, per-role agents)', async () => {
+    await writeConfig(
+      cwd,
+      [
+        'cockpit:',
+        '  owner: alice',
+        '  auto:',
+        '    loop: { model: sonnet, effort: low }',
+        '    heartbeatSeconds: 1200',
+        '    quiet: true',
+        '    agents:',
+        '      default: { model: sonnet, effort: medium }',
+        '      reviewer: { model: opus, effort: high }',
+        '      validator: { model: haiku }',
+        '',
+      ].join('\n'),
+    );
+    const result = await loadCockpitConfig({ cwd, whoami: async () => null });
+    expect(result.warnings).toEqual([]);
+    expect(result.config.auto).toEqual({
+      loop: { model: 'sonnet', effort: 'low' },
+      heartbeatSeconds: 1200,
+      quiet: true,
+      agents: {
+        default: { model: 'sonnet', effort: 'medium' },
+        reviewer: { model: 'opus', effort: 'high' },
+        validator: { model: 'haiku' },
+      },
+    });
+  });
+
+  it('auto block alone yields source cockpit-block', async () => {
+    await writeConfig(cwd, 'cockpit:\n  auto:\n    quiet: true\n');
+    const result = await loadCockpitConfig({ cwd, whoami: async () => null });
+    expect(result.source).toBe('cockpit-block');
+    expect(result.config.auto?.quiet).toBe(true);
+  });
+
+  it('invalid cockpit.auto degrades to a warning without breaking owner/assignee', async () => {
+    await writeConfig(
+      cwd,
+      [
+        'cockpit:',
+        '  owner: alice',
+        '  auto:',
+        '    heartbeatSeconds: 5',
+        '    agents:',
+        '      reviewre: { model: opus }',
+        '',
+      ].join('\n'),
+    );
+    const result = await loadCockpitConfig({ cwd, whoami: async () => null });
+    expect(result.config.owner).toBe('alice');
+    expect(result.config.auto).toBeUndefined();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('cockpit.auto ignored (invalid)');
+  });
+
+  it('unknown effort value in cockpit.auto is rejected (warning), valid entries unaffected elsewhere', async () => {
+    await writeConfig(
+      cwd,
+      'cockpit:\n  auto:\n    loop: { model: sonnet, effort: turbo }\n',
+    );
+    const result = await loadCockpitConfig({ cwd, whoami: async () => null });
+    expect(result.config.auto).toBeUndefined();
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('absent auto block leaves config.auto undefined with no warnings', async () => {
+    await writeConfig(cwd, 'cockpit:\n  owner: alice\n');
+    const result = await loadCockpitConfig({ cwd, whoami: async () => null });
+    expect(result.config.auto).toBeUndefined();
+    expect(result.warnings).toEqual([]);
+  });
 });

--- a/packages/cockpit/src/config/loader.ts
+++ b/packages/cockpit/src/config/loader.ts
@@ -3,7 +3,9 @@ import { existsSync } from 'node:fs';
 import { findWorkspaceConfigPath } from '@generacy-ai/config';
 import { parse as parseYaml } from 'yaml';
 import {
-  CockpitConfigSchema,
+  CockpitAutoConfigSchema,
+  CockpitBaseConfigSchema,
+  type CockpitAutoConfig,
   type CockpitConfig,
   type CockpitConfigSource,
   type LoadedCockpitConfig,
@@ -67,9 +69,30 @@ export async function loadCockpitConfig(
     }
   }
 
-  const parsedCockpit = CockpitConfigSchema.parse(cockpitBlock ?? {});
+  const parsedCockpit = CockpitBaseConfigSchema.parse(cockpitBlock ?? {});
+
+  // `auto` degrades to a warning on parse failure so a bad (or newer) auto
+  // block never breaks owner/assignee consumers (advance, queue, resume, …).
+  let auto: CockpitAutoConfig | undefined;
+  if (cockpitBlock != null && typeof cockpitBlock === 'object') {
+    const autoRaw = (cockpitBlock as Record<string, unknown>)['auto'];
+    if (autoRaw !== undefined) {
+      const autoResult = CockpitAutoConfigSchema.safeParse(autoRaw);
+      if (autoResult.success) {
+        auto = autoResult.data;
+      } else {
+        const detail = autoResult.error.issues
+          .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+          .join('; ');
+        warnings.push(`cockpit.auto ignored (invalid): ${detail}`);
+      }
+    }
+  }
+
   const source: CockpitConfigSource =
-    parsedCockpit.owner != null || parsedCockpit.assignee != null ? 'cockpit-block' : 'defaults';
+    parsedCockpit.owner != null || parsedCockpit.assignee != null || auto != null
+      ? 'cockpit-block'
+      : 'defaults';
 
   let owner: string | undefined = parsedCockpit.owner;
   if (owner == null) {
@@ -83,7 +106,7 @@ export async function loadCockpitConfig(
     }
   }
 
-  const config: CockpitConfig = { owner, assignee: parsedCockpit.assignee };
+  const config: CockpitConfig = { owner, assignee: parsedCockpit.assignee, auto };
 
   return { config, source, warnings };
 }

--- a/packages/cockpit/src/config/schema.ts
+++ b/packages/cockpit/src/config/schema.ts
@@ -1,8 +1,72 @@
 import { z } from 'zod';
+import { AgentEntrySchema } from '@generacy-ai/config';
 
-export const CockpitConfigSchema = z.object({
+/**
+ * Named analysis roles the `/cockpit:auto` playbook dispatches to subagents.
+ * Mirrors the agent files shipped in `claude-plugin-cockpit/agents/`.
+ */
+export const COCKPIT_AGENT_ROLES = [
+  'clarifier',
+  'reviewer',
+  'validator',
+  'fixer',
+  'diagnoser',
+] as const;
+export type CockpitAgentRole = (typeof COCKPIT_AGENT_ROLES)[number];
+
+/**
+ * Per-role agent selectors for `/cockpit:auto` subagents. Each entry reuses
+ * the orchestrator's `AgentEntrySchema` shape (`{ provider?, model?, effort? }`).
+ * Resolution: role entry → `default` → inherit the loop session's model.
+ */
+export const CockpitAutoAgentsSchema = z
+  .object({
+    default: AgentEntrySchema.optional(),
+    clarifier: AgentEntrySchema.optional(),
+    reviewer: AgentEntrySchema.optional(),
+    validator: AgentEntrySchema.optional(),
+    fixer: AgentEntrySchema.optional(),
+    diagnoser: AgentEntrySchema.optional(),
+  })
+  .strict();
+export type CockpitAutoAgents = z.infer<typeof CockpitAutoAgentsSchema>;
+
+/**
+ * `cockpit.auto` block — configuration for the `/cockpit:auto` run loop.
+ *
+ * - `loop`: model/effort for the dispatch loop session itself. Consumed by
+ *   launchers that start a `/cockpit:auto` session headlessly (the playbook
+ *   cannot change its own session model mid-run).
+ * - `heartbeatSeconds`: base interval for the belt-and-braces heartbeat
+ *   (default 300). The playbook backs off from this base while drains stay
+ *   empty; clamped to the harness ScheduleWakeup range [60, 3600].
+ * - `quiet`: suppress transcript narration (ledger echoes, status tables,
+ *   printed run summary) for headless runs. Durable records (ledger file,
+ *   tracking-issue comments) are unaffected.
+ * - `agents`: per-role model/effort overrides for the analysis subagents.
+ */
+export const CockpitAutoConfigSchema = z
+  .object({
+    loop: AgentEntrySchema.optional(),
+    heartbeatSeconds: z.number().int().min(60).max(3600).optional(),
+    quiet: z.boolean().optional(),
+    agents: CockpitAutoAgentsSchema.optional(),
+  })
+  .strict();
+export type CockpitAutoConfig = z.infer<typeof CockpitAutoConfigSchema>;
+
+/**
+ * Base `cockpit:` block fields. Parsed strictly-throwing by the loader (as
+ * before); kept separate from `auto` so an invalid `auto` block degrades to a
+ * warning instead of breaking `owner`/`assignee` consumers.
+ */
+export const CockpitBaseConfigSchema = z.object({
   owner: z.string().min(1).optional(),
   assignee: z.string().min(1).optional(),
+});
+
+export const CockpitConfigSchema = CockpitBaseConfigSchema.extend({
+  auto: CockpitAutoConfigSchema.optional(),
 });
 
 export type CockpitConfig = z.infer<typeof CockpitConfigSchema>;

--- a/packages/cockpit/src/index.ts
+++ b/packages/cockpit/src/index.ts
@@ -13,8 +13,15 @@ export { TIER_RANK, WAITING_PIPELINE_ORDER } from './state/precedence.js';
 // Config
 export {
   CockpitConfigSchema,
+  CockpitBaseConfigSchema,
+  CockpitAutoConfigSchema,
+  CockpitAutoAgentsSchema,
+  COCKPIT_AGENT_ROLES,
   type CockpitConfig,
   type CockpitConfigSource,
+  type CockpitAutoConfig,
+  type CockpitAutoAgents,
+  type CockpitAgentRole,
   type LoadedCockpitConfig,
 } from './config/schema.js';
 export {

--- a/packages/generacy-plugin-claude-code/src/launch/claude-code-launch-plugin.ts
+++ b/packages/generacy-plugin-claude-code/src/launch/claude-code-launch-plugin.ts
@@ -267,6 +267,10 @@ export class ClaudeCodeLaunchPlugin {
       claudeArgs.push('--model', intent.model);
     }
 
+    if (intent.effort) {
+      claudeArgs.push('--effort', intent.effort);
+    }
+
     return {
       command: 'python3',
       args: ['-u', '-c', PTY_WRAPPER, ...claudeArgs],

--- a/packages/generacy-plugin-claude-code/src/launch/types.ts
+++ b/packages/generacy-plugin-claude-code/src/launch/types.ts
@@ -105,6 +105,8 @@ export interface ConversationTurnIntent {
   sessionId?: string;
   /** Model override (omit for CLI default) */
   model?: string;
+  /** Optional reasoning-effort override, provider-interpreted. */
+  effort?: Effort;
   /** Whether to skip permission prompts */
   skipPermissions: boolean;
 }

--- a/packages/orchestrator/src/conversation/__tests__/__snapshots__/conversation-spawner.test.ts.snap
+++ b/packages/orchestrator/src/conversation/__tests__/__snapshots__/conversation-spawner.test.ts.snap
@@ -6,6 +6,7 @@ exports[`ConversationSpawner > spawnTurn — LaunchRequest snapshot > captures f
   "cwd": "/workspace",
   "env": {},
   "intent": {
+    "effort": undefined,
     "kind": "conversation-turn",
     "message": "Tell me about TypeScript",
     "model": "claude-sonnet-4-6",

--- a/packages/orchestrator/src/conversation/conversation-manager.ts
+++ b/packages/orchestrator/src/conversation/conversation-manager.ts
@@ -76,6 +76,7 @@ export class ConversationManager {
       process: null as any, // No long-lived process; per-turn spawning
       startedAt: new Date().toISOString(),
       model,
+      effort: options.effort,
       initialCommand: options.initialCommand,
       state: 'active',
       stdin: null,
@@ -134,6 +135,7 @@ export class ConversationManager {
       message,
       sessionId: handle.sessionId,
       model: handle.model,
+      effort: handle.effort,
       skipPermissions: handle.skipPermissions,
     });
 

--- a/packages/orchestrator/src/conversation/conversation-spawner.ts
+++ b/packages/orchestrator/src/conversation/conversation-spawner.ts
@@ -1,3 +1,4 @@
+import type { Effort } from '@generacy-ai/config';
 import type { ChildProcessHandle } from '../worker/types.js';
 import type { AgentLauncher } from '../launcher/agent-launcher.js';
 import { buildLaunchCredentials } from '../worker/credentials-helper.js';
@@ -14,6 +15,8 @@ export interface ConversationTurnOptions {
   sessionId?: string;
   /** Model to use */
   model?: string;
+  /** Reasoning-effort override, provider-interpreted */
+  effort?: Effort;
   /** Skip permission prompts */
   skipPermissions: boolean;
 }
@@ -58,6 +61,7 @@ export class ConversationSpawner {
         message: options.message,
         sessionId: options.sessionId,
         model: options.model,
+        effort: options.effort,
         skipPermissions: options.skipPermissions,
       },
       cwd: options.cwd,

--- a/packages/orchestrator/src/conversation/types.ts
+++ b/packages/orchestrator/src/conversation/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { EffortSchema, type Effort } from '@generacy-ai/config';
 import type { ChildProcessHandle } from '../worker/types.js';
 
 // =============================================================================
@@ -23,6 +24,7 @@ export interface ConversationHandle {
   process: ChildProcessHandle;
   startedAt: string;
   model?: string;
+  effort?: Effort;
   initialCommand?: string;
   state: ConversationState;
   /** Writable stream for sending messages to the CLI process stdin */
@@ -50,6 +52,7 @@ export interface ConversationStartOptions {
   workingDirectory: string;
   initialCommand?: string;
   model?: string;
+  effort?: Effort;
   skipPermissions?: boolean;
 }
 
@@ -62,6 +65,7 @@ export const ConversationStartSchema = z.object({
   workingDirectory: z.string().min(1).max(64),
   initialCommand: z.string().max(4096).optional(),
   model: z.string().max(64).optional(),
+  effort: EffortSchema.optional(),
   skipPermissions: z.boolean().default(true),
 });
 

--- a/packages/orchestrator/src/launcher/types.ts
+++ b/packages/orchestrator/src/launcher/types.ts
@@ -115,6 +115,8 @@ export interface ConversationTurnIntent {
   sessionId?: string;
   /** Model override (omit for default) */
   model?: string;
+  /** Optional reasoning-effort override, provider-interpreted. */
+  effort?: Effort;
   /** Whether to skip permission prompts */
   skipPermissions: boolean;
 }


### PR DESCRIPTION
## Summary

Companion PR to the /cockpit:auto token-efficiency work in agency (playbook compaction + named subagents). Adds the configuration surface and missing launch-path plumbing:

- **cockpit.auto config block** (@generacy-ai/cockpit): CockpitConfigSchema gains an optional strict `auto` block under the existing `cockpit:` key in .generacy/config.yaml:
  ```yaml
  cockpit:
    auto:
      loop: { model: sonnet, effort: low }      # loop session (consumed by headless launchers)
      heartbeatSeconds: 1200                    # base heartbeat; playbook backs off while quiet
      quiet: true                               # suppress transcript narration for headless runs
      agents:
        default:   { model: sonnet }
        clarifier: { model: opus, effort: high }
        reviewer:  { model: opus, effort: high }
        validator: { model: haiku }
        fixer:     { model: sonnet, effort: high }
        diagnoser: { model: sonnet }
  ```
  Per-role entries reuse the orchestrator's AgentEntrySchema ({ provider?, model?, effort? }). An invalid auto block degrades to a loader **warning** and is ignored — it can never break owner/assignee consumers (advance/queue/resume/scope).

- **effort on the conversation launch path** (@generacy-ai/orchestrator + @generacy-ai/generacy-plugin-claude-code): POST /conversations / ConversationTurnIntent gain an optional `effort` field, threaded through ConversationManager/ConversationSpawner to `claude --effort <level>`. The phase path already supported effort; the conversation path (how a UI headlessly launches `/cockpit:auto <ref> --gates=ui`) now does too.

## Testing

- @generacy-ai/cockpit: 491 tests pass (5 new loader tests for the auto block: full parse, auto-only source, invalid-degrades-to-warning, bad effort enum, absent block).
- @generacy-ai/orchestrator: 2942 tests pass (one LaunchRequest snapshot updated for the new effort field).
- @generacy-ai/generacy-plugin-claude-code: 153 tests pass.
- Changeset included (minor × 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
