### PR TITLE
fix(setup): don't clobber the JIT git credential helper in wizard mode

### DIFF
--- a/.changeset/wizard-jit-credential-clobber.md
+++ b/.changeset/wizard-jit-credential-clobber.md
@@ -1,0 +1,5 @@
+---
+'@generacy-ai/generacy': patch
+---
+
+`setup auth` and `setup workspace` no longer clobber the JIT git credential helper on wizard-mode clusters. Both commands previously configured static credentials from the activation-time `GH_TOKEN` (a 1-hour GitHub App installation token) — `setup auth` wrote `credential.helper store` + `~/.git-credentials`, and `setup workspace` ran `gh auth setup-git`, replacing the `git-credential-generacy` helper wired by cluster-base's setup-credentials.sh. Workers (which run no git-helper-guard) then lost all git auth an hour after activation. When wizard mode is active and the JIT helper is present in git config, both commands now leave credential configuration untouched.

--- a/packages/generacy/src/__tests__/setup/auth.test.ts
+++ b/packages/generacy/src/__tests__/setup/auth.test.ts
@@ -51,6 +51,7 @@ beforeEach(() => {
   delete process.env['GH_EMAIL'];
   delete process.env['GH_USERNAME'];
   delete process.env['GH_TOKEN'];
+  delete process.env['GENERACY_BOOTSTRAP_MODE'];
 });
 
 afterEach(() => {
@@ -266,6 +267,66 @@ describe('setup auth command', () => {
       expect(mockWriteFileSync).not.toHaveBeenCalled();
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'GH_TOKEN not set — git push/pull to private repos will require manual authentication',
+      );
+    });
+  });
+
+  describe('JIT credential helper gating (wizard mode)', () => {
+    // Wizard clusters authenticate git via git-credential-generacy; the only
+    // GH_TOKEN in their environment is the 1-hour activation token, so static
+    // credential configuration must be skipped when the JIT helper is active.
+    it('skips static git/gh credential configuration when the JIT helper is active', async () => {
+      process.env['GH_TOKEN'] = 'ghs_wizardtoken';
+      process.env['GENERACY_BOOTSTRAP_MODE'] = 'wizard';
+      mockExecBehavior({
+        'credential.https://github.com.helper': {
+          stdout: "!CONTROL_PLANE_SOCKET_PATH='/run/generacy-git-token/control.sock' node 'git-credential-generacy.js'",
+        },
+      });
+
+      await runAuthCommand([]);
+
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      const cmds = mockExecSync.mock.calls.map((call) => call[0] as string);
+      expect(cmds).not.toContain('git config --global credential.helper store');
+      expect(cmds.some((cmd) => cmd.includes('gh auth login --with-token'))).toBe(false);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'JIT git credential helper active (wizard mode) — skipping static git/gh credential configuration',
+      );
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        'GH_TOKEN not set — git push/pull to private repos will require manual authentication',
+      );
+    });
+
+    it('still configures static credentials in wizard mode when the JIT helper is absent', async () => {
+      process.env['GH_TOKEN'] = 'ghp_abc123';
+      process.env['GENERACY_BOOTSTRAP_MODE'] = 'wizard';
+      mockExecBehavior(); // helper lookup returns '' → no JIT marker
+
+      await runAuthCommand([]);
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'git config --global credential.helper store',
+        expect.any(Object),
+      );
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '/home/testuser/.git-credentials',
+        'https://git:ghp_abc123@github.com\n',
+        { mode: 0o600 },
+      );
+    });
+
+    it('still configures static credentials outside wizard mode even when the JIT helper is configured', async () => {
+      process.env['GH_TOKEN'] = 'ghp_abc123';
+      mockExecBehavior({
+        'credential.https://github.com.helper': { stdout: 'git-credential-generacy' },
+      });
+
+      await runAuthCommand([]);
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'git config --global credential.helper store',
+        expect.any(Object),
       );
     });
   });

--- a/packages/generacy/src/__tests__/setup/workspace.test.ts
+++ b/packages/generacy/src/__tests__/setup/workspace.test.ts
@@ -59,6 +59,7 @@ beforeEach(() => {
   delete process.env['GITHUB_ORG'];
   delete process.env['GH_TOKEN'];
   delete process.env['GH_USERNAME'];
+  delete process.env['GENERACY_BOOTSTRAP_MODE'];
 });
 
 afterEach(() => {
@@ -703,6 +704,50 @@ describe('setup workspace command', () => {
         '/home/testuser/.git-credentials',
         'https://testuser:ghp_testtoken@github.com\n',
         { mode: 0o600 },
+      );
+    });
+
+    it('leaves credential config untouched when the JIT helper is active (wizard mode)', async () => {
+      process.env['GENERACY_BOOTSTRAP_MODE'] = 'wizard';
+      mockExecBehavior({
+        'credential.https://github.com.helper': {
+          stdout: "!CONTROL_PLANE_SOCKET_PATH='/run/generacy-git-token/control.sock' node 'git-credential-generacy.js'",
+        },
+      });
+      mockFileSystem();
+
+      await runWorkspaceCommand(['--repos', 'test-repo']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'JIT git credential helper active (wizard mode) — leaving git credential configuration untouched',
+      );
+      const cmds = mockExecSync.mock.calls.map((call) => call[0] as string);
+      expect(cmds).not.toContain('gh auth setup-git');
+      expect(cmds).not.toContain('git config --global credential.helper store');
+    });
+
+    it('keeps gh auth setup-git in wizard mode when the JIT helper is not configured', async () => {
+      process.env['GENERACY_BOOTSTRAP_MODE'] = 'wizard';
+      mockExecBehavior(); // helper lookup returns '' → no JIT marker; gh auth status ok
+      mockFileSystem();
+
+      await runWorkspaceCommand(['--repos', 'test-repo']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'gh CLI is authenticated, configuring git to use gh credentials',
+      );
+    });
+
+    it('keeps gh auth setup-git outside wizard mode even when the JIT helper is configured', async () => {
+      mockExecBehavior({
+        'credential.https://github.com.helper': { stdout: 'git-credential-generacy' },
+      });
+      mockFileSystem();
+
+      await runWorkspaceCommand(['--repos', 'test-repo']);
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'gh CLI is authenticated, configuring git to use gh credentials',
       );
     });
 

--- a/packages/generacy/src/cli/commands/setup/auth.ts
+++ b/packages/generacy/src/cli/commands/setup/auth.ts
@@ -9,6 +9,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { getLogger } from '../../utils/logger.js';
 import { exec, execSafe } from '../../utils/exec.js';
+import { jitCredentialHelperActive } from './jit-credentials.js';
 
 /**
  * Auth configuration resolved from CLI args and environment variables.
@@ -71,8 +72,19 @@ export function setupAuthCommand(): Command {
         }
       }
 
+      // Wizard clusters authenticate via the JIT credential helper; the only
+      // GH_TOKEN in their environment is the 1-hour activation token, and
+      // configuring it statically here would replace never-stale JIT auth
+      // with a token that dies within the hour. See jit-credentials.ts.
+      const jitActive = jitCredentialHelperActive();
+      if (jitActive) {
+        logger.info(
+          'JIT git credential helper active (wizard mode) — skipping static git/gh credential configuration',
+        );
+      }
+
       // Step 2: Configure git credential helper
-      if (config.token) {
+      if (config.token && !jitActive) {
         exec('git config --global credential.helper store');
 
         const home = homedir();
@@ -85,14 +97,14 @@ export function setupAuthCommand(): Command {
           { mode: 0o600 },
         );
         logger.info('Git credentials configured for github.com');
-      } else {
+      } else if (!config.token) {
         logger.warn(
           'GH_TOKEN not set — git push/pull to private repos will require manual authentication',
         );
       }
 
       // Step 3: Configure gh CLI auth
-      if (config.token) {
+      if (config.token && !jitActive) {
         const authCheck = execSafe('gh auth status');
         if (authCheck.ok) {
           logger.info('GitHub CLI authenticated via GH_TOKEN env var');

--- a/packages/generacy/src/cli/commands/setup/jit-credentials.ts
+++ b/packages/generacy/src/cli/commands/setup/jit-credentials.ts
@@ -1,0 +1,40 @@
+/**
+ * Detection for the cluster-base JIT git credential helper.
+ *
+ * Wizard-mode (cloud) clusters authenticate git via `git-credential-generacy`
+ * (generacy-ai/generacy#766, wired by cluster-base's setup-credentials.sh):
+ * every git operation mints a fresh GitHub App installation token from the
+ * control-plane, so auth can never go stale. The only GitHub token present in
+ * the container environment is the activation-time `ghs_` installation token
+ * sourced from wizard-credentials.env — it expires one hour after activation.
+ *
+ * `setup auth` and `setup workspace` predate that helper: given a GH_TOKEN
+ * they configure `credential.helper store` / run `gh auth setup-git`, which
+ * REPLACES the JIT helper wiring with a static copy of the 1-hour token and
+ * breaks all git auth in the container an hour later
+ * (generacy-ai/cluster-base#66 saw the same clobber from VS Code).
+ *
+ * Both commands consult this gate and leave git/gh credential configuration
+ * alone when the JIT helper is active.
+ */
+import { execSafe } from '../../utils/exec.js';
+
+const JIT_HELPER_MARKER = 'git-credential-generacy';
+
+/**
+ * True when this container relies on the JIT git credential helper.
+ *
+ * Requires BOTH wizard bootstrap mode and the helper actually present in git
+ * config: on wizard clusters running a pre-JIT cluster-base image the helper
+ * was never configured, and skipping the legacy static setup there would
+ * leave the container with no git credentials at all.
+ */
+export function jitCredentialHelperActive(): boolean {
+  if (process.env['GENERACY_BOOTSTRAP_MODE'] !== 'wizard') {
+    return false;
+  }
+  const helpers = execSafe(
+    'git config --global --get-all credential.https://github.com.helper',
+  );
+  return helpers.ok && helpers.stdout.includes(JIT_HELPER_MARKER);
+}

--- a/packages/generacy/src/cli/commands/setup/workspace.ts
+++ b/packages/generacy/src/cli/commands/setup/workspace.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { getLogger } from '../../utils/logger.js';
 import { exec, execSafe } from '../../utils/exec.js';
+import { jitCredentialHelperActive } from './jit-credentials.js';
 import { tryLoadWorkspaceConfig, getRepoNames, parseRepoList, scanForWorkspaceConfig } from '@generacy-ai/config';
 
 /**
@@ -155,6 +156,17 @@ function detectPackageManager(repoPath: string): 'pnpm' | 'npm' {
  */
 function ensureGitCredentials(): void {
   const logger = getLogger();
+
+  // Wizard clusters already authenticate via the JIT credential helper.
+  // `gh auth setup-git` REPLACES the per-host helper list, so running it here
+  // would swap never-stale JIT auth for the 1-hour activation token that
+  // happens to satisfy `gh auth status`. See jit-credentials.ts.
+  if (jitCredentialHelperActive()) {
+    logger.info(
+      'JIT git credential helper active (wizard mode) — leaving git credential configuration untouched',
+    );
+    return;
+  }
 
   const ghAuth = execSafe('gh auth status');
   if (ghAuth.ok) {


### PR DESCRIPTION
## Problem

On wizard-mode (cloud) clusters, git auth in **worker containers dies exactly one hour after activation** (diagnosed live on the painworth ai-lawfirm cluster: every clone fails with `remote: Invalid username or token`).

cluster-base's `setup-credentials.sh` correctly wires the JIT credential helper (`git-credential-generacy`, #766) as the sole github.com helper — every git operation mints a fresh installation token via the git-token proxy (#768), so auth should never go stale. But the worker entrypoint then runs the generacy setup commands with the activation-time `GH_TOKEN` (a 1-hour `ghs_` installation token from `wizard-credentials.env`) exported into the environment, and:

1. `generacy setup auth` sees `GH_TOKEN` → writes `credential.helper store` + a static `~/.git-credentials`
2. `generacy setup workspace` → `ensureGitCredentials()` sees `gh auth status` pass (the JIT `gh` wrapper answers it) → runs `gh auth setup-git`, which **replaces** the per-host helper list, deleting the JIT helper entirely

The orchestrator self-heals via `git-helper-guard.sh` (cluster-base#66) but workers never launch the guard, so they keep the static wiring: everything works until the activation token hits its 1-hour expiry, then all git operations 401. Restarts fail immediately whenever `wizard-credentials.env` is older than an hour.

## Fix

Both commands now skip static git/gh credential configuration when a new shared gate, `jitCredentialHelperActive()`, is true:

- `GENERACY_BOOTSTRAP_MODE=wizard`, **and**
- `git-credential-generacy` is present in the global `credential.https://github.com.helper` list

The two-part gate keeps legacy static behavior on wizard clusters running pre-JIT cluster-base images (where skipping would leave the container with no git credentials at all) and in local-dev/devcontainer mode (where a long-lived PAT via `store` is intentional).

Git identity configuration (user.name/email) and the final `gh auth status` verification are unchanged.

## Testing

- 6 new unit tests covering: skip when wizard+JIT, legacy behavior when wizard without JIT, legacy behavior when JIT config present outside wizard mode (both commands)
- `pnpm vitest run src/__tests__/setup/{auth,workspace}.test.ts`: 66/66 pass; `pnpm build` clean
- Live-verified the failure mode and the JIT path end-to-end on the affected cluster (re-asserting the JIT helper in the running workers restored auth immediately)

Companion cluster-base PR adds defense in depth: run `git-helper-guard.sh` on workers and re-assert the JIT helper after the setup steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)