### PR TITLE
fix(orchestrator): review/remediate second-wave regressions from #1153

### DIFF
--- a/.changeset/review-remediate-second-wave.md
+++ b/.changeset/review-remediate-second-wave.md
@@ -1,0 +1,6 @@
+---
+"@generacy-ai/orchestrator": patch
+"@generacy-ai/workflow-engine": patch
+---
+
+Fix the second wave of review/remediate regressions found in the post-merge review of #1153: narrow the resume-strip retain set (clarification/sibling-review/ci answers are stripped again; only remediation-limit and, under the CI gate, implementation-review survive), trust actions-runs CI green and post an honest, deduped CI-pause comment, dedupe the remediation-limit comment against issue comments, clear the Redis remediation budget on completion and at the on-ci-green approval pause, mark validate-origin/body-only findings `synthetic` so the verification pass can resolve them, gate resolution-scoped reviews on scope consumption instead of "no prior artifact", preserve engine sidecars across `git clean` while never committing them (PrManager and the legacy feedback handler), expand untracked directories in `getStatus`, and reclassify fail-then-pass infra failures against real vitest/pnpm output with a per-package fallback.

--- a/packages/orchestrator/src/__tests__/pr-feedback-external-remediate.integration.test.ts
+++ b/packages/orchestrator/src/__tests__/pr-feedback-external-remediate.integration.test.ts
@@ -39,7 +39,7 @@ import type { WorkerContext, Logger, WorkflowPhase, PhaseResult } from '../worke
 import { getPhaseSequence } from '../worker/types.js';
 import type { WorkerConfig } from '../worker/config.js';
 import type { ReviewExecutor } from '../worker/review-executor.js';
-import type { FindingsArtifact } from '../worker/review-findings-artifact.js';
+import type { ReviewArtifact, Severity } from '../worker/review-artifact.js';
 import { SeedAwareReviewExecutor } from '../worker/seed-aware-review-executor.js';
 import { writeExternalFeedbackSeed } from '../worker/external-feedback-seed.js';
 import {
@@ -238,21 +238,13 @@ function makeCleanDelegate(checkoutPath: string): ReviewExecutor {
 
 function makeFindingsReader(
   checkoutPath: string,
-): (context: WorkerContext) => Promise<{ artifact: FindingsArtifact; round: number } | null> {
+): (context: WorkerContext) => Promise<{ artifact: ReviewArtifact; blockingSeverity: Severity } | null> {
   return async () => {
     const ra = readReviewArtifactSync(checkoutPath, WORKFLOW_ID);
     if (!ra) return null;
-    return {
-      artifact: {
-        verdict: ra.verdict,
-        findings: ra.findings.map((f, idx) => ({
-          marker: `finding-${idx}`,
-          text: f.title,
-          severity: 'blocking' as const,
-        })),
-      },
-      round: ra.round,
-    };
+    // Live seam shape (#1161): the canonical artifact (round lives in `ra.round`)
+    // plus the blocking severity used for the poster's render projection.
+    return { artifact: ra, blockingSeverity: 'critical' };
   };
 }
 

--- a/packages/orchestrator/src/__tests__/pr-feedback-handler-body-flow.test.ts
+++ b/packages/orchestrator/src/__tests__/pr-feedback-handler-body-flow.test.ts
@@ -47,6 +47,7 @@ const mockGitHub = {
   postPrComment: vi.fn(),
   getStatus: vi.fn(),
   stageAll: vi.fn(),
+  stageFiles: vi.fn(),
   commit: vi.fn(),
   push: vi.fn(),
   replyToPRComment: vi.fn(),
@@ -210,6 +211,7 @@ describe('PrFeedbackHandler body-flow (#1047)', () => {
       has_changes: true, staged: ['src/x.ts'], unstaged: [], untracked: [],
     });
     (mockGitHub.stageAll as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (mockGitHub.stageFiles as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     (mockGitHub.commit as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     (mockGitHub.push as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     (mockGitHub.replyToPRComment as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 1 });

--- a/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
+++ b/packages/orchestrator/src/__tests__/pr-feedback-integration.test.ts
@@ -55,6 +55,7 @@ const mockGitHub = {
   listOpenPullRequests: vi.fn(),
   getStatus: vi.fn(),
   stageAll: vi.fn(),
+  stageFiles: vi.fn(),
   commit: vi.fn(),
   push: vi.fn(),
   replyToPRComment: vi.fn(),
@@ -1847,6 +1848,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
       untracked: [],
     });
     mockGitHub.stageAll = vi.fn().mockResolvedValue(undefined);
+    mockGitHub.stageFiles = vi.fn().mockResolvedValue(undefined);
     mockGitHub.commit = vi.fn().mockResolvedValue(undefined);
     mockGitHub.push = vi.fn().mockResolvedValue(undefined);
     mockGitHub.replyToPRComment = vi.fn().mockResolvedValue(undefined);
@@ -1967,15 +1969,15 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     expect(prompt).toContain('Do NOT resolve any review threads');
 
     // Verify changes were staged, committed, and pushed
-    expect(mockGitHub.stageAll).toHaveBeenCalled();
+    expect(mockGitHub.stageFiles).toHaveBeenCalled();
     expect(mockGitHub.commit).toHaveBeenCalledWith(
-      expect.stringContaining('Address PR #100 review feedback'),
+      expect.stringContaining('Address PR #100 review feedback'), expect.any(Array),
     );
     expect(mockGitHub.commit).toHaveBeenCalledWith(
-      expect.stringContaining('issue #42'),
+      expect.stringContaining('issue #42'), expect.any(Array),
     );
     expect(mockGitHub.commit).toHaveBeenCalledWith(
-      expect.stringContaining('Co-Authored-By: Claude Sonnet 4.5'),
+      expect.stringContaining('Co-Authored-By: Claude Sonnet 4.5'), expect.any(Array),
     );
     expect(mockGitHub.push).toHaveBeenCalledWith('origin', '42-add-tests');
 
@@ -2302,7 +2304,7 @@ describe('PR Feedback Integration Test: Worker Processing', () => {
     await handler.handle(queueItem, '/tmp/workspace/test-org/test-repo');
 
     // Should not commit or push
-    expect(mockGitHub.stageAll).not.toHaveBeenCalled();
+    expect(mockGitHub.stageFiles).not.toHaveBeenCalled();
     expect(mockGitHub.commit).not.toHaveBeenCalled();
     expect(mockGitHub.push).not.toHaveBeenCalled();
 

--- a/packages/orchestrator/src/worker/__tests__/ci-merge-readiness.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/ci-merge-readiness.test.ts
@@ -51,22 +51,26 @@ describe('evaluateCiReadiness', () => {
     expect(readiness.source).toBe('check-runs');
   });
 
-  // #1157 FR-007 (Q5→C): the actions/runs fallback is blind to third-party
-  // required checks, so a would-be `green` aggregated from it is failed-closed
-  // to `not-passed`. See contracts/fr-007-fallback-guard.md.
-  it('actions-runs + would-be green → downgraded to not-passed (FR-007)', async () => {
+  // The actions/runs fallback is blind to third-party required checks, but a
+  // `green` read from it is TRUSTED (documented limitation, logged at warn).
+  // The #1157 FR-007 fail-closed downgrade made every validate on a token
+  // lacking `checks:read` pause with a "CI is red" reason while CI was green.
+  it('actions-runs + green → stays green and logs the blind-spot warning', async () => {
     const { github } = githubReturning([
       {
         runs: [{ status: 'completed', conclusion: 'success' }],
         source: 'actions-runs',
       },
     ]);
-    const readiness = await evaluateCiReadiness({ github, ...baseParams });
-    expect(readiness.verdict).toBe('not-passed');
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
+    const readiness = await evaluateCiReadiness({ github, ...baseParams, logger });
+    expect(readiness.verdict).toBe('green');
     expect(readiness.source).toBe('actions-runs');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(String(logger.warn.mock.calls[0][1])).toMatch(/third-party/i);
   });
 
-  it('check-runs + green → stays green (FR-007 guard does not fire)', async () => {
+  it('check-runs + green → stays green', async () => {
     const { github } = githubReturning([
       {
         runs: [{ status: 'completed', conclusion: 'success' }],
@@ -77,7 +81,7 @@ describe('evaluateCiReadiness', () => {
     expect(readiness.verdict).toBe('green');
   });
 
-  it('actions-runs + pending → unchanged (only green is downgraded)', async () => {
+  it('actions-runs + pending → unchanged', async () => {
     const { github } = githubReturning([
       { runs: [], source: 'actions-runs' },
     ]);
@@ -85,7 +89,7 @@ describe('evaluateCiReadiness', () => {
     expect(readiness.verdict).toBe('pending');
   });
 
-  it('actions-runs + not-passed → unchanged (already blocked)', async () => {
+  it('actions-runs + not-passed → unchanged', async () => {
     const { github } = githubReturning([
       {
         runs: [{ status: 'completed', conclusion: 'failure' }],
@@ -110,7 +114,7 @@ describe('waitForCiGreen', () => {
       sleep,
       now: () => 0,
     });
-    expect(outcome).toEqual({ kind: 'green' });
+    expect(outcome).toEqual({ kind: 'green', verdict: 'green', source: 'check-runs' });
     expect(calls()).toBe(1);
     expect(sleep).not.toHaveBeenCalled();
   });
@@ -126,7 +130,7 @@ describe('waitForCiGreen', () => {
       sleep: vi.fn(async () => {}),
       now: () => 0,
     });
-    expect(outcome).toEqual({ kind: 'not-passed' });
+    expect(outcome).toEqual({ kind: 'not-passed', verdict: 'not-passed', source: 'check-runs' });
   });
 
   it('pending → timeout after the wait window with bounded backoff (SC-005)', async () => {
@@ -145,7 +149,7 @@ describe('waitForCiGreen', () => {
       sleep,
       now: () => clock,
     });
-    expect(outcome).toEqual({ kind: 'timeout' });
+    expect(outcome).toEqual({ kind: 'timeout', verdict: 'pending', source: 'check-runs' });
     // Bounded, increasing backoff capped at 30s; last delay clamped to remaining.
     expect(slept[0]).toBe(5_000);
     expect(slept[1]).toBe(10_000);
@@ -172,7 +176,7 @@ describe('waitForCiGreen', () => {
       sleep,
       now: () => clock,
     });
-    expect(outcome).toEqual({ kind: 'green' });
+    expect(outcome).toEqual({ kind: 'green', verdict: 'green', source: 'check-runs' });
     expect(calls()).toBe(2);
     expect(sleep).toHaveBeenCalledTimes(1);
   });

--- a/packages/orchestrator/src/worker/__tests__/fail-then-pass.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/fail-then-pass.test.ts
@@ -17,7 +17,8 @@ interface ExecOutcome {
   stderr?: string;
   /** Simulate a timeout kill (execFile sets `killed`/`code: 'ETIMEDOUT'`). */
   killed?: boolean;
-  code?: string;
+  /** execFile sets `code` to the numeric exit code, or a string such as ETIMEDOUT. */
+  code?: string | number;
   /** Simulate an AbortError (execFile rejection when the signal aborts). */
   errName?: string;
 }
@@ -34,7 +35,7 @@ const execFileSpy = vi.fn((cmd: string, args: string[], _opts: unknown, cb: unkn
       stdout?: string;
       stderr?: string;
       killed?: boolean;
-      code?: string;
+      code?: string | number;
     };
     err.stdout = r.stdout ?? '';
     err.stderr = r.stderr ?? '';
@@ -53,15 +54,242 @@ vi.mock('node:child_process', () => ({
 const mkdirSpy = vi.fn(async () => undefined);
 const copyFileSpy = vi.fn(async () => undefined);
 const rmSpy = vi.fn(async () => undefined);
+// `stat` backs the no-root-vitest fallback's nearest-`package.json` walk. Tests
+// that exercise the fallback list the package.json paths that "exist".
+let existingPackageJsons: Set<string> = new Set();
+const statSpy = vi.fn(async (path: string) => {
+  if (existingPackageJsons.has(path)) return {};
+  const err = new Error('no such file') as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  throw err;
+});
 vi.mock('node:fs/promises', () => ({
   mkdtemp: vi.fn(async (prefix: string) => `${prefix}XXXX`),
-  mkdir: (...args: unknown[]) => (mkdirSpy as unknown as (...a: unknown[]) => Promise<void>)(...args),
+  mkdir: (...args: unknown[]) =>
+    (mkdirSpy as unknown as (...a: unknown[]) => Promise<void>)(...args),
   copyFile: (...args: unknown[]) =>
     (copyFileSpy as unknown as (...a: unknown[]) => Promise<void>)(...args),
   rm: (...args: unknown[]) => (rmSpy as unknown as (...a: unknown[]) => Promise<void>)(...args),
+  stat: (...args: unknown[]) =>
+    (statSpy as unknown as (...a: unknown[]) => Promise<unknown>)(...args),
 }));
 
-const { runFailThenPass } = await import('../fail-then-pass.js');
+const { runFailThenPass, isInfraFailure, isRunnerNotFound } = await import('../fail-then-pass.js');
+
+// ---------------------------------------------------------------------------
+// Realistic runner-output fixtures. Captured verbatim from `npx vitest run`
+// (vitest 3.2.4 / vite 7.3.1 / node 22) and `pnpm vitest run` (pnpm 9.15.9) in
+// a scratch workspace on 2026-08-22; only the absolute scratch path was
+// shortened to `/work/repo` and a vite internals path to `<vite>`. The
+// `broken.test.ts` fixture is a test importing a nonexistent `../dist/…` —
+// the shape every dist-resolving monorepo (generacy included) produces when
+// the base worktree has not been built.
+// ---------------------------------------------------------------------------
+
+/** Suite failed to LOAD (dist-resolution) — zero tests collected. Exit 1. */
+const VITEST_SUITE_LOAD_FAILURE = `
+ RUN  v3.2.4 /work/repo
+
+
+⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  broken.test.ts [ broken.test.ts ]
+Error: Cannot find module '../dist/nonexistent.js' imported from '/work/repo/broken.test.ts'
+ ❯ broken.test.ts:2:1
+      1| import { describe, it, expect } from 'vitest';
+      2| import { thing } from '../dist/nonexistent.js';
+       | ^
+      3| describe('broken', () => { it('x', () => { expect(thing).toBe(1); }); …
+      4| 
+
+Caused by: Error: Failed to load url ../dist/nonexistent.js (resolved id: ../dist/nonexistent.js) in /work/repo/broken.test.ts. Does the file exist?
+ ❯ loadAndTransform <vite>/dist/node/chunks/config.js:22663:33
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+
+ Test Files  1 failed (1)
+      Tests  no tests
+   Start at  04:10:44
+   Duration  559ms (transform 77ms, setup 0ms, collect 0ms, tests 0ms, environment 1ms, prepare 116ms)
+`;
+
+/** A collected test genuinely failed (assertion). Exit 1. */
+const VITEST_GENUINE_FAILURE = `
+ RUN  v3.2.4 /work/repo
+
+ ❯ real-fail.test.ts (2 tests | 1 failed) 10ms
+   × real > fails 8ms
+     → expected 1 to be 2 // Object.is equality
+   ✓ real > passes 0ms
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  real-fail.test.ts > real > fails
+AssertionError: expected 1 to be 2 // Object.is equality
+
+- Expected
++ Received
+
+- 2
++ 1
+
+ ❯ real-fail.test.ts:2:56
+      1| import { describe, it, expect } from 'vitest';
+      2| describe('real', () => { it('fails', () => { expect(1).toBe(2); }); it…
+       |                                                        ^
+      3| 
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+
+ Test Files  1 failed (1)
+      Tests  1 failed | 1 passed (2)
+   Start at  04:10:45
+   Duration  467ms (transform 47ms, setup 0ms, collect 36ms, tests 10ms, environment 0ms, prepare 89ms)
+`;
+
+/** One suite failed to load AND one collected test genuinely failed. Exit 1. */
+const VITEST_MIXED_FAILURE = `
+ RUN  v3.2.4 /work/repo
+
+ ❯ real-fail.test.ts (2 tests | 1 failed) 10ms
+   × real > fails 8ms
+     → expected 1 to be 2 // Object.is equality
+   ✓ real > passes 0ms
+
+⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  broken.test.ts [ broken.test.ts ]
+Error: Cannot find module '../dist/nonexistent.js' imported from '/work/repo/broken.test.ts'
+ ❯ broken.test.ts:2:1
+
+Caused by: Error: Failed to load url ../dist/nonexistent.js (resolved id: ../dist/nonexistent.js) in /work/repo/broken.test.ts. Does the file exist?
+ ❯ loadAndTransform <vite>/dist/node/chunks/config.js:22663:33
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
+
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  real-fail.test.ts > real > fails
+AssertionError: expected 1 to be 2 // Object.is equality
+
+ ❯ real-fail.test.ts:2:56
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
+
+
+ Test Files  2 failed (2)
+      Tests  1 failed | 1 passed (2)
+   Start at  04:10:47
+   Duration  472ms (transform 66ms, setup 0ms, collect 27ms, tests 10ms, environment 0ms, prepare 190ms)
+`;
+
+/** vitest resolved no files for the filter. Exit 1. */
+const VITEST_NO_TEST_FILES = `
+ RUN  v3.2.4 /work/repo
+
+No test files found, exiting with code 1
+
+filter: nope.test.ts
+include: **/*.{test,spec}.?(c|m)[jt]s?(x)
+exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*
+`;
+
+/** All tests passed. Exit 0. */
+const VITEST_PASS = `
+ RUN  v3.2.4 /work/repo
+
+ ✓ pass.test.ts (1 test) 2ms
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Start at  04:10:48
+   Duration  443ms (transform 44ms, setup 0ms, collect 34ms, tests 2ms, environment 0ms, prepare 74ms)
+`;
+
+/**
+ * Root `pnpm vitest run` in a workspace where vitest is only a package
+ * devDependency (pnpm 9.15.9). Exit 254. `undefined` is pnpm's own stray line.
+ */
+const PNPM_VITEST_NOT_FOUND = `undefined
+ ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found`;
+const PNPM_VITEST_NOT_FOUND_EXIT = 254;
+
+/**
+ * `pnpm --filter <pkg> exec vitest run` wrapping a GENUINE failure (pnpm
+ * 9.15.9): the same ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL code, exit 1. This is why
+ * that code alone must not be a not-found signature.
+ */
+const PNPM_FILTER_EXEC_GENUINE_FAILURE = `
+ Test Files  1 failed (1)
+      Tests  1 failed (1)
+   Start at  04:11:51
+   Duration  469ms (transform 67ms, setup 0ms, collect 54ms, tests 9ms, environment 0ms, prepare 115ms)
+
+undefined
+/work/repo/packages/a:
+ ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command failed with exit code 1: vitest run x.test.ts`;
+
+describe('isInfraFailure / isRunnerNotFound classification (realistic vitest 3.2.4 + pnpm 9.15 output)', () => {
+  it('suite-level load failure (Cannot find module + FAIL [file] + "Tests no tests") → infra, despite "Test Files 1 failed"', () => {
+    expect(/Test Files\s+1 failed/.test(VITEST_SUITE_LOAD_FAILURE)).toBe(true);
+    expect(/\bFAIL\b/.test(VITEST_SUITE_LOAD_FAILURE)).toBe(true);
+    expect(isInfraFailure(VITEST_SUITE_LOAD_FAILURE, 1)).toBe(true);
+  });
+
+  it('genuine assertion failure (× line, FAIL file > name, "Tests 1 failed") → NOT infra', () => {
+    expect(isInfraFailure(VITEST_GENUINE_FAILURE, 1)).toBe(false);
+  });
+
+  it('broken suite + a genuine test failure in the same run → NOT infra (a real failure is never masked)', () => {
+    expect(isInfraFailure(VITEST_MIXED_FAILURE, 1)).toBe(false);
+  });
+
+  it('"No test files found" → infra', () => {
+    expect(isInfraFailure(VITEST_NO_TEST_FILES, 1)).toBe(true);
+  });
+
+  it('all-pass output → NOT infra', () => {
+    expect(isInfraFailure(VITEST_PASS)).toBe(false);
+    expect(isInfraFailure(VITEST_PASS, 0)).toBe(false);
+  });
+
+  it('pnpm `Command "vitest" not found` (exit 254) → infra / runner-not-found', () => {
+    expect(isRunnerNotFound(PNPM_VITEST_NOT_FOUND, PNPM_VITEST_NOT_FOUND_EXIT)).toBe(true);
+    expect(isInfraFailure(PNPM_VITEST_NOT_FOUND, PNPM_VITEST_NOT_FOUND_EXIT)).toBe(true);
+    // The text alone is enough (no exit code available).
+    expect(isInfraFailure(PNPM_VITEST_NOT_FOUND)).toBe(true);
+  });
+
+  it('exit 127 / "command not found" (no pnpm at all) → infra / runner-not-found', () => {
+    expect(isRunnerNotFound('/bin/sh: 1: pnpm: command not found', 127)).toBe(true);
+    expect(isRunnerNotFound('', 127)).toBe(true);
+    expect(isRunnerNotFound('', 254)).toBe(true);
+  });
+
+  it('pnpm "No projects matched the filters" (exit 0 no-op) → infra / runner-not-found', () => {
+    expect(isRunnerNotFound('No projects matched the filters in "/work/repo"', 0)).toBe(true);
+    expect(isInfraFailure('No projects matched the filters in "/work/repo"', 0)).toBe(true);
+  });
+
+  it('ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL wrapping a genuine failure → NOT infra', () => {
+    expect(isRunnerNotFound(PNPM_FILTER_EXEC_GENUINE_FAILURE, 1)).toBe(false);
+    expect(isInfraFailure(PNPM_FILTER_EXEC_GENUINE_FAILURE, 1)).toBe(false);
+  });
+
+  it('bare module-resolution error with no run evidence → infra (legacy fixture)', () => {
+    expect(isInfraFailure('Error: Cannot find module @generacy-ai/foo/dist/index.js')).toBe(true);
+    expect(isInfraFailure('Error [ERR_MODULE_NOT_FOUND]: Cannot find package')).toBe(true);
+  });
+
+  it('ambiguous non-zero output with no signature → NOT infra (bias to a genuine outcome)', () => {
+    expect(isInfraFailure('base red', 1)).toBe(false);
+    expect(isInfraFailure('FAIL x.test.ts', 1)).toBe(false);
+    expect(isInfraFailure('', 1)).toBe(false);
+  });
+});
 
 const BASE_REF = 'origin/develop';
 const CHECKOUT = '/tmp/checkout';
@@ -91,6 +319,8 @@ describe('runFailThenPass (#1134 T009 / #1150)', () => {
     // Restore the default no-op copy; tests that simulate a missing source
     // override this and must not leak the override into later tests.
     copyFileSpy.mockImplementation(async () => undefined);
+    statSpy.mockClear();
+    existingPackageJsons = new Set();
     handler = () => ({ ok: true });
   });
 
@@ -388,8 +618,10 @@ describe('runFailThenPass (#1134 T009 / #1150)', () => {
       if (isWorktreeRemove(cmd, args)) return { ok: true };
       if (isPnpmInstall(cmd, args)) return { ok: true };
       if (isVitest(cmd, args)) {
-        // Module resolution error before any test collected — an infra failure.
-        return { ok: false, stderr: 'Error: Cannot find module @generacy-ai/foo/dist/index.js' };
+        // Real vitest 3 output for a suite that failed to LOAD (unbuilt dist):
+        // prints ` FAIL  file [ file ]` AND `Test Files  1 failed` yet collected
+        // zero tests — must be infra, never a satisfied fail-on-base.
+        return { ok: false, stdout: VITEST_SUITE_LOAD_FAILURE, code: 1 };
       }
       return { ok: true };
     };
@@ -552,5 +784,270 @@ describe('runFailThenPass (#1134 T009 / #1150)', () => {
       true,
     );
     expect(rmSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Defect 1 — suite-level dist-resolution failures in a dist-resolving
+  // monorepo were read as genuine base failures; defect 2 — no-root-vitest
+  // repos produced a false `branch-failed`. Realistic fixtures throughout.
+  // -------------------------------------------------------------------------
+
+  it('suite-load failure at base + genuine pass on branch → skip (the base never exercised a test)', async () => {
+    let vitestCalls = 0;
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args)) {
+        vitestCalls += 1;
+        return vitestCalls === 1
+          ? { ok: false, stdout: VITEST_SUITE_LOAD_FAILURE, code: 1 }
+          : { ok: true, stdout: VITEST_PASS };
+      }
+      return { ok: true };
+    };
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: ['packages/a/src/x.test.ts'],
+      signal: new AbortController().signal,
+    });
+
+    // Previously this degenerated to "does the branch pass" → `pass`.
+    expect(result).toEqual({
+      kind: 'skip',
+      reason: 'infra:cannot-find-module at base ref',
+    });
+    expect(vitestCalls).toBe(1);
+  });
+
+  it('genuine assertion failure at base (realistic output) + pass on branch → pass', async () => {
+    let vitestCalls = 0;
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args)) {
+        vitestCalls += 1;
+        return vitestCalls === 1
+          ? { ok: false, stdout: VITEST_GENUINE_FAILURE, code: 1 }
+          : { ok: true, stdout: VITEST_PASS };
+      }
+      return { ok: true };
+    };
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: ['packages/a/src/x.test.ts'],
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual({ kind: 'pass' });
+    expect(vitestCalls).toBe(2);
+  });
+
+  it('mixed (broken suite + genuine failure) at base, suite-load failure on branch → branch skip, not pass', async () => {
+    let vitestCalls = 0;
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args)) {
+        vitestCalls += 1;
+        return vitestCalls === 1
+          ? { ok: false, stdout: VITEST_MIXED_FAILURE, code: 1 }
+          : { ok: false, stdout: VITEST_SUITE_LOAD_FAILURE, code: 1 };
+      }
+      return { ok: true };
+    };
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: ['packages/a/src/x.test.ts'],
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual({
+      kind: 'skip',
+      reason: 'infra:cannot-find-module on branch',
+    });
+  });
+
+  it('base exits 0 but collected zero tests ("No test files found" / passWithNoTests) → skip, never base-passed', async () => {
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args)) return { ok: true, stdout: VITEST_NO_TEST_FILES };
+      return { ok: true };
+    };
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: ['packages/a/src/x.test.ts'],
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual({
+      kind: 'skip',
+      reason: 'infra:no-test-files at base ref',
+    });
+  });
+
+  it('no root vitest anywhere (root + branch both `Command "vitest" not found`, no owning package) → skip vitest-not-found, NOT branch-failed', async () => {
+    // No package.json is reachable for the changed file, so no fallback run.
+    let vitestCalls = 0;
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args)) {
+        vitestCalls += 1;
+        return {
+          ok: false,
+          stderr: PNPM_VITEST_NOT_FOUND,
+          code: PNPM_VITEST_NOT_FOUND_EXIT,
+        };
+      }
+      return { ok: true };
+    };
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: ['packages/a/src/x.test.ts'],
+      signal: new AbortController().signal,
+    });
+
+    // Previously: base "fails", branch "fails" → { kind: 'fail', reason: 'branch-failed' }.
+    expect(result).toEqual({
+      kind: 'skip',
+      reason: 'infra:vitest-not-found at base ref',
+    });
+    // Short-circuited at the base side: only the base root run happened.
+    expect(vitestCalls).toBe(1);
+    expect(execFileSpy.mock.calls.some(([, a]) => (a as string[])[0] === '--dir')).toBe(false);
+  });
+
+  it('no root vitest → falls back to `pnpm --dir <owning pkg> exec vitest run <pkg-relative files>` on both refs', async () => {
+    const worktree = '/tmp/gen-ftp-XXXX/wt';
+    existingPackageJsons = new Set([
+      `${worktree}/packages/a/package.json`,
+      `${CHECKOUT}/packages/a/package.json`,
+      `${worktree}/packages/b/package.json`,
+      `${CHECKOUT}/packages/b/package.json`,
+    ]);
+    const spawns: Array<{ args: string[]; cwd: string }> = [];
+    let dirCalls = 0;
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args)) {
+        return {
+          ok: false,
+          stderr: PNPM_VITEST_NOT_FOUND,
+          code: PNPM_VITEST_NOT_FOUND_EXIT,
+        };
+      }
+      if (cmd === 'pnpm' && args[0] === '--dir') {
+        dirCalls += 1;
+        // base: both packages fail genuinely; branch: both pass.
+        return dirCalls <= 2
+          ? { ok: false, stdout: VITEST_GENUINE_FAILURE, code: 1 }
+          : { ok: true, stdout: VITEST_PASS };
+      }
+      return { ok: true };
+    };
+    execFileSpy.mockImplementation((cmd: string, args: string[], opts: unknown, cb: unknown) => {
+      if (cmd === 'pnpm') spawns.push({ args, cwd: (opts as { cwd: string }).cwd });
+      const callback = cb as (err: unknown, res?: { stdout: string; stderr: string }) => void;
+      const r = handler(cmd, args);
+      if (r.ok) {
+        callback(null, { stdout: r.stdout ?? '', stderr: r.stderr ?? '' });
+      } else {
+        const err = new Error('command failed') as Error & {
+          stdout?: string;
+          stderr?: string;
+          code?: string | number;
+        };
+        err.stdout = r.stdout ?? '';
+        err.stderr = r.stderr ?? '';
+        err.code = r.code;
+        callback(err);
+      }
+    });
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: [
+        'packages/a/src/x.test.ts',
+        'packages/a/src/__tests__/y.test.ts',
+        'packages/b/test/z.test.ts',
+      ],
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual({ kind: 'pass' });
+    const fallback = spawns.filter((s) => s.args[0] === '--dir');
+    expect(fallback.map((s) => s.args)).toEqual([
+      ['--dir', 'packages/a', 'exec', 'vitest', 'run', 'src/x.test.ts', 'src/__tests__/y.test.ts'],
+      ['--dir', 'packages/b', 'exec', 'vitest', 'run', 'test/z.test.ts'],
+      ['--dir', 'packages/a', 'exec', 'vitest', 'run', 'src/x.test.ts', 'src/__tests__/y.test.ts'],
+      ['--dir', 'packages/b', 'exec', 'vitest', 'run', 'test/z.test.ts'],
+    ]);
+    // Fallback runs are spawned from the same root as the failed root run
+    // (base worktree first, then the branch checkout).
+    expect(fallback.map((s) => s.cwd)).toEqual([worktree, worktree, CHECKOUT, CHECKOUT]);
+    // `--filter` is never used (exit-0 "No projects matched" trap).
+    expect(spawns.some((s) => s.args.includes('--filter'))).toBe(false);
+  });
+
+  it('no root vitest and the owning package has no vitest either → skip vitest-not-found', async () => {
+    const worktree = '/tmp/gen-ftp-XXXX/wt';
+    existingPackageJsons = new Set([`${worktree}/packages/a/package.json`]);
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args) || (cmd === 'pnpm' && args[0] === '--dir')) {
+        return {
+          ok: false,
+          stderr: PNPM_VITEST_NOT_FOUND,
+          code: PNPM_VITEST_NOT_FOUND_EXIT,
+        };
+      }
+      return { ok: true };
+    };
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: ['packages/a/src/x.test.ts'],
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual({
+      kind: 'skip',
+      reason: 'infra:vitest-not-found at base ref',
+    });
+  });
+
+  it('fallback genuine failure on the branch (ERR_PNPM wrapper, exit 1) is still branch-failed, not infra', async () => {
+    const worktree = '/tmp/gen-ftp-XXXX/wt';
+    existingPackageJsons = new Set([
+      `${worktree}/packages/a/package.json`,
+      `${CHECKOUT}/packages/a/package.json`,
+    ]);
+    handler = (cmd, args) => {
+      if (isVitest(cmd, args)) {
+        return {
+          ok: false,
+          stderr: PNPM_VITEST_NOT_FOUND,
+          code: PNPM_VITEST_NOT_FOUND_EXIT,
+        };
+      }
+      if (cmd === 'pnpm' && args[0] === '--dir') {
+        return { ok: false, stdout: PNPM_FILTER_EXEC_GENUINE_FAILURE, code: 1 };
+      }
+      return { ok: true };
+    };
+
+    const result = await runFailThenPass({
+      checkoutPath: CHECKOUT,
+      baseRef: BASE_REF,
+      changedTestFiles: ['packages/a/src/x.test.ts'],
+      signal: new AbortController().signal,
+    });
+
+    expect(result.kind).toBe('fail');
+    if (result.kind === 'fail') {
+      expect(result.reason).toBe('branch-failed');
+      expect(result.evidence).toContain('pnpm --dir packages/a exec vitest run src/x.test.ts');
+    }
   });
 });

--- a/packages/orchestrator/src/worker/__tests__/helpers/bugfix-harness.ts
+++ b/packages/orchestrator/src/worker/__tests__/helpers/bugfix-harness.ts
@@ -35,7 +35,7 @@ import type { PhaseLoopDeps } from '../../phase-loop.js';
 import type { WorkerContext, Logger, PhaseResult, WorkflowPhase } from '../../types.js';
 import { DEFAULT_VALIDATE_COMMAND, type WorkerConfig } from '../../config.js';
 import { ReviewPoster } from '../../review-poster.js';
-import type { FindingsArtifact, ReviewVerdict } from '../../review-findings-artifact.js';
+import { deriveFindingId, type ReviewArtifact, type ReviewFinding, type Verdict } from '../../review-artifact.js';
 import type { CiRun } from '@generacy-ai/workflow-engine';
 import type { GitHubClient, CreateReviewInput, Review } from '@generacy-ai/workflow-engine';
 import type { OrchestratorSettings } from '@generacy-ai/config';
@@ -62,7 +62,7 @@ export {
   fullWorkspaceCount,
 } from './bugfix-fixture-graph.js';
 export type { FixtureGraph, PhaseLoopDeps, WorkerContext, WorkerConfig, WorkflowPhase };
-export type { FindingsArtifact, ReviewVerdict, CiRun, CreateReviewInput, Review, GitHubClient };
+export type { ReviewArtifact, ReviewFinding, Verdict, CiRun, CreateReviewInput, Review, GitHubClient };
 
 export const mockLogger = {
   info: () => {},
@@ -382,7 +382,7 @@ export interface BugfixDepsOptions {
    * Verdict returned by `readFindingsArtifact` keyed by review round. Round 1
    * defaults to `clean`; supply a per-round map to steer remediate cycles.
    */
-  verdictByRound?: (round: number) => FindingsArtifact;
+  verdictByRound?: (round: number) => ReviewArtifact;
   /** Explicit gate list for `gateChecker.checkGates`. Defaults to `[]`. */
   gates?: ReturnType<typeof onCiGreenGate>;
   /** Ledger the validate stub records the branch-side effective command into. */
@@ -416,14 +416,18 @@ export function createBugfixDeps(options: BugfixDepsOptions = {}): BugfixDeps {
   );
 
   // Round-steered verdict for the review phase (US1 clean happy path by default).
-  let lastVerdict: ReviewVerdict | null = null;
+  let lastVerdict: Verdict | null = null;
   let callRound = 0;
   const verdictByRound =
     options.verdictByRound ??
-    ((): FindingsArtifact => ({
-      verdict: 'clean',
-      findings: [{ marker: 'f-adv-1', text: 'nit', severity: 'advisory' }],
-    }));
+    ((round: number): ReviewArtifact =>
+      makeReviewArtifact({
+        verdict: 'clean',
+        // Advisory-only: a `minor` finding is below the bugfix `critical` blocking
+        // severity, so it renders as non-blocking.
+        findings: [makeFinding({ severity: 'minor', file: 'src/nit.ts', title: 'nit', round })],
+        round,
+      }));
 
   const deps: BugfixDeps = {
     validateCommands,
@@ -478,9 +482,12 @@ export function createBugfixDeps(options: BugfixDepsOptions = {}): BugfixDeps {
     }),
     readFindingsArtifact: vi.fn(async (_ctx: WorkerContext) => {
       callRound += 1;
-      const artifact = verdictByRound(callRound);
+      // Live seam shape (#1161): `round` lives only in `artifact.round` (pinned
+      // to the call count so per-round steering stays monotonic), paired with
+      // the blocking severity — `critical`, matching `bugfixSettings()`.
+      const artifact = { ...verdictByRound(callRound), round: callRound };
       lastVerdict = artifact.verdict;
-      return { artifact, round: callRound };
+      return { artifact, blockingSeverity: 'critical' as const };
     }),
     remediateTrigger: () => lastVerdict === 'changes-required',
   };
@@ -600,19 +607,51 @@ export function fireOnceTrigger(): () => boolean {
   };
 }
 
-/** Findings artifact with a round-1 blocking "missing regression test" finding. */
-export function missingRegressionTestArtifact(round: number): FindingsArtifact {
+/**
+ * Build a canonical `ReviewFinding` (#1161 shape) from the fields a scenario
+ * cares about; `id` is derived exactly as the engine derives it.
+ */
+export function makeFinding(
+  f: Pick<ReviewFinding, 'severity' | 'file' | 'title'> & Partial<ReviewFinding>,
+): ReviewFinding {
+  return {
+    id: deriveFindingId(f.file, f.title),
+    detail: f.title,
+    round: 1,
+    status: 'open',
+    ...f,
+  };
+}
+
+/** Build a canonical `ReviewArtifact` (#1161 shape) with sane defaults. */
+export function makeReviewArtifact(
+  a: Pick<ReviewArtifact, 'verdict'> & Partial<ReviewArtifact>,
+): ReviewArtifact {
+  return {
+    findings: [],
+    round: 1,
+    lastReviewedCommitSha: 'deadbeef',
+    remediationCount: 0,
+    markedReadyByEngine: false,
+    ...a,
+  };
+}
+
+/** Review artifact with a round-1 blocking "missing regression test" finding. */
+export function missingRegressionTestArtifact(round: number): ReviewArtifact {
   if (round === 1) {
-    return {
+    return makeReviewArtifact({
       verdict: 'changes-required',
       findings: [
-        {
-          marker: 'f-block-1',
-          text: 'Missing regression test that fails without the fix',
-          severity: 'blocking',
-        },
+        makeFinding({
+          severity: 'critical',
+          file: 'packages/core/src/x.ts',
+          title: 'Missing regression test that fails without the fix',
+          round,
+        }),
       ],
-    };
+      round,
+    });
   }
-  return { verdict: 'clean', findings: [] };
+  return makeReviewArtifact({ verdict: 'clean', findings: [], round });
 }

--- a/packages/orchestrator/src/worker/__tests__/label-manager.onresumestart.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/label-manager.onresumestart.test.ts
@@ -1,20 +1,31 @@
 /**
- * #1154 SC-003 (contracts/onresumestart-strip.md): `LabelManager.onResumeStart()`
- * must retain every `completed:<X>` where X is a human-gate suffix while still
- * removing stale `waiting-for:*` and `agent:paused` labels. Non-gate
- * `completed:<phase>` labels are unaffected.
+ * `LabelManager.onResumeStart()` resume-strip retain rule.
+ *
+ * The strip removes stale `waiting-for:*` + `agent:paused` and the paired
+ * `completed:<X>` for every `waiting-for:<X>` present, EXCEPT the explicit
+ * retain set the worker passes (`resolveResumeRetainSuffixes(config)`):
+ *   - `remediation-limit` — always (consumed + removed by the phase-loop reset
+ *     branch).
+ *   - `implementation-review` — ONLY when `ciMergeGateEnabled` (the relocated
+ *     gate's terminal no-op resume reads it).
+ * Everything else — `ci`, `clarification`, `sibling-review`, the artifact
+ * review gates — is stripped so the resumed phase can pause again (clarify
+ * follow-ups; a validate re-pause must not leave a stale `completed:ci`).
  *
  * These assertions drive the real `onResumeStart()` (not a hand-injected label
- * set), so they exercise the FR-001 guard directly.
+ * set).
  */
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { LabelManager, isHumanGateCompletion } from '../label-manager.js';
+import {
+  LabelManager,
+  DEFAULT_RESUME_RETAIN_SUFFIXES,
+  resolveResumeRetainSuffixes,
+} from '../label-manager.js';
 import type { GitHubClient } from '@generacy-ai/workflow-engine';
 import type { Logger } from '../types.js';
 
-// Representative human-gate suffixes covering GATE_MAPPING, the on-ci-green gate
-// (#1133 / #1154 FR-004), and the supplemental static set.
-const HUMAN_GATE_SUFFIXES = [
+// Every human-gate suffix the strip may encounter paired with a waiting-for.
+const ALL_GATE_SUFFIXES = [
   'clarification',
   'spec-review',
   'clarification-review',
@@ -54,7 +65,40 @@ function createLabelManager(): LabelManager {
   );
 }
 
-describe('LabelManager.onResumeStart — #1154 human-gate retention (SC-003)', () => {
+function pairedLabels(): { name: string }[] {
+  return [
+    { name: 'agent:paused' },
+    { name: 'workflow:speckit-feature' },
+    { name: 'completed:specify' }, // non-gate phase completion, no waiting-for
+    ...ALL_GATE_SUFFIXES.flatMap((s) => [
+      { name: `waiting-for:${s}` },
+      { name: `completed:${s}` },
+    ]),
+  ];
+}
+
+function removedLabels(): string[] {
+  return (mockGithub.removeLabels.mock.calls[0]?.[3] as string[]) ?? [];
+}
+
+describe('resolveResumeRetainSuffixes', () => {
+  it('retains only remediation-limit by default', () => {
+    expect(DEFAULT_RESUME_RETAIN_SUFFIXES).toEqual(['remediation-limit']);
+    expect(resolveResumeRetainSuffixes({})).toEqual(['remediation-limit']);
+    expect(resolveResumeRetainSuffixes({ ciMergeGateEnabled: false })).toEqual([
+      'remediation-limit',
+    ]);
+  });
+
+  it('adds implementation-review only when ciMergeGateEnabled', () => {
+    expect(resolveResumeRetainSuffixes({ ciMergeGateEnabled: true })).toEqual([
+      'remediation-limit',
+      'implementation-review',
+    ]);
+  });
+});
+
+describe('LabelManager.onResumeStart — explicit retain set', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mockGithub.getIssue.mockReset();
@@ -72,64 +116,86 @@ describe('LabelManager.onResumeStart — #1154 human-gate retention (SC-003)', (
     mockGithub.createLabel.mockResolvedValue(undefined);
   });
 
-  it('every listed suffix is genuinely a human-gate completion', () => {
-    for (const suffix of HUMAN_GATE_SUFFIXES) {
-      expect(isHumanGateCompletion(`completed:${suffix}`)).toBe(true);
-    }
-  });
+  it('default (no options): strips every paired completed:<X> except remediation-limit', async () => {
+    mockGithub.getIssue.mockResolvedValue({ labels: pairedLabels() });
 
-  it('retains every human-gate completed:<X> while removing waiting-for:* and agent:paused', async () => {
-    const labels = [
-      { name: 'agent:paused' },
-      { name: 'workflow:speckit-feature' },
-      { name: 'completed:specify' }, // non-gate phase completion, no waiting-for
-      ...HUMAN_GATE_SUFFIXES.flatMap((s) => [
-        { name: `waiting-for:${s}` },
-        { name: `completed:${s}` },
-      ]),
-    ];
-    mockGithub.getIssue.mockResolvedValue({ labels });
+    await createLabelManager().onResumeStart();
 
-    await lmResume();
-
-    const removed = mockGithub.removeLabels.mock.calls[0]?.[3] as string[];
-    // agent:paused + every waiting-for:<X> is removed …
+    const removed = removedLabels();
     expect(removed).toContain('agent:paused');
-    for (const s of HUMAN_GATE_SUFFIXES) {
+    for (const s of ALL_GATE_SUFFIXES) {
       expect(removed).toContain(`waiting-for:${s}`);
+      if (s === 'remediation-limit') {
+        expect(removed).not.toContain(`completed:${s}`);
+      } else {
+        expect(removed).toContain(`completed:${s}`);
+      }
     }
-    // … but NO completed:<X> for any human gate is removed.
-    for (const s of HUMAN_GATE_SUFFIXES) {
-      expect(removed).not.toContain(`completed:${s}`);
-    }
-    // … and the non-gate phase completion is untouched.
+    // Non-gate phase completion with no waiting-for is untouched.
     expect(removed).not.toContain('completed:specify');
-
     expect(mockGithub.addLabels).toHaveBeenCalledWith('owner', 'repo', 42, ['agent:in-progress']);
   });
 
-  it('non-gate completed:<phase> with a co-present waiting-for:<phase> is still stripped', async () => {
-    // A hypothetical non-gate suffix (a phase name) is NOT a human gate, so the
-    // strip still removes it — proving the guard is scoped to gate suffixes only.
+  it('ciMergeGateEnabled retain set: implementation-review also survives; ci/clarification/sibling-review still stripped', async () => {
+    mockGithub.getIssue.mockResolvedValue({ labels: pairedLabels() });
+
+    await createLabelManager().onResumeStart({
+      retainCompletedSuffixes: resolveResumeRetainSuffixes({ ciMergeGateEnabled: true }),
+    });
+
+    const removed = removedLabels();
+    expect(removed).not.toContain('completed:remediation-limit');
+    expect(removed).not.toContain('completed:implementation-review');
+    expect(removed).toContain('completed:ci');
+    expect(removed).toContain('completed:clarification');
+    expect(removed).toContain('completed:sibling-review');
+    expect(removed).toContain('waiting-for:implementation-review');
+    expect(removed).toContain('agent:paused');
+  });
+
+  it('flag OFF retain set: implementation-review is stripped', async () => {
     mockGithub.getIssue.mockResolvedValue({
       labels: [
-        { name: 'waiting-for:implement' },
-        { name: 'completed:implement' },
+        { name: 'waiting-for:implementation-review' },
+        { name: 'completed:implementation-review' },
         { name: 'agent:paused' },
       ],
     });
 
-    await lmResume();
+    await createLabelManager().onResumeStart({
+      retainCompletedSuffixes: resolveResumeRetainSuffixes({ ciMergeGateEnabled: false }),
+    });
 
-    expect(isHumanGateCompletion('completed:implement')).toBe(false);
-    const removed = mockGithub.removeLabels.mock.calls[0]?.[3] as string[];
-    expect(removed).toContain('completed:implement');
-    expect(removed).toContain('waiting-for:implement');
-    expect(removed).toContain('agent:paused');
+    expect(removedLabels()).toEqual([
+      'waiting-for:implementation-review',
+      'agent:paused',
+      'completed:implementation-review',
+    ]);
+  });
+
+  it('a waiting-for:ci answered with completed:ci is fully cleared so a validate re-pause cannot pair a stale completed:ci', async () => {
+    mockGithub.getIssue.mockResolvedValue({
+      labels: [
+        { name: 'waiting-for:ci' },
+        { name: 'completed:ci' },
+        { name: 'agent:paused' },
+      ],
+    });
+
+    await createLabelManager().onResumeStart({
+      retainCompletedSuffixes: resolveResumeRetainSuffixes({ ciMergeGateEnabled: true }),
+    });
+
+    expect(removedLabels()).toEqual(['waiting-for:ci', 'agent:paused', 'completed:ci']);
+  });
+
+  it('retained completed:<X> without a paired waiting-for is left alone (no-op)', async () => {
+    mockGithub.getIssue.mockResolvedValue({
+      labels: [{ name: 'completed:remediation-limit' }, { name: 'agent:paused' }],
+    });
+
+    await createLabelManager().onResumeStart();
+
+    expect(removedLabels()).toEqual(['agent:paused']);
   });
 });
-
-async function lmResume(): Promise<void> {
-  const lm = createLabelManager();
-  await lm.onResumeStart();
-}

--- a/packages/orchestrator/src/worker/__tests__/label-manager.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/label-manager.test.ts
@@ -218,7 +218,7 @@ describe('LabelManager', () => {
   });
 
   describe('onResumeStart', () => {
-    it('removes waiting-for:* and agent:paused but retains human-gate completed:* (#1154 FR-001)', async () => {
+    it('removes waiting-for:*, agent:paused, and the paired completed:clarification so follow-up questions can pause again', async () => {
       const lm = createLabelManager();
       mockGithub.getIssue.mockResolvedValue({
         labels: [
@@ -233,12 +233,15 @@ describe('LabelManager', () => {
       await lm.onResumeStart();
 
       expect(mockGithub.getIssue).toHaveBeenCalledWith('owner', 'repo', 42);
-      // #1154 FR-001: `clarification` is a human-gate suffix, so
-      // `completed:clarification` MUST survive the resume strip. Only the stale
-      // `waiting-for:*` and `agent:paused` labels are removed.
+      // `completed:clarification` is NOT in the resume retain set: a resumed
+      // `clarify` that asks follow-up questions must be able to pause again, so
+      // the paired completion is stripped alongside the stale pause labels.
+      // (The #1154 blanket human-gate exemption let it survive and the
+      // "already satisfied" check skipped the follow-up pause.)
       expect(mockGithub.removeLabels).toHaveBeenCalledWith('owner', 'repo', 42, [
         'waiting-for:clarification',
         'agent:paused',
+        'completed:clarification',
       ]);
       expect(mockGithub.addLabels).toHaveBeenCalledWith('owner', 'repo', 42, ['agent:in-progress']);
     });

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.ci-merge-gate.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.ci-merge-gate.test.ts
@@ -15,7 +15,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { PhaseLoop } from '../phase-loop.js';
+import { PhaseLoop, CI_PAUSE_MARKER } from '../phase-loop.js';
 import type { PhaseLoopDeps } from '../phase-loop.js';
 import type { WorkerContext, Logger, PhaseResult, WorkflowPhase } from '../types.js';
 import { getPhaseSequence } from '../types.js';
@@ -95,7 +95,9 @@ function createMockDeps(): PhaseLoopDeps {
 interface ContextOverrides {
   ciRuns?: CiRun[];
   ciRunsFn?: ReturnType<typeof vi.fn>;
+  ciSource?: 'check-runs' | 'actions-runs';
   issueLabels?: string[];
+  issueCommentBodies?: string[];
   startPhase?: WorkflowPhase;
   command?: 'process' | 'continue';
 }
@@ -103,7 +105,10 @@ interface ContextOverrides {
 function createMockContext(checkoutPath: string, overrides: ContextOverrides = {}): WorkerContext {
   const getCiRunsForSha =
     overrides.ciRunsFn ??
-    vi.fn().mockResolvedValue({ runs: overrides.ciRuns ?? [], source: 'check-runs' });
+    vi.fn().mockResolvedValue({
+      runs: overrides.ciRuns ?? [],
+      source: overrides.ciSource ?? 'check-runs',
+    });
   return {
     workerId: 'test-worker',
     item: {
@@ -126,6 +131,15 @@ function createMockContext(checkoutPath: string, overrides: ContextOverrides = {
       getIssue: vi.fn().mockResolvedValue({ labels: overrides.issueLabels ?? [] }),
       getCiRunsForSha,
       addIssueComment: vi.fn().mockResolvedValue(undefined),
+      getIssueComments: vi.fn().mockResolvedValue(
+        (overrides.issueCommentBodies ?? []).map((body, idx) => ({
+          id: idx + 1,
+          body,
+          author: 'bot',
+          created_at: '',
+          updated_at: '',
+        })),
+      ),
       removeLabels: vi.fn().mockResolvedValue(undefined),
     } as any,
     logger: mockLogger,
@@ -234,6 +248,35 @@ describe('#1133 — CI-aware merge gate (phase-loop)', () => {
     // approve→resume terminal no-op (SC-003) sees the label state the pause really
     // leaves and cockpit treats the PR as merge-eligible while it waits.
     expect(deps.labelManager.onPhaseComplete).toHaveBeenCalledWith('validate');
+  });
+
+  it('on-ci-green pause clears the Redis remediation-budget mirror (loop converged) so a later address-pr-feedback re-entry starts fresh', async () => {
+    const context = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'success' }],
+    });
+    const config = createConfig({
+      ciMergeGateEnabled: true,
+      ciWaitTimeoutMs: 900_000,
+      gates: { 'speckit-feature': [CI_GREEN_GATE] },
+    });
+    const tracker = {
+      clearRaw: vi.fn().mockResolvedValue(undefined),
+      getValueRaw: vi.fn().mockResolvedValue(null),
+      setValueRaw: vi.fn().mockResolvedValue(undefined),
+    };
+    const depsWithTracker = { ...deps, phaseTracker: tracker } as unknown as PhaseLoopDeps;
+    const sequence = getPhaseSequence('speckit-feature', false) as WorkflowPhase[];
+
+    const result = await phaseLoop.executeLoop(context, config, depsWithTracker, sequence);
+
+    // Still a non-completing approval pause…
+    expect(result.completed).toBe(false);
+    expect(result.gateHit).toBe(true);
+    // …but the review↔remediate loop has converged (validate + CI green), so the
+    // durable budget mirror must be cleared here, not only on `completed: true`.
+    expect(tracker.clearRaw).toHaveBeenCalledWith(
+      expect.stringMatching(/^remediation-count:/),
+    );
   });
 
   it('SC-003: a continue re-entry at validate with completed:validate + completed:implementation-review is a merge-eligible terminal no-op', async () => {
@@ -396,5 +439,161 @@ describe('#1157 — red-CI pause (phase-loop)', () => {
     expect(result.gateHit).toBe(true);
     expect(deps.labelManager.onGateHit).toHaveBeenCalledWith('validate', 'waiting-for:ci');
     expect(context.github.getCiRunsForSha).not.toHaveBeenCalled();
+  });
+});
+
+// Post-#1157 review: the CI merge gate must be usable on tokens lacking
+// `checks:read` (the `actions/runs` fallback), and the pause comment must report
+// the REAL verdict + source and dedupe on re-pause.
+describe('CI merge gate — actions-runs trust + pause comment verdict/source/dedupe', () => {
+  let phaseLoop: PhaseLoop;
+  let deps: PhaseLoopDeps;
+  let checkoutPath: string;
+
+  beforeEach(async () => {
+    phaseLoop = new PhaseLoop(mockLogger);
+    deps = createMockDeps();
+    checkoutPath = await mkdtemp(path.join(tmpdir(), 'phase-loop-ci-trust-'));
+  });
+
+  afterEach(async () => {
+    await rm(checkoutPath, { recursive: true, force: true });
+  });
+
+  it('actions-runs green is trusted: the implementation-review gate opens (no waiting-for:ci pause)', async () => {
+    const context = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'success' }],
+      ciSource: 'actions-runs',
+    });
+    const config = createConfig({
+      ciMergeGateEnabled: true,
+      ciWaitTimeoutMs: 900_000,
+      gates: { 'speckit-feature': [CI_GREEN_GATE] },
+    });
+    const sequence = getPhaseSequence('speckit-feature', false) as WorkflowPhase[];
+
+    const result = await phaseLoop.executeLoop(context, config, deps, sequence);
+
+    expect(result.completed).toBe(false);
+    expect(result.gateHit).toBe(true);
+    expect(deps.labelManager.onGateHit).toHaveBeenCalledWith(
+      'validate',
+      'waiting-for:implementation-review',
+    );
+    expect(deps.labelManager.onGateHit).not.toHaveBeenCalledWith('validate', 'waiting-for:ci');
+    expect(deps.labelManager.onPhaseComplete).toHaveBeenCalledWith('validate');
+  });
+
+  it('red CI pause comment carries the marker and reports the real verdict + source + sha', async () => {
+    const context = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'failure' }],
+      ciSource: 'actions-runs',
+    });
+    const config = createConfig({
+      ciMergeGateEnabled: true,
+      ciWaitTimeoutMs: 900_000,
+      gates: { 'speckit-feature': [CI_GREEN_GATE] },
+    });
+    const sequence = getPhaseSequence('speckit-feature', false) as WorkflowPhase[];
+
+    await phaseLoop.executeLoop(context, config, deps, sequence);
+
+    expect(deps.labelManager.onGateHit).toHaveBeenCalledWith('validate', 'waiting-for:ci');
+    expect(context.github.addIssueComment).toHaveBeenCalledTimes(1);
+    const body = (context.github.addIssueComment as any).mock.calls[0][3] as string;
+    expect(body).toContain(CI_PAUSE_MARKER);
+    expect(body).toContain('CI verdict: `not-passed` (source: actions-runs) for head `a1b2c3d4`');
+    expect(body).not.toContain('CI is red');
+  });
+
+  it('timeout pause comment reports verdict pending', async () => {
+    const context = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'skipped' }],
+    });
+    const config = createConfig({
+      ciMergeGateEnabled: true,
+      ciWaitTimeoutMs: 0,
+      gates: { 'speckit-feature': [CI_GREEN_GATE] },
+    });
+    const sequence = getPhaseSequence('speckit-feature', false) as WorkflowPhase[];
+
+    await phaseLoop.executeLoop(context, config, deps, sequence);
+
+    const body = (context.github.addIssueComment as any).mock.calls[0][3] as string;
+    expect(body).toContain(CI_PAUSE_MARKER);
+    expect(body).toContain('CI verdict: `pending` (source: check-runs)');
+  });
+
+  it('re-pause on the same verdict/sha does not re-post when the latest issue comment carries the marker', async () => {
+    // First pause: capture the body it posts.
+    const first = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'failure' }],
+    });
+    const config = createConfig({
+      ciMergeGateEnabled: true,
+      ciWaitTimeoutMs: 900_000,
+      gates: { 'speckit-feature': [CI_GREEN_GATE] },
+    });
+    const sequence = getPhaseSequence('speckit-feature', false) as WorkflowPhase[];
+    await phaseLoop.executeLoop(first, config, deps, sequence);
+    const posted = (first.github.addIssueComment as any).mock.calls[0][3] as string;
+
+    // Second pause (operator added completed:ci, validate re-ran, CI still red
+    // on the same head): the latest issue comment is the one just posted.
+    const second = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'failure' }],
+      issueCommentBodies: ['earlier chatter', posted],
+    });
+    const deps2 = createMockDeps();
+    const result = await phaseLoop.executeLoop(second, config, deps2, sequence);
+
+    expect(result.gateHit).toBe(true);
+    expect(deps2.labelManager.onGateHit).toHaveBeenCalledWith('validate', 'waiting-for:ci');
+    expect(second.github.getIssueComments).toHaveBeenCalledWith(OWNER, REPO, ISSUE);
+    expect(second.github.addIssueComment).not.toHaveBeenCalled();
+  });
+
+  it('re-pause with a different sha re-posts even though the latest comment carries the marker', async () => {
+    const first = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'failure' }],
+    });
+    const config = createConfig({
+      ciMergeGateEnabled: true,
+      ciWaitTimeoutMs: 900_000,
+      gates: { 'speckit-feature': [CI_GREEN_GATE] },
+    });
+    const sequence = getPhaseSequence('speckit-feature', false) as WorkflowPhase[];
+    await phaseLoop.executeLoop(first, config, deps, sequence);
+    const posted = (first.github.addIssueComment as any).mock.calls[0][3] as string;
+
+    const second = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'failure' }],
+      issueCommentBodies: [posted],
+    });
+    (second.github.getCurrentCommitSha as any).mockResolvedValue('ffffffff');
+    const deps2 = createMockDeps();
+    await phaseLoop.executeLoop(second, config, deps2, sequence);
+
+    expect(second.github.addIssueComment).toHaveBeenCalledTimes(1);
+    const body = (second.github.addIssueComment as any).mock.calls[0][3] as string;
+    expect(body).toContain('for head `ffffffff`');
+  });
+
+  it('a failing dedupe read still posts the pause comment (best-effort)', async () => {
+    const context = createMockContext(checkoutPath, {
+      ciRuns: [{ status: 'completed', conclusion: 'failure' }],
+    });
+    (context.github.getIssueComments as any).mockRejectedValue(new Error('gh boom'));
+    const config = createConfig({
+      ciMergeGateEnabled: true,
+      ciWaitTimeoutMs: 900_000,
+      gates: { 'speckit-feature': [CI_GREEN_GATE] },
+    });
+    const sequence = getPhaseSequence('speckit-feature', false) as WorkflowPhase[];
+
+    const result = await phaseLoop.executeLoop(context, config, deps, sequence);
+
+    expect(result.gateHit).toBe(true);
+    expect(context.github.addIssueComment).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.merge-conflict-scoped-review.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.merge-conflict-scoped-review.integration.test.ts
@@ -17,7 +17,8 @@
  * the #1127 integration suite — so no real review logic runs here. The
  * scoped-executor window logic itself is unit-tested in review-executor.test.ts.
  */
-import { promises as fs } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { promises as fs, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -27,14 +28,18 @@ import type { WorkerContext, Logger, PhaseResult, WorkflowPhase } from '../types
 import { getPhaseSequence } from '../types.js';
 import type { WorkerConfig } from '../config.js';
 import { ReviewPoster } from '../review-poster.js';
-import type { FindingsArtifact } from '../review-findings-artifact.js';
 import type { ReviewArtifact, Severity } from '../review-artifact.js';
 import {
   bumpRemediationCount,
+  deriveFindingId,
   readReviewArtifactSync,
   writeReviewArtifact,
 } from '../review-artifact.js';
 import type { GitHubClient, Review } from '@generacy-ai/workflow-engine';
+import {
+  createReviewCompositionHarness,
+  type ReviewCompositionHarness,
+} from './helpers/review-composition-harness.js';
 
 const mockLogger = {
   info: () => {},
@@ -156,10 +161,18 @@ function phaseStartOrder(deps: PhaseLoopDeps): WorkflowPhase[] {
   );
 }
 
-function cleanArtifact(): FindingsArtifact {
+function cleanArtifact(): ReviewArtifact {
+  // Canonical #1161 shape; a `minor` finding is below the `critical` blocking
+  // severity the reader pairs it with, so it renders as advisory.
   return {
     verdict: 'clean',
-    findings: [{ marker: 'f-adv-1', text: 'nit', severity: 'advisory' }],
+    findings: [
+      { id: 'f-adv-1', severity: 'minor', file: 'src/nit.ts', title: 'nit', detail: 'nit', round: 1, status: 'open' },
+    ],
+    round: 1,
+    lastReviewedCommitSha: 'head456',
+    remediationCount: 0,
+    markedReadyByEngine: false,
   };
 }
 
@@ -174,7 +187,7 @@ describe('#1131 T015 — merge-conflict re-arm → scoped review → validate (S
     it(`starts at review and lands in validate on a clean verdict (${workflow})`, async () => {
       const github = createGithubSpy();
       const deps = createMockDeps(github);
-      deps.readFindingsArtifact = vi.fn().mockResolvedValue({ artifact: cleanArtifact(), round: 1 });
+      deps.readFindingsArtifact = vi.fn().mockResolvedValue({ artifact: cleanArtifact(), blockingSeverity: 'critical' });
       const context = createResumedContext(workflow, { baseSha: 'base123', headSha: 'head456' });
       const config = createConfig();
       const sequence = getPhaseSequence(workflow, true) as WorkflowPhase[];
@@ -197,7 +210,7 @@ describe('#1131 T015 — merge-conflict re-arm → scoped review → validate (S
   it('does not bypass validate: markReadyForReview fires but the loop still runs validate (SC-004)', async () => {
     const github = createGithubSpy();
     const deps = createMockDeps(github);
-    deps.readFindingsArtifact = vi.fn().mockResolvedValue({ artifact: cleanArtifact(), round: 1 });
+    deps.readFindingsArtifact = vi.fn().mockResolvedValue({ artifact: cleanArtifact(), blockingSeverity: 'critical' });
     const context = createResumedContext('speckit-feature', { baseSha: 'base123', headSha: 'head456' });
     const config = createConfig();
     const sequence = getPhaseSequence('speckit-feature', true) as WorkflowPhase[];
@@ -549,5 +562,186 @@ describe('#1164 T014 — post-resolution re-arm runs validate on merged tree (SC
     expect(phaseStartOrder(deps)).not.toContain('validate');
     expect(deps.cliSpawner.runValidatePhase).not.toHaveBeenCalled();
     expect(deps.prManager.markReadyForReview).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Scope consumption through the REAL `ReviewExecutor` with a prior artifact.
+ *
+ * Defect: `review-executor.ts` gated the resolution scope on `!priorRound`.
+ * On the real path conflicts surface at validate entry — AFTER round 1
+ * persisted the sidecar — so the scoped review NEVER ran: the re-review was a
+ * verification pass whose delta (`lastReviewedCommitSha`..HEAD) spanned the
+ * whole upstream base merge. The scripted stand-in above (#1164 T009) writes
+ * the sidecar itself and cannot observe that. This suite composes the real
+ * executor (via `review-composition-harness`) with a prior artifact on disk
+ * and asserts: the scope is applied once (conflicted-path charter + still-open
+ * prior findings), its consumption is persisted, and the following round
+ * falls back to the remediation delta so the loop still converges.
+ */
+describe('scoped review with a prior artifact — real ReviewExecutor applies the scope once', () => {
+  let harness: ReviewCompositionHarness;
+
+  beforeEach(async () => {
+    harness = await createReviewCompositionHarness({ issueNumber: 1171 });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  /** Two real commits so `isEmptyWindow`'s `git diff base..head` is non-empty. */
+  function commitTwice(dir: string): { base: string; head: string } {
+    const git = (args: string[]) => execFileSync('git', args, { cwd: dir }).toString().trim();
+    writeFileSync(path.join(dir, 'src-a.txt'), 'one');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'c0']);
+    const base = git(['rev-parse', '--short', 'HEAD']);
+    writeFileSync(path.join(dir, 'src-a.txt'), 'two');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'c1 (merge resolution)']);
+    const head = git(['rev-parse', '--short', 'HEAD']);
+    return { base, head };
+  }
+
+  it('applies the conflicted-path scope on round 2 (prior artifact present), persists consumption, then converges on the delta', async () => {
+    const { base, head } = commitTwice(harness.checkoutPath);
+
+    // Round 1 already happened before the validate-entry conflict: a clean
+    // artifact with one open sub-blocking finding still to confirm.
+    await writeReviewArtifact(harness.checkoutPath, harness.workflowId, {
+      findings: [
+        {
+          id: deriveFindingId('src/a.ts', 'Nit from round 1'),
+          severity: 'minor',
+          file: 'src/a.ts',
+          title: 'Nit from round 1',
+          detail: 'advisory',
+          round: 1,
+          status: 'open',
+        },
+      ],
+      verdict: 'clean',
+      round: 1,
+      lastReviewedCommitSha: 'r1sha',
+      remediationCount: 0,
+      markedReadyByEngine: false,
+    });
+
+    // Round 2 (scoped): the resolution introduced a blocking defect in the
+    // conflicted path. Round 3 (delta): the remediation fixed it.
+    const inner = harness.makeSpawningLauncher({
+      mode: 'write',
+      candidateJsonByRound: {
+        2: JSON.stringify({
+          findings: [
+            {
+              severity: 'critical',
+              file: 'src/a.ts',
+              title: 'Resolution dropped the null guard',
+              detail: 'must fix',
+              status: 'open',
+            },
+          ],
+        }),
+        3: JSON.stringify({
+          findings: [
+            {
+              severity: 'critical',
+              file: 'src/a.ts',
+              title: 'Resolution dropped the null guard',
+              detail: 'restored',
+              status: 'resolved',
+            },
+          ],
+        }),
+      },
+    });
+    const prompts: string[] = [];
+    const agentLauncher = {
+      launch: vi.fn(async (req: { intent: { prompt: string } }) => {
+        prompts.push(req.intent.prompt);
+        return inner.launch(req as never);
+      }),
+    } as unknown as typeof inner;
+
+    // Parent-1 diff of the merge commit brings upstream-only files along; the
+    // remediation delta (round 3) touches only the conflicted file.
+    const getFilesChangedBetween = harness.github.getFilesChangedBetween as ReturnType<typeof vi.fn>;
+    getFilesChangedBetween.mockImplementation(async (b: string, h: string) =>
+      b === base && h === head ? ['upstream/only.ts', 'src/a.ts'] : ['src/a.ts'],
+    );
+
+    const remediateExecute = vi.fn(async (): Promise<PhaseResult> => {
+      await bumpRemediationCount(harness.checkoutPath, harness.workflowId);
+      return makeSuccessResult('remediate');
+    });
+    const { context, config, deps } = harness.build({
+      agentLauncher,
+      startPhase: 'review',
+      extraDeps: {
+        remediateExecutor: { execute: remediateExecute } as never,
+        remediateTrigger: (ctx: WorkerContext) =>
+          readReviewArtifactSync(ctx.checkoutPath, harness.workflowId)?.verdict ===
+          'changes-required',
+        gateChecker: {
+          checkGates: vi.fn(
+            (phase: WorkflowPhase, workflowName: string, cfg: WorkerConfig) =>
+              (cfg.gates?.[workflowName] ?? []).filter((g) => g.phase === phase),
+          ),
+        } as never,
+      },
+    });
+    config.gates = {
+      [harness.workflowName]: [
+        {
+          phase: 'review',
+          gateLabel: 'waiting-for:remediation-limit',
+          condition: 'on-remediation-limit',
+        },
+      ],
+    } as WorkerConfig['gates'];
+    // Shaped exactly as the worker builds it after a merge-conflict re-arm.
+    context.resumeReason = 'merge-conflict-resolved';
+    context.reviewScope = { baseSha: base, headSha: head, conflictedPaths: ['src/a.ts'] };
+
+    const result = await harness.phaseLoop.executeLoop(context, config, deps, [
+      'review',
+      'validate',
+    ]);
+
+    expect(result.completed).toBe(true);
+    expect(result.gateHit).toBe(false);
+    expect(phaseStartOrder(deps)).toEqual(['review', 'remediate', 'review', 'validate']);
+    expect(deps.labelManager.onGateHit).not.toHaveBeenCalled();
+
+    // Round 2 charter: scoped to the conflicted path (upstream-only files
+    // excluded) AND a verification pass carrying the still-open prior finding.
+    expect(prompts).toHaveLength(2);
+    expect(prompts[0]).toContain('Conflicted paths:');
+    expect(prompts[0]).toContain('- src/a.ts');
+    expect(prompts[0]).not.toContain('upstream/only.ts');
+    expect(prompts[0]).toContain('Nit from round 1');
+    expect(prompts[0]).toContain('## Confirming an addressed finding');
+    expect(getFilesChangedBetween).toHaveBeenCalledWith(base, head);
+    expect(getFilesChangedBetween).not.toHaveBeenCalledWith('r1sha', expect.anything());
+
+    // Round 3 charter: the scope was consumed — plain delta verification pass
+    // over the remediation commits, never re-spanning the upstream merge.
+    expect(prompts[1]).not.toContain('Conflicted paths:');
+    expect(prompts[1]).not.toContain(`${base}..${head}`);
+    expect(prompts[1]).toContain('Resolution dropped the null guard');
+
+    const finalArtifact = readReviewArtifactSync(harness.checkoutPath, harness.workflowId);
+    expect(finalArtifact?.round).toBe(3);
+    expect(finalArtifact?.verdict).toBe('clean');
+    expect(finalArtifact?.remediationCount).toBe(1);
+    expect(finalArtifact?.consumedReviewScopeHeadSha).toBe(head);
+    const defect = finalArtifact?.findings.find((f) => f.title === 'Resolution dropped the null guard');
+    expect(defect?.status).toBe('resolved');
+    // The round-2 lastReviewedCommitSha (merge HEAD) was the round-3 delta base.
+    const round2Head = getFilesChangedBetween.mock.calls.at(-1)?.[0];
+    expect(round2Head).not.toBe('r1sha');
+    expect(round2Head).not.toBe(base);
   });
 });

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediate-skip-revert.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediate-skip-revert.test.ts
@@ -16,7 +16,7 @@ import { PhaseLoop } from '../phase-loop.js';
 import type { PhaseLoopDeps } from '../phase-loop.js';
 import type { WorkerContext, Logger, WorkflowPhase, PhaseResult } from '../types.js';
 import type { WorkerConfig } from '../config.js';
-import type { FindingsArtifact } from '../review-findings-artifact.js';
+import type { ReviewArtifact, Severity } from '../review-artifact.js';
 import { readReviewArtifactSync, writeReviewArtifact } from '../review-artifact.js';
 
 const mockLogger = {
@@ -72,21 +72,13 @@ function makeScriptedReviewExecutor(checkoutPath: string, verdicts: Verdict[]) {
 
 function makeFindingsReader(
   checkoutPath: string,
-): (context: WorkerContext) => Promise<{ artifact: FindingsArtifact; round: number } | null> {
+): (context: WorkerContext) => Promise<{ artifact: ReviewArtifact; blockingSeverity: Severity } | null> {
   return async () => {
     const ra = readReviewArtifactSync(checkoutPath, WORKFLOW_ID);
     if (!ra) return null;
-    return {
-      artifact: {
-        verdict: ra.verdict,
-        findings: ra.findings.map((f, idx) => ({
-          marker: `finding-${idx}`,
-          text: f.title,
-          severity: 'blocking' as const,
-        })),
-      },
-      round: ra.round,
-    };
+    // Live seam shape (#1161): the canonical artifact (round lives in `ra.round`)
+    // plus the blocking severity used for the poster's render projection.
+    return { artifact: ra, blockingSeverity: 'critical' };
   };
 }
 

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediate.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediate.test.ts
@@ -121,6 +121,7 @@ function makeGithub(
     getFilesChangedByOwnCommits: vi.fn().mockResolvedValue(['packages/orchestrator/src/foo.ts']),
     getFilesChangedBetween: vi.fn().mockResolvedValue(['packages/orchestrator/src/foo.ts']),
     getIssue: vi.fn(async () => ({ labels: [...labels] })),
+    getIssueComments: vi.fn().mockResolvedValue([]),
     addIssueComment,
     removeLabels,
     addLabels,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-comment-dedupe.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-comment-dedupe.test.ts
@@ -1,13 +1,15 @@
 // #1154 SC-004 (FR-005): the "Remediation limit reached" gate-body comment is
-// marker-deduped. On a resume/re-pause cycle where the same cap gate fires again,
-// the hidden `REMEDIATION_LIMIT_MARKER` already present in `listPrCommentBodies`
-// suppresses a second `addIssueComment`. Once the marker is gone (fresh PR / cleared
-// history), a genuinely new cap pause posts the comment once more.
+// marker-deduped. The comment is posted to the ISSUE (`addIssueComment`), so the
+// dedupe MUST read the issue's comments (`getIssueComments`) — the original
+// implementation read PR comments (`listPrCommentBodies(prNumber)`), never found
+// the marker, and re-posted on every re-park. On a resume/re-pause cycle where
+// the same cap gate fires again, the hidden `REMEDIATION_LIMIT_MARKER` already
+// present in the issue comments suppresses a second `addIssueComment`. Once the
+// marker is gone (cleared history), a genuinely new cap pause posts once more.
 //
 // Drives PhaseLoop.executeLoop to the #1128 remediation-cap gate (rc >= max &&
 // verdict === 'changes-required') so the real posting/dedupe path in phase-loop.ts
-// runs. Unlike the cap harness, `getPrNumber()` returns a real PR number so the
-// `listPrCommentBodies` marker grep is exercised.
+// runs.
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -18,7 +20,7 @@ import type { WorkerContext, Logger, WorkflowPhase, PhaseResult } from '../types
 import { getPhaseSequence } from '../types.js';
 import type { WorkerConfig } from '../config.js';
 import type { OrchestratorSettings } from '@generacy-ai/config';
-import type { FindingsArtifact } from '../review-findings-artifact.js';
+import type { ReviewArtifact, Severity } from '../review-artifact.js';
 import {
   bumpRemediationCount,
   readReviewArtifactSync,
@@ -75,22 +77,17 @@ function makeScriptedReviewExecutor(checkoutPath: string) {
 
 function makeFindingsReader(
   checkoutPath: string,
-): (context: WorkerContext, round: number) => Promise<FindingsArtifact | null> {
+): (context: WorkerContext) => Promise<{ artifact: ReviewArtifact; blockingSeverity: Severity } | null> {
   return async () => {
     const ra = readReviewArtifactSync(checkoutPath, WORKFLOW_ID);
     if (!ra) return null;
-    return {
-      verdict: ra.verdict,
-      findings: ra.findings.map((f, idx) => ({
-        marker: `finding-${idx}`,
-        text: f.title,
-        severity: 'blocking' as const,
-      })),
-    };
+    // Live seam shape (#1161): the canonical artifact (round lives in `ra.round`)
+    // plus the blocking severity used for the poster's render projection.
+    return { artifact: ra, blockingSeverity: 'critical' };
   };
 }
 
-function baseDeps(prCommentBodies: string[]): PhaseLoopDeps {
+function baseDeps(prNumber: number | undefined = PR_NUMBER): PhaseLoopDeps {
   return {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
@@ -121,7 +118,7 @@ function baseDeps(prCommentBodies: string[]): PhaseLoopDeps {
     } as any,
     prManager: {
       commitPushAndEnsurePr: vi.fn().mockResolvedValue({ prUrl: null, hasChanges: true }),
-      getPrNumber: vi.fn().mockReturnValue(PR_NUMBER),
+      getPrNumber: vi.fn().mockReturnValue(prNumber),
       convertToDraftIfEngineMarkedReady: vi.fn().mockResolvedValue(undefined),
       markReadyForReview: vi.fn().mockResolvedValue(undefined),
     } as any,
@@ -130,7 +127,7 @@ function baseDeps(prCommentBodies: string[]): PhaseLoopDeps {
 
 function capContext(
   checkoutPath: string,
-  prCommentBodies: string[],
+  issueCommentBodies: string[],
   addIssueComment: ReturnType<typeof vi.fn>,
 ): WorkerContext {
   return {
@@ -153,7 +150,12 @@ function capContext(
       getIssue: vi.fn().mockResolvedValue({ labels: [], state: 'open' }),
       addIssueComment,
       removeLabels: vi.fn().mockResolvedValue(undefined),
-      listPrCommentBodies: vi.fn().mockResolvedValue(prCommentBodies),
+      // ISSUE-side read — the surface the dedupe must consult.
+      getIssueComments: vi.fn().mockResolvedValue(
+        issueCommentBodies.map((body, idx) => ({ id: idx + 1, body, author: 'bot', created_at: '', updated_at: '' })),
+      ),
+      // PR-side read — must NOT be consulted (wrong object; see header).
+      listPrCommentBodies: vi.fn().mockResolvedValue([]),
     } as any,
     logger: mockLogger,
     signal: new AbortController().signal,
@@ -224,12 +226,12 @@ describe('PhaseLoop remediation-limit comment dedupe (#1154 SC-004 / FR-005)', (
     vi.clearAllMocks();
   });
 
-  it('suppresses a second comment when the marker is already present on the PR', async () => {
+  it('suppresses a second comment when the marker is already present in the ISSUE comments', async () => {
     await seedCappedState(checkoutPath);
     const addIssueComment = vi.fn().mockResolvedValue(undefined);
-    // A prior cap pause already posted the marked comment.
+    // A prior cap pause already posted the marked comment on the issue.
     const priorComment = `${REMEDIATION_LIMIT_MARKER}\n## Remediation limit reached\n...`;
-    const deps = baseDeps([priorComment]);
+    const deps = baseDeps();
     wireExecutors(deps, checkoutPath);
     deps.settings = { workflows: { [WORKFLOW]: { maxRemediations: MAX } } } as OrchestratorSettings;
 
@@ -240,20 +242,22 @@ describe('PhaseLoop remediation-limit comment dedupe (#1154 SC-004 / FR-005)', (
     // Re-parked at the same cap gate.
     expect(result.completed).toBe(false);
     expect(result.gateHit).toBe(true);
-    // The marker grep found the prior comment → no duplicate posted.
-    expect(ctx.github.listPrCommentBodies).toHaveBeenCalledWith(OWNER, REPO, PR_NUMBER);
+    // The marker grep read the ISSUE comments (the object the comment is posted
+    // to) and found the prior comment → no duplicate posted.
+    expect(ctx.github.getIssueComments).toHaveBeenCalledWith(OWNER, REPO, ISSUE);
+    expect(ctx.github.listPrCommentBodies).not.toHaveBeenCalled();
     expect(addIssueComment).not.toHaveBeenCalled();
   });
 
-  it('posts the comment once when no marker is present on the PR', async () => {
+  it('posts the comment once when no marker is present in the issue comments', async () => {
     await seedCappedState(checkoutPath);
     const addIssueComment = vi.fn().mockResolvedValue(undefined);
-    // Fresh PR history — marker absent.
-    const deps = baseDeps([]);
+    // Fresh issue history — marker absent.
+    const deps = baseDeps();
     wireExecutors(deps, checkoutPath);
     deps.settings = { workflows: { [WORKFLOW]: { maxRemediations: MAX } } } as OrchestratorSettings;
 
-    const ctx = capContext(checkoutPath, [], addIssueComment);
+    const ctx = capContext(checkoutPath, ['unrelated chatter'], addIssueComment);
     const sequence = getPhaseSequence(WORKFLOW, true) as WorkflowPhase[];
     const result = await phaseLoop.executeLoop(ctx, capConfig(), deps, sequence);
 
@@ -264,5 +268,23 @@ describe('PhaseLoop remediation-limit comment dedupe (#1154 SC-004 / FR-005)', (
     const body = addIssueComment.mock.calls[0][3] as string;
     expect(body).toContain(REMEDIATION_LIMIT_MARKER);
     expect(body).toContain('src/cap.ts:12');
+  });
+
+  it('still dedupes when no PR exists (getPrNumber() undefined)', async () => {
+    await seedCappedState(checkoutPath);
+    const addIssueComment = vi.fn().mockResolvedValue(undefined);
+    const priorComment = `${REMEDIATION_LIMIT_MARKER}\n## Remediation limit reached\n...`;
+    const deps = baseDeps(undefined);
+    wireExecutors(deps, checkoutPath);
+    deps.settings = { workflows: { [WORKFLOW]: { maxRemediations: MAX } } } as OrchestratorSettings;
+
+    const ctx = capContext(checkoutPath, [priorComment], addIssueComment);
+    const sequence = getPhaseSequence(WORKFLOW, true) as WorkflowPhase[];
+    const result = await phaseLoop.executeLoop(ctx, capConfig(), deps, sequence);
+
+    expect(result.completed).toBe(false);
+    expect(result.gateHit).toBe(true);
+    expect(ctx.github.getIssueComments).toHaveBeenCalledWith(OWNER, REPO, ISSUE);
+    expect(addIssueComment).not.toHaveBeenCalled();
   });
 });

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-persist.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-persist.test.ts
@@ -16,6 +16,10 @@
 //        gate falls back to the disk value, and nothing crashes.
 //   reset — a `completed:remediation-limit` resume resets disk to 0 AND clears
 //        the durable Redis mirror via `clearRaw`.
+//   completion — a loop that converges (`completed: true`) clears the Redis
+//        mirror so a later re-entry (address-pr-feedback re-seeds disk at 0)
+//        cannot reconcile a stale spent budget back up and park at the cap
+//        with zero attempts; a gate pause (non-completing exit) keeps it.
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -168,7 +172,7 @@ function capContext(checkoutPath: string, labels: string[] = []): WorkerContext 
           if (idx >= 0) labelSet.splice(idx, 1);
         }
       }),
-      listPrCommentBodies: vi.fn().mockResolvedValue([]),
+      getIssueComments: vi.fn().mockResolvedValue([]),
     } as any,
     logger: mockLogger,
     signal: new AbortController().signal,
@@ -270,6 +274,53 @@ describe('PhaseLoop remediation-count persistence (#1162 SC-003 / FR-003)', () =
     expect(tracker.getValueRaw).toHaveBeenCalledWith(REMEDIATION_COUNT_KEY);
     // getValueRaw returned null, so no seed was attempted; disk stays capped.
     expect(readReviewArtifactSync(checkoutPath, WORKFLOW_ID)?.remediationCount).toBe(MAX);
+  });
+
+  it('completion: a converging loop clears the Redis mirror so a post-completion re-entry starts fresh', async () => {
+    // Prior rounds spent MAX remediations, but the latest review is clean:
+    // the cap gate must not fire (verdict check) and the loop converges.
+    await writeReviewArtifact(checkoutPath, WORKFLOW_ID, {
+      findings: [],
+      verdict: 'clean',
+      round: MAX + 1,
+      lastReviewedCommitSha: 'clean',
+      remediationCount: MAX,
+    });
+    const tracker = makeTracker({ [REMEDIATION_COUNT_KEY]: String(MAX) });
+    const deps = baseDeps();
+    deps.phaseTracker = tracker as any;
+    deps.settings = CAPPED_SETTINGS;
+    // Inert review executor (stub) leaves the clean disk artifact untouched.
+
+    const ctx = capContext(checkoutPath);
+    const result = await phaseLoop.executeLoop(ctx, capConfig(), deps, ['review'] as WorkflowPhase[]);
+
+    expect(result.completed).toBe(true);
+    expect(result.gateHit).toBe(false);
+    // The durable mirror was cleared on the completed terminal path.
+    expect(tracker.clearRaw).toHaveBeenCalledWith(REMEDIATION_COUNT_KEY);
+    expect(await tracker.getValueRaw(REMEDIATION_COUNT_KEY)).toBeNull();
+  });
+
+  it('gate pause: a non-completing exit at the cap keeps the Redis mirror', async () => {
+    await seedCappedState(checkoutPath);
+    const tracker = makeTracker({ [REMEDIATION_COUNT_KEY]: String(MAX) });
+    const deps = baseDeps();
+    deps.phaseTracker = tracker as any;
+    deps.settings = CAPPED_SETTINGS;
+    const reviewExecutor = makeScriptedReviewExecutor(checkoutPath);
+    deps.reviewExecutor = reviewExecutor as any;
+
+    const ctx = capContext(checkoutPath);
+    const sequence = getPhaseSequence(WORKFLOW, true) as WorkflowPhase[];
+    const result = await phaseLoop.executeLoop(ctx, capConfig(), deps, sequence);
+
+    // Parked at the cap — a non-completing exit.
+    expect(result.completed).toBe(false);
+    expect(result.gateHit).toBe(true);
+    // The spent budget persists across the pause (restart-safe).
+    expect(tracker.clearRaw).not.toHaveBeenCalledWith(REMEDIATION_COUNT_KEY);
+    expect(await tracker.getValueRaw(REMEDIATION_COUNT_KEY)).toBe(String(MAX));
   });
 
   it('reset: a completed:remediation-limit resume zeroes disk and clears the Redis mirror', async () => {

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.resume-gates.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.resume-gates.integration.test.ts
@@ -21,6 +21,13 @@
 //     terminal no-op short-circuit must fire so `validate` does NOT re-run.
 //     WITHOUT FR-001 the strip removes `completed:implementation-review` and the
 //     short-circuit's two-label precondition is not met → validate re-runs.
+//     The retain set is the explicit one the worker passes
+//     (`resolveResumeRetainSuffixes({ ciMergeGateEnabled: true })`).
+//   Follow-ups (post-#1154 review): the retain set is EXPLICIT, not "every
+//     human gate" — `completed:clarification` must be stripped so a resumed
+//     clarify with follow-up questions pauses again, and `completed:ci` must be
+//     stripped so a validate re-pause leaves no stale `completed:ci` for the
+//     label monitor to pair forever.
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -28,12 +35,12 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { WORKFLOW_LABELS } from '@generacy-ai/workflow-engine';
 import { PhaseLoop } from '../phase-loop.js';
 import type { PhaseLoopDeps } from '../phase-loop.js';
-import { LabelManager } from '../label-manager.js';
+import { LabelManager, resolveResumeRetainSuffixes } from '../label-manager.js';
 import type { WorkerContext, Logger, WorkflowPhase, PhaseResult } from '../types.js';
 import { getPhaseSequence } from '../types.js';
 import type { WorkerConfig } from '../config.js';
 import type { OrchestratorSettings } from '@generacy-ai/config';
-import type { FindingsArtifact } from '../review-findings-artifact.js';
+import type { ReviewArtifact, Severity } from '../review-artifact.js';
 import {
   bumpRemediationCount,
   readReviewArtifactSync,
@@ -97,6 +104,11 @@ function makeLabelBackedGithub(initialLabels: string[]) {
     commitExistsInCheckout: vi.fn(async () => true),
     getIssueLabels: vi.fn(async () => [...labels]),
     addIssueComment: vi.fn(async () => undefined),
+    getIssueComments: vi.fn(async () => []),
+    getCiRunsForSha: vi.fn(async () => ({
+      runs: [{ status: 'completed', conclusion: 'failure' }],
+      source: 'check-runs' as const,
+    })),
   };
 }
 
@@ -137,23 +149,13 @@ function makeScriptedReviewExecutor(checkoutPath: string, verdicts: Verdict[]) {
 
 function makeFindingsReader(
   checkoutPath: string,
-): (context: WorkerContext) => Promise<{ artifact: FindingsArtifact; round: number } | null> {
+): (context: WorkerContext) => Promise<{ artifact: ReviewArtifact; blockingSeverity: Severity } | null> {
   return async () => {
     const ra = readReviewArtifactSync(checkoutPath, WORKFLOW_ID);
     if (!ra) return null;
-    // #1156 (FR-005): readFindingsArtifact returns { artifact, round } — the
-    // round is read from the sidecar (authoritative, monotonic), not passed in.
-    return {
-      artifact: {
-        verdict: ra.verdict,
-        findings: ra.findings.map((f, idx) => ({
-          marker: `finding-${idx}`,
-          text: f.title,
-          severity: 'blocking' as const,
-        })),
-      },
-      round: ra.round,
-    };
+    // Live seam shape (#1161): the canonical artifact (round lives in `ra.round`)
+    // plus the blocking severity used for the poster's render projection.
+    return { artifact: ra, blockingSeverity: 'critical' };
   };
 }
 
@@ -364,9 +366,13 @@ describe.each([['speckit-feature'], ['speckit-bugfix']])(
 
       const labelManager = new LabelManager(github as any, OWNER, REPO, ISSUE, mockLogger);
 
-      await labelManager.onResumeStart();
+      // claude-cli-worker passes the config-derived retain set; with the CI
+      // merge gate ON it includes `implementation-review`.
+      await labelManager.onResumeStart({
+        retainCompletedSuffixes: resolveResumeRetainSuffixes({ ciMergeGateEnabled: true }),
+      });
 
-      // FR-001: implementation-review (a human gate) survived; completed:validate
+      // Retain set: implementation-review survived; completed:validate
       // (a phase completion, never a strip candidate) is untouched; pause labels
       // cleared; agent:in-progress added.
       expect(github.labels.has('completed:implementation-review')).toBe(true);
@@ -399,6 +405,107 @@ describe.each([['speckit-feature'], ['speckit-bugfix']])(
       // validate must NOT re-run — no revalidation, no review executor invocation.
       expect(deps.cliSpawner.runValidatePhase).not.toHaveBeenCalled();
       expect(reviewExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    it('clarify resume with follow-up questions pauses again (completed:clarification is stripped)', async () => {
+      // The operator answered the first round (`completed:clarification`); the
+      // resumed clarify phase writes a NEW pending question.
+      const github = makeLabelBackedGithub([
+        'waiting-for:clarification',
+        'agent:paused',
+      ]);
+      await github.addLabels(OWNER, REPO, ISSUE, ['completed:clarification']);
+
+      const labelManager = new LabelManager(github as any, OWNER, REPO, ISSUE, mockLogger);
+      await labelManager.onResumeStart({
+        retainCompletedSuffixes: resolveResumeRetainSuffixes({ ciMergeGateEnabled: false }),
+      });
+
+      // The answer to the PREVIOUS round is consumed by the strip.
+      expect(github.labels.has('completed:clarification')).toBe(false);
+      expect(github.labels.has('waiting-for:clarification')).toBe(false);
+      expect(github.labels.has('agent:paused')).toBe(false);
+
+      const deps = baseDeps(labelManager);
+      // The clarify phase "asks a follow-up": the spawned CLI leaves an
+      // unanswered question in specs/<issue>-*/clarifications.md.
+      const specDir = path.join(checkoutPath, 'specs', `${ISSUE}-feature`);
+      (deps.cliSpawner.spawnPhase as any).mockImplementation(async (phase: WorkflowPhase) => {
+        if (phase === 'clarify') {
+          await fs.mkdir(specDir, { recursive: true });
+          await fs.writeFile(
+            path.join(specDir, 'clarifications.md'),
+            [
+              '# Clarifications',
+              '',
+              '### Q1: Follow-up',
+              '**Context**: after the first answer',
+              '**Question**: which option?',
+              '**Answer**: [PENDING]',
+              '',
+            ].join('\n'),
+          );
+        }
+        return makeSuccessResult(phase);
+      });
+
+      const ctx = makeContext(github, checkoutPath, workflowName, 'clarify');
+      const config = makeConfig({
+        gates: {
+          [workflowName]: [
+            { phase: 'clarify', gateLabel: 'waiting-for:clarification', condition: 'on-questions' },
+          ],
+        },
+      });
+      const result = await phaseLoop.executeLoop(ctx, config, deps, ['clarify'] as WorkflowPhase[]);
+
+      // The follow-up question re-raised the gate instead of being skipped as
+      // "already satisfied" by the stale completion label.
+      expect(result.completed).toBe(false);
+      expect(result.gateHit).toBe(true);
+      expect(github.labels.has('waiting-for:clarification')).toBe(true);
+      expect(github.labels.has('agent:paused')).toBe(true);
+      expect(github.labels.has('completed:clarification')).toBe(false);
+    });
+
+    it('ci re-pause after a completed:ci resume leaves no stale completed:ci', async () => {
+      // The operator answered `waiting-for:ci` with `completed:ci`; validate
+      // re-runs and CI is still red on the head → it must re-pause cleanly.
+      const github = makeLabelBackedGithub(['waiting-for:ci', 'agent:paused']);
+      await github.addLabels(OWNER, REPO, ISSUE, ['completed:ci']);
+
+      const labelManager = new LabelManager(github as any, OWNER, REPO, ISSUE, mockLogger);
+      await labelManager.onResumeStart({
+        retainCompletedSuffixes: resolveResumeRetainSuffixes({ ciMergeGateEnabled: true }),
+      });
+
+      expect(github.labels.has('completed:ci')).toBe(false);
+      expect(github.labels.has('waiting-for:ci')).toBe(false);
+
+      const deps = baseDeps(labelManager);
+      const ctx = makeContext(github, checkoutPath, workflowName, 'validate');
+      const config = makeConfig({
+        ciMergeGateEnabled: true,
+        ciWaitTimeoutMs: 900_000,
+        gates: {
+          [workflowName]: [
+            { phase: 'validate', gateLabel: 'waiting-for:implementation-review', condition: 'on-ci-green' },
+          ],
+        },
+      });
+      const result = await phaseLoop.executeLoop(ctx, config, deps, ['validate'] as WorkflowPhase[]);
+
+      // Re-paused on CI with a clean label pair: no stale completed:ci for the
+      // label monitor to pair with the fresh waiting-for:ci.
+      expect(result.completed).toBe(false);
+      expect(result.gateHit).toBe(true);
+      expect(github.labels.has('waiting-for:ci')).toBe(true);
+      expect(github.labels.has('agent:paused')).toBe(true);
+      expect(github.labels.has('completed:ci')).toBe(false);
+      expect(github.labels.has('completed:validate')).toBe(false);
+      // The pause comment reports the real verdict + source.
+      const body = (github.addIssueComment.mock.calls[0] as any[])[3] as string;
+      expect(body).toContain('CI verdict: `not-passed` (source: check-runs)');
     });
   },
 );

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.validate-synthetic-convergence.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.validate-synthetic-convergence.integration.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Validate-origin convergence through the REAL `ReviewExecutor`.
+ *
+ * Defect: `synthesizeValidateChangesRequiredArtifact` stores the validate
+ * COMMAND in the finding's `file`; `advanceArtifact` flips open→resolved only
+ * when `file ∈ delta.files`, and a command string is never a changed path. So
+ * the synthesized finding was carried forward open at critical severity every
+ * round → verdict stayed `changes-required` → remediate → … →
+ * `waiting-for:remediation-limit`. The existing
+ * `phase-loop.validate-remediate.integration.test.ts` masks this by stubbing
+ * the review executor to write a clean artifact.
+ *
+ * This suite composes the real executor (via `review-composition-harness`) and
+ * a scripted review CLI that does what the verification charter now instructs:
+ * re-emit the `[synthetic: validate]` finding with the same `file` + `title` and
+ * `status: "resolved"`. It proves the loop converges
+ * (validate fail → remediate → review resolves synthetic → validate green) with
+ * the `on-remediation-limit` cap gate ARMED and never tripped.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PhaseResult, WorkerContext, WorkflowPhase } from '../types.js';
+import type { WorkerConfig } from '../config.js';
+import {
+  bumpRemediationCount,
+  deriveFindingId,
+  readReviewArtifact,
+  readReviewArtifactSync,
+} from '../review-artifact.js';
+import {
+  createReviewCompositionHarness,
+  type ReviewCompositionHarness,
+} from './helpers/review-composition-harness.js';
+
+const VALIDATE_COMMAND = 'pnpm test && pnpm build';
+
+function makeSuccessResult(phase: WorkflowPhase): PhaseResult {
+  return { phase, success: true, exitCode: 0, durationMs: 1, output: [] };
+}
+
+function makeValidateFailure(): PhaseResult {
+  return {
+    phase: 'validate',
+    success: false,
+    exitCode: 1,
+    durationMs: 1,
+    output: [],
+    capturedStdout: 'FAIL src/foo.test.ts > expects bar',
+    capturedStderr: '',
+    error: { message: 'validate failed', output: 'exit 1', phase: 'validate' },
+  } as PhaseResult;
+}
+
+describe('validate-origin synthetic finding converges through the real ReviewExecutor', () => {
+  let harness: ReviewCompositionHarness;
+
+  beforeEach(async () => {
+    harness = await createReviewCompositionHarness({ issueNumber: 1170 });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  it('validate fail → remediate → review re-emits the synthetic finding resolved → validate green; cap never trips', async () => {
+    // Round 1: whole-PR review, clean. Round 3 (after the validate-origin
+    // remediate): the reviewer confirms the synthetic finding as resolved —
+    // same `file` (the validate command) + `title`, `status: "resolved"`.
+    const agentLauncher = harness.makeSpawningLauncher({
+      mode: 'write',
+      candidateJsonByRound: {
+        1: JSON.stringify({ findings: [] }),
+        3: JSON.stringify({
+          findings: [
+            {
+              severity: 'critical',
+              file: VALIDATE_COMMAND,
+              title: 'validate phase failed',
+              detail: 'The remediation fixed the failing test.',
+              status: 'resolved',
+            },
+          ],
+        }),
+      },
+    });
+
+    const runValidatePhase = vi
+      .fn()
+      .mockResolvedValueOnce(makeValidateFailure())
+      .mockResolvedValue(makeSuccessResult('validate'));
+    const remediateExecute = vi.fn(async (): Promise<PhaseResult> => {
+      // The real RemediateExecutor bumps the budget once per execution.
+      await bumpRemediationCount(harness.checkoutPath, harness.workflowId);
+      return makeSuccessResult('remediate');
+    });
+
+    const { context, config, deps } = harness.build({
+      agentLauncher,
+      startPhase: 'review',
+      extraDeps: {
+        remediateExecutor: { execute: remediateExecute } as never,
+        remediateTrigger: (ctx: WorkerContext) =>
+          readReviewArtifactSync(ctx.checkoutPath, harness.workflowId)?.verdict ===
+          'changes-required',
+        failureFingerprintTracker: { countPriorOccurrences: vi.fn(async () => 0) } as never,
+        // Honour `config.gates` so the remediation cap is live for this run.
+        gateChecker: {
+          checkGates: vi.fn(
+            (phase: WorkflowPhase, workflowName: string, cfg: WorkerConfig) =>
+              (cfg.gates?.[workflowName] ?? []).filter((g) => g.phase === phase),
+          ),
+        } as never,
+      },
+    });
+    (deps.cliSpawner as { runValidatePhase: unknown }).runValidatePhase = runValidatePhase;
+    config.gates = {
+      [harness.workflowName]: [
+        {
+          phase: 'review',
+          gateLabel: 'waiting-for:remediation-limit',
+          condition: 'on-remediation-limit',
+        },
+      ],
+    } as WorkerConfig['gates'];
+
+    const result = await harness.phaseLoop.executeLoop(context, config, deps, [
+      'review',
+      'validate',
+    ]);
+
+    expect(result.completed).toBe(true);
+    expect(result.gateHit).toBe(false);
+
+    const phaseStarts = (deps.labelManager.onPhaseStart as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: unknown[]) => c[0] as WorkflowPhase,
+    );
+    // review(clean) → validate(fail → synth) → review(stub) → remediate →
+    // review(real: resolves synthetic) → validate(green).
+    expect(phaseStarts).toEqual(['review', 'validate', 'review', 'remediate', 'review', 'validate']);
+    expect(remediateExecute).toHaveBeenCalledTimes(1);
+    expect(runValidatePhase).toHaveBeenCalledTimes(2);
+    // The cap gate was armed and never fired.
+    expect(deps.labelManager.onGateHit).not.toHaveBeenCalled();
+
+    const artifact = await readReviewArtifact(harness.checkoutPath, harness.workflowId);
+    expect(artifact).not.toBeNull();
+    expect(artifact!.verdict).toBe('clean');
+    expect(artifact!.round).toBe(3);
+    expect(artifact!.remediationCount).toBe(1);
+    const synthetic = artifact!.findings.find((f) => f.synthetic === 'validate');
+    expect(synthetic).toBeDefined();
+    expect(synthetic!.id).toBe(deriveFindingId(VALIDATE_COMMAND, 'validate phase failed'));
+    expect(synthetic!.status).toBe('resolved');
+  });
+
+  it('a green validate auto-resolves an open synthetic finding even when no review confirmed it', async () => {
+    // Round 3 reviewer OMITS the synthetic finding (anti-vanish keeps it open →
+    // changes-required → a second remediate → round 4 confirms). This proves the
+    // safety net is orthogonal: after the final green validate, no open
+    // synthetic:validate finding survives in the sidecar regardless of how the
+    // review rounds went.
+    const agentLauncher = harness.makeSpawningLauncher({
+      mode: 'write',
+      candidateJsonByRound: {
+        1: JSON.stringify({ findings: [] }),
+        3: JSON.stringify({ findings: [] }),
+        4: JSON.stringify({
+          findings: [
+            {
+              severity: 'critical',
+              file: VALIDATE_COMMAND,
+              title: 'validate phase failed',
+              detail: 'Fixed.',
+              status: 'resolved',
+            },
+          ],
+        }),
+      },
+    });
+    const runValidatePhase = vi
+      .fn()
+      .mockResolvedValueOnce(makeValidateFailure())
+      .mockResolvedValue(makeSuccessResult('validate'));
+    const remediateExecute = vi.fn(async (): Promise<PhaseResult> => {
+      await bumpRemediationCount(harness.checkoutPath, harness.workflowId);
+      return makeSuccessResult('remediate');
+    });
+    const { context, config, deps } = harness.build({
+      agentLauncher,
+      startPhase: 'review',
+      extraDeps: {
+        remediateExecutor: { execute: remediateExecute } as never,
+        remediateTrigger: (ctx: WorkerContext) =>
+          readReviewArtifactSync(ctx.checkoutPath, harness.workflowId)?.verdict ===
+          'changes-required',
+        failureFingerprintTracker: { countPriorOccurrences: vi.fn(async () => 0) } as never,
+      },
+    });
+    (deps.cliSpawner as { runValidatePhase: unknown }).runValidatePhase = runValidatePhase;
+
+    const result = await harness.phaseLoop.executeLoop(context, config, deps, [
+      'review',
+      'validate',
+    ]);
+    expect(result.completed).toBe(true);
+    expect(remediateExecute).toHaveBeenCalledTimes(2);
+
+    const artifact = await readReviewArtifact(harness.checkoutPath, harness.workflowId);
+    expect(artifact!.verdict).toBe('clean');
+    expect(
+      artifact!.findings.filter((f) => f.synthetic === 'validate' && f.status === 'open'),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.push-guard.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.push-guard.test.ts
@@ -56,6 +56,7 @@ const mockGitHub = {
   listPrCommentBodies: vi.fn().mockResolvedValue([]),
   getStatus: vi.fn(),
   stageAll: vi.fn(),
+  stageFiles: vi.fn(),
   commit: vi.fn(),
   push: vi.fn(),
   replyToPRComment: vi.fn().mockResolvedValue(undefined),
@@ -186,7 +187,7 @@ describe('PrFeedbackHandler push-guard integration (#1051 T025)', () => {
       },
     ]);
     mockGitHub.getStatus.mockResolvedValue({
-      has_changes: true, staged: [], unstaged: [], untracked: [], branch: 'feature-100', hasUnpushed: false, unpushedCount: 0,
+      has_changes: true, staged: [], unstaged: ['x.ts'], untracked: [], branch: 'feature-100', hasUnpushed: false, unpushedCount: 0,
     });
     mockGitHub.getIssue.mockResolvedValue({
       number: 100, title: 'issue', state: 'open', labels: [], assignees: [], body: '', created_at: '', updated_at: '',
@@ -249,7 +250,7 @@ describe('PrFeedbackHandler push-guard integration (#1051 T025)', () => {
 
     // Push NOT called.
     expect(mockGitHub.push).not.toHaveBeenCalled();
-    expect(mockGitHub.stageAll).not.toHaveBeenCalled();
+    expect(mockGitHub.stageFiles).not.toHaveBeenCalled();
     expect(mockGitHub.commit).not.toHaveBeenCalled();
   });
 
@@ -312,7 +313,7 @@ describe('PrFeedbackHandler push-guard integration (#1051 T025)', () => {
     expect(refuseCall).toBeUndefined();
 
     // Normal push flow proceeds.
-    expect(mockGitHub.stageAll).toHaveBeenCalled();
+    expect(mockGitHub.stageFiles).toHaveBeenCalled();
     expect(mockGitHub.commit).toHaveBeenCalled();
     expect(mockGitHub.push).toHaveBeenCalled();
   });

--- a/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/pr-feedback-handler.test.ts
@@ -32,6 +32,7 @@ const mockGitHub = {
   getPRReviewThreads: vi.fn(),
   getStatus: vi.fn(),
   stageAll: vi.fn(),
+  stageFiles: vi.fn(),
   commit: vi.fn(),
   push: vi.fn(),
   replyToPRComment: vi.fn(),
@@ -189,6 +190,7 @@ describe('PrFeedbackHandler', () => {
     mockGitHub.getPRReviewThreads = vi.fn().mockResolvedValue([]);
     mockGitHub.getStatus = vi.fn().mockResolvedValue({ has_changes: false, staged: [], unstaged: [], untracked: [] });
     mockGitHub.stageAll = vi.fn().mockResolvedValue(undefined);
+    mockGitHub.stageFiles = vi.fn().mockResolvedValue(undefined);
     mockGitHub.commit = vi.fn().mockResolvedValue(undefined);
     mockGitHub.push = vi.fn().mockResolvedValue(undefined);
     mockGitHub.replyToPRComment = vi.fn().mockResolvedValue(undefined);
@@ -247,6 +249,62 @@ describe('PrFeedbackHandler', () => {
     });
   });
 
+  describe('engine sidecar filtering on the legacy commit path (#1162)', () => {
+    it('stages and commits only non-sidecar paths, with an explicit pathspec', async () => {
+      const item = createQueueItem({ prNumber: 100, reviewThreadIds: [1] });
+      const checkoutPath = '/tmp/workspace/test-owner/test-repo';
+      mockGitHub.getPRReviewThreads = vi.fn().mockResolvedValue([
+        createMockComment(1, false, 'src/index.ts', 15),
+      ]);
+      const { handle } = createMockProcess(0, 50);
+      spawnFn.mockReturnValue(handle);
+      // Sidecars now survive the cross-run `git clean` (repo-checkout.ts), so
+      // they show up as untracked alongside the real fix.
+      mockGitHub.getStatus = vi.fn().mockResolvedValue({
+        has_changes: true,
+        staged: ['src/index.ts'],
+        unstaged: ['src/util.ts'],
+        untracked: [
+          '.generacy/review-findings-test-owner-test-repo-42.json',
+          '.generacy/pause-context-42.json',
+          '.generacy/',
+        ],
+      });
+
+      await handler.handle(item, checkoutPath);
+
+      expect(mockGitHub.stageAll).not.toHaveBeenCalled();
+      expect(mockGitHub.stageFiles).toHaveBeenCalledWith(['src/index.ts', 'src/util.ts']);
+      expect(mockGitHub.commit).toHaveBeenCalledWith(
+        expect.stringContaining('Address PR #100 review feedback'),
+        ['src/index.ts', 'src/util.ts'],
+      );
+    });
+
+    it('skips the commit entirely when only engine sidecars changed', async () => {
+      const item = createQueueItem({ prNumber: 100, reviewThreadIds: [1] });
+      const checkoutPath = '/tmp/workspace/test-owner/test-repo';
+      mockGitHub.getPRReviewThreads = vi.fn().mockResolvedValue([
+        createMockComment(1, false, 'src/index.ts', 15),
+      ]);
+      const { handle } = createMockProcess(0, 50);
+      spawnFn.mockReturnValue(handle);
+      mockGitHub.getStatus = vi.fn().mockResolvedValue({
+        has_changes: true,
+        staged: [],
+        unstaged: [],
+        untracked: ['.generacy/review-findings-test-owner-test-repo-42.json'],
+      });
+
+      await handler.handle(item, checkoutPath);
+
+      expect(mockGitHub.stageAll).not.toHaveBeenCalled();
+      expect(mockGitHub.stageFiles).not.toHaveBeenCalled();
+      expect(mockGitHub.commit).not.toHaveBeenCalled();
+      expect(mockGitHub.push).not.toHaveBeenCalled();
+    });
+  });
+
   describe('handle - successful flow', () => {
     it('processes unresolved comments, commits changes, posts replies, and removes label', async () => {
       const item = createQueueItem({ prNumber: 100, reviewThreadIds: [1, 2] });
@@ -293,9 +351,9 @@ describe('PrFeedbackHandler', () => {
       );
 
       // Should stage, commit, and push
-      expect(mockGitHub.stageAll).toHaveBeenCalled();
+      expect(mockGitHub.stageFiles).toHaveBeenCalled();
       expect(mockGitHub.commit).toHaveBeenCalledWith(
-        expect.stringContaining('Address PR #100 review feedback'),
+        expect.stringContaining('Address PR #100 review feedback'), expect.any(Array),
       );
       expect(mockGitHub.push).toHaveBeenCalledWith('origin', 'feature-branch');
 
@@ -358,7 +416,7 @@ describe('PrFeedbackHandler', () => {
       await handler.handle(item, checkoutPath);
 
       // Should not stage, commit, or push
-      expect(mockGitHub.stageAll).not.toHaveBeenCalled();
+      expect(mockGitHub.stageFiles).not.toHaveBeenCalled();
       expect(mockGitHub.commit).not.toHaveBeenCalled();
       expect(mockGitHub.push).not.toHaveBeenCalled();
 
@@ -1228,13 +1286,13 @@ describe('PrFeedbackHandler', () => {
       await handler.handle(item, checkoutPath);
 
       expect(mockGitHub.commit).toHaveBeenCalledWith(
-        expect.stringContaining('Address PR #100 review feedback'),
+        expect.stringContaining('Address PR #100 review feedback'), expect.any(Array),
       );
       expect(mockGitHub.commit).toHaveBeenCalledWith(
-        expect.stringContaining('issue #42'),
+        expect.stringContaining('issue #42'), expect.any(Array),
       );
       expect(mockGitHub.commit).toHaveBeenCalledWith(
-        expect.stringContaining('Co-Authored-By: Claude Sonnet 4.5'),
+        expect.stringContaining('Co-Authored-By: Claude Sonnet 4.5'), expect.any(Array),
       );
     });
   });

--- a/packages/orchestrator/src/worker/__tests__/pr-feedback-trust.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/pr-feedback-trust.test.ts
@@ -23,6 +23,7 @@ const mockGitHub: Record<string, ReturnType<typeof vi.fn>> = {
   replyToPRComment: vi.fn(),
   resolveReviewThread: vi.fn(),
   stageAll: vi.fn(),
+  stageFiles: vi.fn(),
   commit: vi.fn(),
   push: vi.fn(),
   // #1051 pre-push guard mock — defaults to "no PR in any state" so the
@@ -131,6 +132,7 @@ describe('PR-feedback author-trust gating (FR-006)', () => {
       untracked: [],
     });
     mockGitHub.stageAll.mockResolvedValue(undefined);
+    mockGitHub.stageFiles.mockResolvedValue(undefined);
     mockGitHub.commit.mockResolvedValue(undefined);
     mockGitHub.push.mockResolvedValue(undefined);
     mockGitHub.removeLabels.mockResolvedValue(undefined);

--- a/packages/orchestrator/src/worker/__tests__/pr-manager.staging-filter.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/pr-manager.staging-filter.test.ts
@@ -172,6 +172,32 @@ describe('PrManager staging filter (#1162 FR-001)', () => {
     expect(commit).toHaveBeenCalledWith(expect.any(String), ['src/staged-only.ts']);
   });
 
+  it('G7: a collapsed `.generacy/` directory entry is never staged (wholly-untracked .generacy)', async () => {
+    // A status backend without `--untracked-files=all` reports a wholly
+    // untracked `.generacy/` as ONE directory entry. `isEngineSidecar` cannot
+    // see the sidecars inside it, so staging the entry would commit them all —
+    // the original #1162 failure in any repo with no tracked `.generacy/config.yaml`.
+    const status = makeStatus({
+      untracked: ['.generacy/', 'src/new.ts'],
+    });
+    const { github, stageFiles, commit } = makeGithub(status);
+
+    await commitAndPush(makeManager(github));
+
+    expect(stageFiles).toHaveBeenCalledWith(['src/new.ts']);
+    expect(commit).toHaveBeenCalledWith(expect.any(String), ['src/new.ts']);
+  });
+
+  it('G7: a collapsed `.generacy` (no trailing slash) entry is skipped too, and alone yields no commit', async () => {
+    const status = makeStatus({ untracked: ['.generacy'] });
+    const { github, stageFiles, commit } = makeGithub(status);
+
+    await commitAndPush(makeManager(github));
+
+    expect(stageFiles).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
   it('G6: a pre-staged sidecar in the index is excluded from the commit pathspec', async () => {
     // Some other actor (e.g. an implement agent running `git add -A`) left a
     // sidecar staged in the index. The whole-index `git commit` would fold it

--- a/packages/orchestrator/src/worker/__tests__/product-diff.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/product-diff.test.ts
@@ -5,7 +5,10 @@ import {
   EXCLUDED_PATH_PREFIXES,
   EXCLUDED_EXACT_PATHS,
   ENGINE_SIDECAR_PREFIXES,
+  ENGINE_STATE_DIR,
   isEngineSidecar,
+  engineSidecarCleanExcludes,
+  isCollapsedEngineStateDir,
   isProductFile,
   resolveBaseRef,
   computeProductDiff,
@@ -54,6 +57,49 @@ describe('ENGINE_SIDECAR_PREFIXES / isEngineSidecar', () => {
   it('does NOT match ordinary product paths', () => {
     expect(isEngineSidecar('packages/orchestrator/src/worker/phase-loop.ts')).toBe(false);
     expect(isEngineSidecar('README.md')).toBe(false);
+  });
+});
+
+// #1162 follow-up: the cross-run checkout reset must spare the same sidecars
+// the staging filter refuses to commit — derived from the same prefix list.
+describe('engineSidecarCleanExcludes', () => {
+  it('yields one `<prefix>*` git-clean exclude per sidecar prefix, in order', () => {
+    expect(engineSidecarCleanExcludes()).toEqual([
+      '.generacy/review-findings-*',
+      '.generacy/review-candidate-*',
+      '.generacy/pause-context-*',
+      '.generacy/external-feedback-*',
+      '.generacy/workflow-state-*',
+    ]);
+    expect(engineSidecarCleanExcludes()).toEqual(
+      ENGINE_SIDECAR_PREFIXES.map((p) => `${p}*`),
+    );
+  });
+
+  it('every prefix lives under ENGINE_STATE_DIR', () => {
+    for (const prefix of ENGINE_SIDECAR_PREFIXES) {
+      expect(prefix.startsWith(`${ENGINE_STATE_DIR}/`)).toBe(true);
+    }
+  });
+});
+
+describe('isCollapsedEngineStateDir', () => {
+  it('matches a bare .generacy directory entry with or without trailing slash', () => {
+    expect(isCollapsedEngineStateDir('.generacy/')).toBe(true);
+    expect(isCollapsedEngineStateDir('.generacy')).toBe(true);
+  });
+
+  it('does NOT match files under .generacy or look-alike paths', () => {
+    expect(isCollapsedEngineStateDir('.generacy/config.yaml')).toBe(false);
+    expect(isCollapsedEngineStateDir('.generacy/review-findings-x.json')).toBe(false);
+    expect(isCollapsedEngineStateDir('.generacyx')).toBe(false);
+    expect(isCollapsedEngineStateDir('foo/.generacy/')).toBe(false);
+    expect(isCollapsedEngineStateDir('README.md')).toBe(false);
+  });
+
+  it('is disjoint from isEngineSidecar (a collapsed dir is not itself a sidecar)', () => {
+    expect(isEngineSidecar('.generacy/')).toBe(false);
+    expect(isEngineSidecar('.generacy')).toBe(false);
   });
 });
 

--- a/packages/orchestrator/src/worker/__tests__/repo-checkout.sidecar-clean.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/repo-checkout.sidecar-clean.integration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Integration test (real git): the cross-run checkout reset in
+ * `RepoCheckout.switchBranch` / `updateRepo` must spare the engine's untracked
+ * bookkeeping sidecars under `.generacy/` (#1162).
+ *
+ * `git clean -fd` with no exclusions wiped `.generacy/review-findings-*.json`
+ * (and friends) on every re-entry — new run, address-pr-feedback, merge-conflict
+ * re-arm — so the review round restarted at 1, `markedReadyByEngine` was lost,
+ * and open findings + `lastReviewedCommitSha` were lost. Other untracked files
+ * (including non-sidecar files under `.generacy/`) must still be cleaned, and
+ * tracked-file edits must still be discarded.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, mkdir, writeFile, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RepoCheckout } from '../repo-checkout.js';
+import type { Logger } from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+const mockLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  child: () => mockLogger,
+} as unknown as Logger;
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'test',
+  GIT_AUTHOR_EMAIL: 'test@example.com',
+  GIT_COMMITTER_NAME: 'test',
+  GIT_COMMITTER_EMAIL: 'test@example.com',
+};
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd, env: GIT_ENV });
+  return stdout;
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('RepoCheckout sidecar-preserving clean (#1162, real git)', () => {
+  let workspaceDir: string;
+  let remoteDir: string;
+  let checkoutPath: string;
+
+  beforeEach(async () => {
+    workspaceDir = await mkdtemp(join(tmpdir(), 'repo-checkout-sidecar-'));
+    remoteDir = join(workspaceDir, 'remote.git');
+    // `RepoCheckout.getCheckoutPath` prefers `{workspaceDir}/{repo}` when it has
+    // a `.git` — that routes `ensureCheckout` through the private `updateRepo`.
+    checkoutPath = join(workspaceDir, 'repo');
+
+    // Seed the bare remote (main + feature) from a throwaway working repo, then
+    // clone it the way the worker's bootstrapped checkout would be.
+    const seedDir = join(workspaceDir, 'seed');
+    await git(workspaceDir, 'init', '-q', '--bare', '-b', 'main', remoteDir);
+    await git(workspaceDir, 'init', '-q', '-b', 'main', seedDir);
+    await writeFile(join(seedDir, 'README.md'), 'hello\n');
+    await git(seedDir, 'add', 'README.md');
+    await git(seedDir, 'commit', '-q', '-m', 'init');
+    await git(seedDir, 'branch', 'feature');
+    await git(seedDir, 'remote', 'add', 'origin', remoteDir);
+    await git(seedDir, 'push', '-q', 'origin', 'main', 'feature');
+    await git(workspaceDir, 'clone', '-q', '--branch', 'main', remoteDir, checkoutPath);
+  });
+
+  afterEach(async () => {
+    await rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  /** Dirty the checkout the way a previous worker run leaves it. */
+  async function dirtyCheckout(): Promise<void> {
+    await mkdir(join(checkoutPath, '.generacy', 'epics'), { recursive: true });
+    await writeFile(
+      join(checkoutPath, '.generacy', 'review-findings-x.json'),
+      JSON.stringify({ round: 3, markedReadyByEngine: true }),
+    );
+    await writeFile(join(checkoutPath, '.generacy', 'pause-context-x.json'), '{}');
+    await writeFile(join(checkoutPath, '.generacy', 'workflow-state-x.json'), '{}');
+    await writeFile(join(checkoutPath, '.generacy', 'epics', 'draft.md'), 'not a sidecar');
+    await writeFile(join(checkoutPath, 'junk.txt'), 'leftover');
+    await writeFile(join(checkoutPath, 'README.md'), 'dirty edit\n');
+  }
+
+  async function assertSidecarsSurvivedAndJunkCleaned(): Promise<void> {
+    // Sidecars survive, content intact.
+    const findings = await readFile(join(checkoutPath, '.generacy', 'review-findings-x.json'), 'utf-8');
+    expect(JSON.parse(findings)).toEqual({ round: 3, markedReadyByEngine: true });
+    expect(await exists(join(checkoutPath, '.generacy', 'pause-context-x.json'))).toBe(true);
+    expect(await exists(join(checkoutPath, '.generacy', 'workflow-state-x.json'))).toBe(true);
+    // Everything else untracked is cleaned — including non-sidecar files under .generacy/.
+    expect(await exists(join(checkoutPath, 'junk.txt'))).toBe(false);
+    expect(await exists(join(checkoutPath, '.generacy', 'epics', 'draft.md'))).toBe(false);
+    // Tracked edits are still discarded.
+    expect(await readFile(join(checkoutPath, 'README.md'), 'utf-8')).toBe('hello\n');
+  }
+
+  it('switchBranch keeps .generacy sidecars while cleaning other untracked files', async () => {
+    await dirtyCheckout();
+    const checkout = new RepoCheckout(workspaceDir, mockLogger);
+
+    await checkout.switchBranch(checkoutPath, 'feature');
+
+    expect((await git(checkoutPath, 'branch', '--show-current')).trim()).toBe('feature');
+    await assertSidecarsSurvivedAndJunkCleaned();
+  });
+
+  it('ensureCheckout → updateRepo keeps .generacy sidecars while cleaning other untracked files', async () => {
+    await dirtyCheckout();
+    const checkout = new RepoCheckout(workspaceDir, mockLogger);
+
+    const resolved = await checkout.ensureCheckout('worker-1', 'owner', 'repo', 'main');
+
+    expect(resolved).toBe(checkoutPath);
+    expect((await git(checkoutPath, 'branch', '--show-current')).trim()).toBe('main');
+    await assertSidecarsSurvivedAndJunkCleaned();
+  });
+});

--- a/packages/orchestrator/src/worker/__tests__/repo-checkout.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/repo-checkout.test.ts
@@ -45,7 +45,8 @@ vi.mock('node:util', () => ({
 // Import SUT (after mocks are declared)
 // ---------------------------------------------------------------------------
 
-import { RepoCheckout } from '../repo-checkout.js';
+import { RepoCheckout, sidecarPreservingCleanArgs } from '../repo-checkout.js';
+import { ENGINE_SIDECAR_PREFIXES } from '../product-diff.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -209,6 +210,60 @@ describe('RepoCheckout', () => {
       const resetIdx = callOrder.lastIndexOf('reset');
       expect(fetchIdx).toBeGreaterThanOrEqual(0);
       expect(resetIdx).toBeGreaterThan(fetchIdx);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #1162: cross-run clean must spare engine sidecars (both reset sites)
+  // -------------------------------------------------------------------------
+  describe('sidecar-preserving git clean (#1162)', () => {
+    it('sidecarPreservingCleanArgs() derives one -e pattern per ENGINE_SIDECAR_PREFIXES entry', () => {
+      const args = sidecarPreservingCleanArgs();
+      expect(args.slice(0, 2)).toEqual(['clean', '-fd']);
+      const excludes = args.slice(2);
+      expect(excludes).toEqual(
+        ENGINE_SIDECAR_PREFIXES.flatMap((prefix) => ['-e', `${prefix}*`]),
+      );
+      // Sanity: the review artifact — the sidecar whose loss resets the round — is covered.
+      expect(excludes).toContain('.generacy/review-findings-*');
+      // Exclusions are scoped to sidecars, never the whole .generacy/ tree.
+      expect(excludes).not.toContain('.generacy');
+      expect(excludes).not.toContain('.generacy/');
+    });
+
+    it('updateRepo (ensureCheckout on an existing dir) runs git clean with the sidecar excludes', async () => {
+      mockStat
+        .mockRejectedValueOnce(enoentError())
+        .mockResolvedValue({ isDirectory: () => true });
+
+      await checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop');
+
+      const cleanCalls = findAllCalls('git', ['clean']);
+      expect(cleanCalls).toHaveLength(1);
+      expect(cleanCalls[0]![1]).toEqual(sidecarPreservingCleanArgs());
+      expect(cleanCalls[0]![2]).toEqual({ cwd: '/workspace/worker-1/octocat/repo' });
+    });
+
+    it('switchBranch runs git clean with the sidecar excludes', async () => {
+      await checkout.switchBranch('/workspace/worker-1/octocat/repo', 'feature-42');
+
+      const cleanCalls = findAllCalls('git', ['clean']);
+      expect(cleanCalls).toHaveLength(1);
+      expect(cleanCalls[0]![1]).toEqual(sidecarPreservingCleanArgs());
+      expect(cleanCalls[0]![2]).toEqual({ cwd: '/workspace/worker-1/octocat/repo' });
+    });
+
+    it('never runs a bare `git clean -fd` at either reset site', async () => {
+      mockStat
+        .mockRejectedValueOnce(enoentError())
+        .mockResolvedValue({ isDirectory: () => true });
+      await checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop');
+      await checkout.switchBranch('/workspace/worker-1/octocat/repo', 'feature-42');
+
+      for (const call of findAllCalls('git', ['clean'])) {
+        expect(call[1]).not.toEqual(['clean', '-fd']);
+        expect(call[1]).toContain('-e');
+      }
     });
   });
 
@@ -559,7 +614,9 @@ describe('RepoCheckout', () => {
       await checkout.ensureCheckout('worker-1', 'octocat', 'repo', 'develop');
 
       const resetHeadIdx = callOrder.findIndex((c) => c === 'reset(--hard,HEAD)');
-      const cleanIdx = callOrder.findIndex((c) => c === 'clean(-fd)');
+      // #1162: clean now carries `-e <sidecar-pattern>` excludes; match the
+      // semantic step (`clean -fd ...`), not the exact argv.
+      const cleanIdx = callOrder.findIndex((c) => c.startsWith('clean(-fd'));
       // #1051 FR-001: fetch call is now `fetch(origin,--prune)`; use startsWith
       // so this ordering assertion tracks the semantic step rather than the exact argv.
       const fetchIdx = callOrder.findIndex((c) => c.startsWith('fetch(origin'));
@@ -630,7 +687,9 @@ describe('RepoCheckout', () => {
       await checkout.switchBranch('/workspace/worker-1/octocat/repo', 'my-branch');
 
       const resetHeadIdx = callOrder.findIndex((c) => c === 'reset(--hard,HEAD)');
-      const cleanIdx = callOrder.findIndex((c) => c === 'clean(-fd)');
+      // #1162: clean now carries `-e <sidecar-pattern>` excludes; match the
+      // semantic step (`clean -fd ...`), not the exact argv.
+      const cleanIdx = callOrder.findIndex((c) => c.startsWith('clean(-fd'));
       // #1051 FR-001: fetch call is now `fetch(origin,--prune)`; use startsWith
       // so this ordering assertion tracks the semantic step rather than the exact argv.
       const fetchIdx = callOrder.findIndex((c) => c.startsWith('fetch(origin'));

--- a/packages/orchestrator/src/worker/__tests__/review-artifact.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/review-artifact.test.ts
@@ -266,3 +266,109 @@ describe('computeVerdict severity/verdict matrix (SC-002)', () => {
     });
   }
 });
+
+describe('synthetic findings + consumedReviewScopeHeadSha (schema back-compat)', () => {
+  let checkoutPath: string;
+
+  beforeEach(async () => {
+    checkoutPath = await fs.mkdtemp(path.join(os.tmpdir(), 'review-artifact-syn-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(checkoutPath, { recursive: true, force: true });
+  });
+
+  it('round-trips `synthetic` on a finding and `consumedReviewScopeHeadSha` on the artifact', async () => {
+    const artifact: ReviewArtifact = {
+      findings: [
+        finding({ file: 'pnpm test && pnpm build', title: 'validate phase failed', synthetic: 'validate' }),
+        finding({ file: '(pr-review)', title: 'External feedback from octocat', synthetic: 'external-body' }),
+        finding(),
+      ],
+      verdict: 'changes-required',
+      round: 2,
+      lastReviewedCommitSha: 'abc123',
+      remediationCount: 1,
+      markedReadyByEngine: false,
+      consumedReviewScopeHeadSha: 'merge456',
+    };
+    await writeReviewArtifact(checkoutPath, WORKFLOW_ID, artifact);
+    const read = await readReviewArtifact(checkoutPath, WORKFLOW_ID);
+    expect(read).toEqual(artifact);
+    expect(readReviewArtifactSync(checkoutPath, WORKFLOW_ID)).toEqual(artifact);
+    expect(read?.findings.map((f) => f.synthetic)).toEqual(['validate', 'external-body', undefined]);
+  });
+
+  it('parses a pre-existing sidecar lacking both fields (absent ⇒ undefined, not a parse failure)', async () => {
+    const filePath = getReviewArtifactPath(checkoutPath, WORKFLOW_ID);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        findings: [
+          {
+            severity: 'critical',
+            file: 'pnpm test && pnpm build',
+            title: 'validate phase failed',
+            detail: 'boom',
+            round: 1,
+            status: 'open',
+          },
+        ],
+        verdict: 'changes-required',
+        round: 1,
+        lastReviewedCommitSha: 'abc',
+      }),
+      'utf-8',
+    );
+    const read = await readReviewArtifact(checkoutPath, WORKFLOW_ID);
+    expect(read).not.toBeNull();
+    expect(read?.findings[0]?.synthetic).toBeUndefined();
+    expect(read?.consumedReviewScopeHeadSha).toBeUndefined();
+    expect('synthetic' in (read?.findings[0] ?? {})).toBe(false);
+  });
+
+  it('rejects an unknown synthetic kind (closed enum)', async () => {
+    const filePath = getReviewArtifactPath(checkoutPath, WORKFLOW_ID);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        findings: [{ ...finding(), synthetic: 'bogus' }],
+        verdict: 'changes-required',
+        round: 1,
+        lastReviewedCommitSha: 'abc',
+      }),
+      'utf-8',
+    );
+    expect(await readReviewArtifact(checkoutPath, WORKFLOW_ID)).toBeNull();
+  });
+
+  it('candidate findings never carry `synthetic` — the agent cannot self-tag a finding', async () => {
+    const candidatePath = getReviewCandidatePath(checkoutPath, WORKFLOW_ID);
+    await fs.mkdir(path.dirname(candidatePath), { recursive: true });
+    await fs.writeFile(
+      candidatePath,
+      JSON.stringify({
+        findings: [
+          {
+            severity: 'critical',
+            file: 'pnpm test && pnpm build',
+            title: 'validate phase failed',
+            detail: 'fixed',
+            status: 'resolved',
+            synthetic: 'validate',
+          },
+        ],
+      }),
+      'utf-8',
+    );
+    const candidates = await readCandidateFindings(checkoutPath, WORKFLOW_ID, 2);
+    expect(candidates).toHaveLength(1);
+    expect(candidates?.[0]).not.toHaveProperty('synthetic');
+    // The deterministic id still matches the engine-synthesized copy.
+    expect(candidates?.[0]?.id).toBe(
+      deriveFindingId('pnpm test && pnpm build', 'validate phase failed'),
+    );
+  });
+});

--- a/packages/orchestrator/src/worker/__tests__/review-charter.scoped.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/review-charter.scoped.test.ts
@@ -94,3 +94,51 @@ describe('#1164 review-charter — conflicted-path allowlist', () => {
     expect(charter).toContain('.generacy/review-findings-acme_widgets_42.json');
   });
 });
+
+describe('review-charter — scoped review combined with a verification pass', () => {
+  const verification = {
+    prompt: 'Verification pass — Round 2\n\nOpen findings to verify:\n\n- [critical] Prior open finding (src/a.ts)\n  still there',
+    deltaFiles: ['packages/orchestrator/src/a.ts'],
+  };
+
+  it('names the conflicted paths AND carries the still-open prior findings', () => {
+    const charter = buildReviewCharter({
+      ...BASE,
+      round: 2,
+      diffWindow: {
+        baseSha: 'base123',
+        headSha: 'head456',
+        conflictedPaths: ['packages/orchestrator/src/a.ts'],
+      },
+      verification,
+    });
+    expect(charter).toContain('- packages/orchestrator/src/a.ts');
+    expect(charter.toLowerCase()).toContain('inspect only these conflicted paths');
+    expect(charter.toLowerCase()).toContain('merged-in base branch');
+    // The still-open prior findings ride along (verification framing).
+    expect(charter).toContain('Prior open finding');
+    expect(charter).toContain('## Confirming an addressed finding');
+    // A scoped verification pass is neither a whole-PR review nor trivially flagged.
+    expect(charter).not.toContain('## Empty or trivial diff');
+    expect(charter).not.toContain('changes on this pull request branch');
+  });
+
+  it('falls back to the exact range when no conflictedPaths, still carrying open findings', () => {
+    const charter = buildReviewCharter({
+      ...BASE,
+      round: 2,
+      diffWindow: { baseSha: 'base123', headSha: 'head456' },
+      verification,
+    });
+    expect(charter).toContain('`base123..head456`');
+    expect(charter).toContain('Prior open finding');
+    expect(charter).toContain('## Confirming an addressed finding');
+  });
+
+  it('the verification pass tells the reviewer how to re-emit synthetic findings as resolved', () => {
+    const charter = buildReviewCharter({ ...BASE, round: 2, verification });
+    expect(charter).toContain('`[synthetic: validate]`');
+    expect(charter).toContain('`[synthetic: external-body]`');
+    expect(charter).toContain('`status: "resolved"`');
+  });
+});

--- a/packages/orchestrator/src/worker/__tests__/review-executor.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/review-executor.test.ts
@@ -669,5 +669,332 @@ describe('ReviewExecutor — engine recomputes the verdict (#1124)', () => {
       expect(prompt).toContain(`${sha0}..${sha1}`);
       expect(prompt.toLowerCase()).toContain('merge-conflict');
     });
+
+    // -----------------------------------------------------------------------
+    // Scope consumption: the scope is applied exactly once per `headSha`, even
+    // when a prior artifact exists (the real path: conflicts surface at validate
+    // entry, AFTER round 1 persisted the sidecar). Subsequent rounds fall back
+    // to the `lastReviewedCommitSha`..HEAD delta (#1164 cap-burn fix preserved).
+    // -----------------------------------------------------------------------
+    async function seedPriorArtifact(prior: unknown): Promise<void> {
+      const priorPath = getReviewArtifactPath(checkoutPath, workflowId);
+      await mkdir(path.dirname(priorPath), { recursive: true });
+      await writeFile(priorPath, JSON.stringify(prior), 'utf-8');
+    }
+
+    function makeScopedContextWithPaths(
+      github: GitHubClient,
+      reviewScope: { baseSha: string; headSha: string; conflictedPaths?: string[] },
+    ): WorkerContext {
+      return { ...makeContext(github), reviewScope } as WorkerContext;
+    }
+
+    it('applies the scope on a round with a PRIOR artifact: scoped + verification charter, allowlisted delta, consumption persisted, lastReviewedCommitSha = merge HEAD', async () => {
+      const [sha0, sha1] = await initRepoWithCommits(checkoutPath, 2);
+      await seedPriorArtifact({
+        findings: [
+          {
+            severity: 'critical',
+            file: 'src/a.ts',
+            title: 'Prior open finding',
+            detail: 'Raised in round 1.',
+            round: 1,
+            status: 'open',
+          },
+        ],
+        verdict: 'changes-required',
+        round: 1,
+        lastReviewedCommitSha: 'r1sha',
+        remediationCount: 1,
+      });
+      // The reviewer confirms the prior finding within the conflicted path.
+      const { launcher, launch } = makeLauncher({
+        findings: [
+          {
+            severity: 'critical',
+            file: 'src/a.ts',
+            title: 'Prior open finding',
+            detail: 'Resolved by the conflict resolution.',
+            status: 'resolved',
+          },
+        ],
+      });
+      // Raw parent-1 diff of the merge commit: brings upstream-only files too.
+      const getFilesChangedBetween = vi
+        .fn()
+        .mockResolvedValue(['upstream/only.ts', 'src/a.ts', 'f1.txt']);
+      const github = makeGithub({
+        getCurrentCommitSha: vi.fn().mockResolvedValue('mergehead'),
+        commitExistsInCheckout: vi.fn().mockResolvedValue(true),
+        getFilesChangedBetween,
+      });
+      const executor = new ReviewExecutor({
+        agentLauncher: launcher,
+        config: baseConfig,
+        settings: null,
+        logger,
+      });
+
+      const result = await executor.execute(
+        makeScopedContextWithPaths(github, {
+          baseSha: sha0!,
+          headSha: sha1!,
+          conflictedPaths: ['src/a.ts'],
+        }),
+      );
+      expect(result.success).toBe(true);
+
+      // The delta was the resolution window (not lastReviewedCommitSha..HEAD).
+      expect(getFilesChangedBetween).toHaveBeenCalledWith(sha0, sha1);
+      expect(getFilesChangedBetween).not.toHaveBeenCalledWith('r1sha', 'mergehead');
+
+      // Charter is BOTH scoped (conflicted paths, ignore upstream) AND a
+      // verification pass carrying the still-open prior finding.
+      expect(launch).toHaveBeenCalledTimes(1);
+      const prompt = launch.mock.calls[0]![0].intent.prompt as string;
+      expect(prompt).toContain('Conflicted paths:');
+      expect(prompt).toContain('- src/a.ts');
+      expect(prompt).not.toContain('- upstream/only.ts');
+      expect(prompt).toContain('Prior open finding');
+      expect(prompt).toContain('## Confirming an addressed finding');
+
+      const persisted = await readReviewArtifact(checkoutPath, workflowId);
+      expect(persisted!.round).toBe(2);
+      expect(persisted!.consumedReviewScopeHeadSha).toBe(sha1);
+      // Next round's delta base is the merge HEAD — never re-spans the upstream merge.
+      expect(persisted!.lastReviewedCommitSha).toBe('mergehead');
+      expect(persisted!.remediationCount).toBe(1);
+      expect(persisted!.findings[0]!.status).toBe('resolved');
+      expect(persisted!.verdict).toBe('clean');
+    });
+
+    it('does NOT re-apply a consumed scope: the next round is a plain delta verification pass', async () => {
+      const [sha0, sha1] = await initRepoWithCommits(checkoutPath, 2);
+      await seedPriorArtifact({
+        findings: [],
+        verdict: 'clean',
+        round: 2,
+        lastReviewedCommitSha: 'mergehead',
+        remediationCount: 0,
+        consumedReviewScopeHeadSha: sha1,
+      });
+      const { launcher, launch } = makeLauncher({ findings: [] });
+      const getFilesChangedBetween = vi.fn().mockResolvedValue(['src/b.ts']);
+      const github = makeGithub({
+        getCurrentCommitSha: vi.fn().mockResolvedValue('r3head'),
+        commitExistsInCheckout: vi.fn().mockResolvedValue(true),
+        getFilesChangedBetween,
+      });
+      const executor = new ReviewExecutor({
+        agentLauncher: launcher,
+        config: baseConfig,
+        settings: null,
+        logger,
+      });
+
+      await executor.execute(
+        makeScopedContextWithPaths(github, {
+          baseSha: sha0!,
+          headSha: sha1!,
+          conflictedPaths: ['src/a.ts'],
+        }),
+      );
+
+      // Delta spans the remediation commits (lastReviewed..HEAD), not the scope.
+      expect(getFilesChangedBetween).toHaveBeenCalledWith('mergehead', 'r3head');
+      expect(getFilesChangedBetween).not.toHaveBeenCalledWith(sha0, sha1);
+      const prompt = launch.mock.calls[0]![0].intent.prompt as string;
+      expect(prompt).not.toContain('Conflicted paths:');
+      expect(prompt).not.toContain(`${sha0}..${sha1}`);
+      expect(prompt).toContain('- src/b.ts');
+
+      const persisted = await readReviewArtifact(checkoutPath, workflowId);
+      expect(persisted!.round).toBe(3);
+      expect(persisted!.consumedReviewScopeHeadSha).toBe(sha1);
+    });
+
+    it('applies a NEW scope (different headSha) even though an older one was consumed', async () => {
+      const [, sha1, sha2] = await initRepoWithCommits(checkoutPath, 3);
+      await seedPriorArtifact({
+        findings: [],
+        verdict: 'clean',
+        round: 2,
+        lastReviewedCommitSha: sha1,
+        remediationCount: 0,
+        consumedReviewScopeHeadSha: sha1,
+      });
+      const { launcher, launch } = makeLauncher({ findings: [] });
+      const getFilesChangedBetween = vi.fn().mockResolvedValue(['f2.txt']);
+      const github = makeGithub({
+        getCurrentCommitSha: vi.fn().mockResolvedValue(sha2),
+        commitExistsInCheckout: vi.fn().mockResolvedValue(true),
+        getFilesChangedBetween,
+      });
+      const executor = new ReviewExecutor({
+        agentLauncher: launcher,
+        config: baseConfig,
+        settings: null,
+        logger,
+      });
+
+      await executor.execute(makeScopedContextWithPaths(github, { baseSha: sha1!, headSha: sha2! }));
+
+      expect(getFilesChangedBetween).toHaveBeenCalledWith(sha1, sha2);
+      const prompt = launch.mock.calls[0]![0].intent.prompt as string;
+      expect(prompt).toContain(`${sha1}..${sha2}`);
+      const persisted = await readReviewArtifact(checkoutPath, workflowId);
+      expect(persisted!.consumedReviewScopeHeadSha).toBe(sha2);
+    });
+
+    it('empty window WITH a prior artifact does not short-circuit — runs the delta verification pass and records consumption', async () => {
+      const [sha] = await initRepoWithCommits(checkoutPath, 1);
+      await seedPriorArtifact({
+        findings: [
+          {
+            severity: 'critical',
+            file: 'src/a.ts',
+            title: 'Prior open finding',
+            detail: 'Raised in round 1.',
+            round: 1,
+            status: 'open',
+          },
+        ],
+        verdict: 'changes-required',
+        round: 1,
+        lastReviewedCommitSha: 'r1sha',
+        remediationCount: 0,
+      });
+      const { launcher, launch } = makeLauncher({ findings: [] });
+      const getFilesChangedBetween = vi.fn().mockResolvedValue(['src/b.ts']);
+      const github = makeGithub({
+        getCurrentCommitSha: vi.fn().mockResolvedValue('r2head'),
+        commitExistsInCheckout: vi.fn().mockResolvedValue(true),
+        getFilesChangedBetween,
+      });
+      const executor = new ReviewExecutor({
+        agentLauncher: launcher,
+        config: baseConfig,
+        settings: null,
+        logger,
+      });
+
+      const result = await executor.execute(
+        makeScopedContextWithPaths(github, { baseSha: sha!, headSha: sha! }),
+      );
+      expect(result.success).toBe(true);
+      // A short-circuit here would leave the changes-required prior untouched
+      // and re-trigger remediate every round; instead the real pass runs.
+      expect(launch).toHaveBeenCalledTimes(1);
+      expect(getFilesChangedBetween).toHaveBeenCalledWith('r1sha', 'r2head');
+      const persisted = await readReviewArtifact(checkoutPath, workflowId);
+      expect(persisted!.round).toBe(2);
+      expect(persisted!.consumedReviewScopeHeadSha).toBe(sha);
+      // Anti-vanish still holds: the omitted finding stays open.
+      expect(persisted!.findings[0]!.status).toBe('open');
+    });
+  });
+
+  describe('synthetic findings resolve on re-emission (validate-origin / body-only external)', () => {
+    async function seedPriorArtifact(prior: unknown): Promise<void> {
+      const priorPath = getReviewArtifactPath(checkoutPath, workflowId);
+      await mkdir(path.dirname(priorPath), { recursive: true });
+      await writeFile(priorPath, JSON.stringify(prior), 'utf-8');
+    }
+
+    it('a re-emitted synthetic:validate finding resolves although its "file" (the command) is never in the delta', async () => {
+      const command = 'pnpm test && pnpm build';
+      await seedPriorArtifact({
+        findings: [
+          {
+            severity: 'critical',
+            file: command,
+            title: 'validate phase failed',
+            detail: 'FAIL src/foo.test.ts',
+            round: 2,
+            status: 'open',
+            synthetic: 'validate',
+          },
+        ],
+        verdict: 'changes-required',
+        round: 2,
+        lastReviewedCommitSha: 'failsha',
+        remediationCount: 1,
+      });
+      const { launcher, launch } = makeLauncher({
+        findings: [
+          {
+            severity: 'critical',
+            file: command,
+            title: 'validate phase failed',
+            detail: 'The remediation fixed the failing test.',
+            status: 'resolved',
+          },
+        ],
+      });
+      const github = makeGithub({
+        getCurrentCommitSha: vi.fn().mockResolvedValue('fixsha'),
+        commitExistsInCheckout: vi.fn().mockResolvedValue(true),
+        getFilesChangedBetween: vi.fn().mockResolvedValue(['src/foo.ts']),
+      });
+      const executor = new ReviewExecutor({
+        agentLauncher: launcher,
+        config: baseConfig,
+        settings: null,
+        logger,
+      });
+
+      await executor.execute(makeContext(github));
+
+      // The charter surfaced the synthetic finding with its tag + instructions.
+      const prompt = launch.mock.calls[0]![0].intent.prompt as string;
+      expect(prompt).toContain('[synthetic: validate]');
+      expect(prompt).toContain('validate phase failed');
+
+      const persisted = await readReviewArtifact(checkoutPath, workflowId);
+      expect(persisted!.round).toBe(3);
+      expect(persisted!.findings).toHaveLength(1);
+      expect(persisted!.findings[0]!.status).toBe('resolved');
+      expect(persisted!.findings[0]!.synthetic).toBe('validate');
+      expect(persisted!.verdict).toBe('clean');
+      expect(persisted!.remediationCount).toBe(1);
+    });
+
+    it('an omitted synthetic finding is still carried forward open (anti-vanish)', async () => {
+      await seedPriorArtifact({
+        findings: [
+          {
+            severity: 'critical',
+            file: '(pr-review)',
+            title: 'External feedback from octocat',
+            detail: 'Do X',
+            round: 1,
+            status: 'open',
+            synthetic: 'external-body',
+          },
+        ],
+        verdict: 'changes-required',
+        round: 1,
+        lastReviewedCommitSha: 'seedsha',
+        remediationCount: 0,
+      });
+      const { launcher } = makeLauncher({ findings: [] });
+      const github = makeGithub({
+        getCurrentCommitSha: vi.fn().mockResolvedValue('r2head'),
+        commitExistsInCheckout: vi.fn().mockResolvedValue(true),
+        getFilesChangedBetween: vi.fn().mockResolvedValue(['src/x.ts']),
+      });
+      const executor = new ReviewExecutor({
+        agentLauncher: launcher,
+        config: baseConfig,
+        settings: null,
+        logger,
+      });
+
+      await executor.execute(makeContext(github));
+
+      const persisted = await readReviewArtifact(checkoutPath, workflowId);
+      expect(persisted!.findings[0]!.status).toBe('open');
+      expect(persisted!.verdict).toBe('changes-required');
+    });
   });
 });

--- a/packages/orchestrator/src/worker/__tests__/seed-aware-review-executor.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/seed-aware-review-executor.test.ts
@@ -118,6 +118,11 @@ describe('SeedAwareReviewExecutor (#1130)', () => {
     expect(bodyFinding?.file).toBe('(pr-review)');
     const inlineFinding = artifact?.findings.find((f) => f.file === 'src/a.ts');
     expect(inlineFinding?.line).toBe(12);
+    // The body-only finding is tagged synthetic so the convergence merge can
+    // resolve it on re-emission (its placeholder file is never in a delta); the
+    // path-anchored finding stays a real finding.
+    expect(bodyFinding?.synthetic).toBe('external-body');
+    expect(inlineFinding?.synthetic).toBeUndefined();
 
     // Consume-once: seed deleted so convergence rounds delegate.
     expect(await readExternalFeedbackSeed(checkoutPath, WORKFLOW_ID)).toBeNull();

--- a/packages/orchestrator/src/worker/ci-merge-readiness.ts
+++ b/packages/orchestrator/src/worker/ci-merge-readiness.ts
@@ -16,7 +16,19 @@ export interface CiReadiness {
  * while CI was still `pending` — the caller pauses with `waiting-for:ci`
  * (Q1-C / FR-004) rather than declaring green.
  */
-export type CiWaitOutcome = { kind: 'green' | 'not-passed' | 'timeout' };
+export type CiWaitOutcome = {
+  kind: 'green' | 'not-passed' | 'timeout';
+  /**
+   * The aggregated verdict behind `kind` (`pending` on `timeout`). Surfaced so
+   * the pause comment can report the REAL verdict rather than a canned reason.
+   */
+  verdict: CiVerdict;
+  /**
+   * Which readout produced the verdict. `undefined` only when every readout
+   * threw before the wait window elapsed (timeout with no successful poll).
+   */
+  source?: CiReadiness['source'];
+};
 
 export interface EvaluateCiReadinessParams {
   github: GitHubClient;
@@ -32,14 +44,14 @@ export interface EvaluateCiReadinessParams {
  * verdict. Never declares green on `pending` (FR-004). A thrown readout
  * propagates — `waitForCiGreen` treats it as transient.
  *
- * #1157 FR-007 (Q5→C): the `actions/runs` fallback only enumerates
- * GitHub-Actions workflow runs for the branch and is blind to third-party
- * required checks (external status contexts), so a `green` aggregated from it
- * may be a false green. When `source === 'actions-runs'` (the primary
- * `check-runs` path failed → token likely lacks `checks:read`) a would-be
- * `green` is failed-closed to `not-passed`, routing into the recoverable red-CI
- * pause rather than leaving a false green live. `pending`/`not-passed` and all
- * `check-runs`-sourced verdicts are returned unchanged.
+ * Source trust: the `actions/runs` fallback (used when the primary
+ * `check-runs` readout fails — typically a token lacking `checks:read`) only
+ * enumerates GitHub-Actions workflow runs for the branch and is blind to
+ * third-party required checks (external status contexts). A `green` aggregated
+ * from it is TRUSTED — the blind spot is a documented limitation, logged at
+ * `warn` — because failing it closed (the #1157 FR-007 downgrade) made every
+ * validate on such a token pause with a "CI is red" reason while CI was green,
+ * leaving the merge gate unusable.
  */
 export async function evaluateCiReadiness(
   params: EvaluateCiReadinessParams,
@@ -51,14 +63,14 @@ export async function evaluateCiReadiness(
     headSha,
     branch,
   );
-  let verdict = aggregateCiVerdict(runs);
+  const verdict = aggregateCiVerdict(runs);
   if (source === 'actions-runs' && verdict === 'green') {
     logger?.warn(
       { owner, repo, headSha, runCount: runs.length },
-      '#1157 FR-007: actions/runs fallback cannot see third-party required checks; ' +
-        'downgrading would-be green to not-passed (checks:read likely missing)',
+      'CI green sourced from the actions/runs fallback (check-runs unavailable — ' +
+        'token likely lacks checks:read); third-party required checks are not ' +
+        'visible to this readout. Trusting green.',
     );
-    verdict = 'not-passed';
   }
   return {
     verdict,
@@ -106,15 +118,17 @@ export async function waitForCiGreen(
 
   const start = now();
   let attempt = 0;
+  let lastSource: CiReadiness['source'] | undefined;
 
   for (;;) {
     try {
       const readiness = await evaluateCiReadiness({ ...readinessParams, logger });
+      lastSource = readiness.source;
       if (readiness.verdict === 'green') {
-        return { kind: 'green' };
+        return { kind: 'green', verdict: 'green', source: readiness.source };
       }
       if (readiness.verdict === 'not-passed') {
-        return { kind: 'not-passed' };
+        return { kind: 'not-passed', verdict: 'not-passed', source: readiness.source };
       }
       // pending → keep waiting
     } catch (err) {
@@ -126,7 +140,7 @@ export async function waitForCiGreen(
 
     const elapsed = now() - start;
     if (elapsed >= ciWaitTimeoutMs) {
-      return { kind: 'timeout' };
+      return { kind: 'timeout', verdict: 'pending', source: lastSource };
     }
 
     const delay = Math.min(backoffForAttempt(attempt), ciWaitTimeoutMs - elapsed);

--- a/packages/orchestrator/src/worker/claude-cli-worker.ts
+++ b/packages/orchestrator/src/worker/claude-cli-worker.ts
@@ -16,7 +16,7 @@ import {
   resolveWorkflowOverrides,
 } from './config.js';
 import { PhaseResolver } from './phase-resolver.js';
-import { LabelManager } from './label-manager.js';
+import { LabelManager, resolveResumeRetainSuffixes } from './label-manager.js';
 import { StageCommentManager } from './stage-comment-manager.js';
 import { GateChecker } from './gate-checker.js';
 import { CliSpawner } from './cli-spawner.js';
@@ -886,7 +886,13 @@ export class ClaudeCliWorker {
 
       // 7b. On resume, clean up gate labels before starting the phase loop
       if (item.command === 'continue') {
-        await labelManager.onResumeStart();
+        // Retain set: only gate completions the resumed phase consumes itself
+        // (remediation-limit always; implementation-review only under the
+        // CI-merge gate). Everything else is stripped so a resumed phase can
+        // pause again (clarify follow-ups, ci re-pause).
+        await labelManager.onResumeStart({
+          retainCompletedSuffixes: resolveResumeRetainSuffixes(this.config),
+        });
       }
 
       // 7c. Handle tasks-review gate resume for epics (T015)

--- a/packages/orchestrator/src/worker/fail-then-pass.ts
+++ b/packages/orchestrator/src/worker/fail-then-pass.ts
@@ -25,9 +25,9 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { mkdtemp, mkdir, copyFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, copyFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { join, dirname, relative } from 'node:path';
 
 const execFileAsync = promisify(execFile);
 
@@ -47,34 +47,43 @@ const BASE_INSTALL_TIMEOUT_MS = 5 * 60_000;
 const BASE_TEST_TIMEOUT_MS = 5 * 60_000;
 
 /**
- * Conservative infra-failure signature (FR-004, FR-005; Q2=A pre-collection only).
- *
- * Returns `true` ONLY when the test run failed for an infrastructure reason
- * *before any test was collected/run* — vitest resolved zero test files, or a
- * module/dist-resolution error surfaced before a test executed. Such a run is a
- * broken base/branch env, not evidence about the bug, so the caller maps it to a
- * non-blocking `skip` rather than a `base-passed`/`branch-failed` finding.
- *
- * Returns `false` for any output showing a test was collected and then failed
- * (`FAIL`, per-test `×`/`✓` lines, `Tests  N failed`/`N passed`) and for anything
- * ambiguous — bias to a genuine outcome so a real failure is never masked.
+ * Exit codes that mean the runner itself never started: 127 is the shell's
+ * "command not found"; 254 is pnpm's `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` for
+ * `Command "vitest" not found` (verified against pnpm 9.15 — a root
+ * `pnpm vitest run` in a workspace where vitest is only a package devDependency).
  */
-export function isInfraFailure(output: string): boolean {
-  // A collected-and-run test is a genuine outcome — never infra.
-  const ranTests =
-    /\bFAIL\b/.test(output) ||
-    /\bPASS\b/.test(output) ||
-    /Tests\s+\d+\s+(failed|passed)/.test(output) ||
-    /Test Files\s+\d+\s+(failed|passed)/.test(output) ||
-    /[×✓]\s/.test(output);
-  if (ranTests) {
-    return false;
-  }
+const RUNNER_NOT_FOUND_EXIT_CODES = new Set([127, 254]);
 
-  // Pre-collection signatures: vitest found nothing to run, or a module/dist
-  // resolution error surfaced before any test executed.
+/**
+ * The runner (vitest / pnpm) never started (FR-005).
+ *
+ * `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` on its own is deliberately NOT a
+ * signature: `pnpm --filter <pkg> exec vitest run` prints that same code for a
+ * genuine test failure (`Command failed with exit code 1: vitest run …`). Only
+ * the `Command "vitest" not found` form means the runner was absent.
+ * `No projects matched the filters` is pnpm's exit-0 no-op for an unknown
+ * `--filter` target — a silent false pass, so it is infra too.
+ */
+export function isRunnerNotFound(output: string, exitCode?: number): boolean {
   return (
-    /No test files found/.test(output) ||
+    /Command "vitest" not found/.test(output) ||
+    /\bvitest: (command )?not found\b/.test(output) ||
+    // Shell-level not-found must name the runner on the same line — a bare
+    // "command not found" can appear inside a genuine test's assertion diff.
+    /^[^\n]*\bvitest\b[^\n]*\bcommand not found\b/m.test(output) ||
+    /No projects matched the filters/.test(output) ||
+    (exitCode !== undefined && RUNNER_NOT_FOUND_EXIT_CODES.has(exitCode))
+  );
+}
+
+/** vitest started but collected zero tests (nothing was exercised). */
+function isZeroTestsCollected(output: string): boolean {
+  return /No test files found/.test(output) || /Tests\s+no tests\b/.test(output);
+}
+
+/** A module / dist-resolution (load) error surfaced somewhere in the output. */
+function hasModuleResolutionError(output: string): boolean {
+  return (
     /Cannot find module/.test(output) ||
     /Failed to resolve import/.test(output) ||
     /Failed to load url/.test(output) ||
@@ -83,15 +92,89 @@ export function isInfraFailure(output: string): boolean {
 }
 
 /**
- * Short, log-safe discriminator for the matched infra signature. Assumes
- * `isInfraFailure(output)` already returned `true`; returns `unknown` otherwise.
+ * At least one COLLECTED test failed — the only thing that makes a non-zero exit
+ * a genuine verdict about the bug. vitest 3 prints a per-test `×` line, a
+ * per-test ` FAIL  <file> > <name>` block, and a `Tests  N failed` summary; a
+ * suite that failed to load prints none of these (it prints `Tests  no tests`).
  */
-function infraSignature(output: string): string {
+function hasTestLevelFailure(output: string): boolean {
+  return (
+    /^\s*[×✗]\s/m.test(output) ||
+    /Tests\s+\d+\s+failed/.test(output) ||
+    /\bFAIL\s+\S+\s+>\s/.test(output)
+  );
+}
+
+/**
+ * vitest's suite-level (collection) failure line, ` FAIL  <file> [ <file> ]`,
+ * as opposed to the per-test ` FAIL  <file> > <test name>` line. A workspace
+ * project prefix (` FAIL  |proj| file [ file ]`) is tolerated.
+ */
+function hasSuiteLevelFailure(output: string): boolean {
+  return /\bFAIL\s+.*\[\s*[^\]\s]+\s*\]/.test(output);
+}
+
+/** Any evidence that a test actually ran (passing or failing). */
+function hasRunEvidence(output: string): boolean {
+  return (
+    /\bFAIL\b/.test(output) ||
+    /\bPASS\b/.test(output) ||
+    /Tests\s+\d+\s+(failed|passed)/.test(output) ||
+    /Test Files\s+\d+\s+(failed|passed)/.test(output) ||
+    /[×✓✗]\s/.test(output)
+  );
+}
+
+/**
+ * Infra-failure classifier (FR-004, FR-005; Q2=A pre-collection only).
+ *
+ * Returns `true` ONLY when the run is not evidence about the bug because no
+ * test was actually exercised. Rules, in order:
+ *
+ *   1. The runner never started (`Command "vitest" not found`, `command not
+ *      found`, exit 127/254, `No projects matched the filters`) → infra.
+ *   2. vitest collected zero tests (`No test files found`, `Tests  no tests`)
+ *      → infra. This fires regardless of the `Test Files  N failed` summary,
+ *      which vitest also prints for a suite that failed to LOAD.
+ *   3. At least one collected test failed (`×`/`✗` test line, `Tests  N failed`,
+ *      ` FAIL  <file> > <name>`) → genuine, never infra. A run mixing a broken
+ *      suite with a real test failure is still a real failure.
+ *   4. A suite-level ` FAIL  <file> [ <file> ]` line co-occurring with a
+ *      module/dist-resolution error (`Cannot find module`, `Failed to load url`,
+ *      `ERR_MODULE_NOT_FOUND`, `Failed to resolve import`) → infra. This is
+ *      what a test importing an unbuilt `../dist/…` looks like in vitest 3.
+ *   5. A bare module-resolution error with no evidence any test ran → infra.
+ *   6. Anything else (including anything ambiguous) → genuine outcome, so a
+ *      real failure is never masked.
+ *
+ * Before this ordering, rule 3's old form (`\bFAIL\b` / `Test Files N failed`
+ * ⇒ "ran tests") short-circuited ahead of the resolution signatures, so every
+ * dist-resolving monorepo classified a broken base env as a genuine base
+ * failure and the proof degenerated to "does the branch pass".
+ */
+export function isInfraFailure(output: string, exitCode?: number): boolean {
+  if (isRunnerNotFound(output, exitCode)) return true;
+  if (isZeroTestsCollected(output)) return true;
+  if (hasTestLevelFailure(output)) return false;
+  if (hasSuiteLevelFailure(output) && hasModuleResolutionError(output)) return true;
+  if (hasModuleResolutionError(output) && !hasRunEvidence(output)) return true;
+  return false;
+}
+
+/**
+ * Short, log-safe discriminator for the matched infra signature. Assumes
+ * `isInfraFailure(output, exitCode)` already returned `true`; returns `unknown`
+ * otherwise. Ordered to mirror the classifier so the reported reason is the
+ * rule that actually fired.
+ */
+function infraSignature(output: string, exitCode?: number): string {
+  if (isRunnerNotFound(output, exitCode)) return 'vitest-not-found';
   if (/No test files found/.test(output)) return 'no-test-files';
   if (/Cannot find module/.test(output)) return 'cannot-find-module';
   if (/Failed to resolve import/.test(output)) return 'failed-to-resolve-import';
   if (/Failed to load url/.test(output)) return 'failed-to-load-url';
   if (/ERR_MODULE_NOT_FOUND/.test(output)) return 'err-module-not-found';
+  if (/Tests\s+no tests\b/.test(output)) return 'no-tests-collected';
   return 'unknown';
 }
 
@@ -119,22 +202,39 @@ interface TestRunOutcome {
   output: string;
   /** FR-006: true iff the run was killed by BASE_TEST_TIMEOUT_MS (not an abort). */
   timedOut: boolean;
+  /** Process exit code when the run exited non-zero (undefined on exit 0 / kill). */
+  exitCode?: number;
+}
+
+type RunVerdict = 'pass' | 'fail' | 'infra' | 'timeout';
+
+/**
+ * Collapse a run into the verdict the proof reasons about. `infra` is checked
+ * BEFORE the exit code so a run that exited 0 without exercising anything (e.g.
+ * `passWithNoTests`, or pnpm's exit-0 "No projects matched") can never be read
+ * as a `pass` — on the base side that would be a phantom `base-passed`, and a
+ * base `skip` must never count as fail-on-base satisfied either.
+ */
+function verdictOf(outcome: TestRunOutcome): RunVerdict {
+  if (outcome.timedOut) return 'timeout';
+  if (isInfraFailure(outcome.output, outcome.exitCode)) return 'infra';
+  return outcome.passed ? 'pass' : 'fail';
 }
 
 /**
- * Run the given test files with vitest in `cwd`. Never throws — a non-zero exit
- * (test failure) is captured as `{ passed: false }`. A run that overruns
+ * Spawn one `pnpm <args>` in `cwd`. Never throws on a non-zero exit — it is
+ * captured as `{ passed: false, exitCode }`. A run that overruns
  * BASE_TEST_TIMEOUT_MS is killed and reported as `{ timedOut: true }` (FR-006);
  * an `AbortError` from the caller's phase `signal` propagates (must not be
  * converted into a spurious finding).
  */
-async function runTests(
+async function spawnPnpm(
   cwd: string,
-  files: string[],
-  signal: AbortSignal,
+  args: string[],
+  signal: AbortSignal
 ): Promise<TestRunOutcome> {
   try {
-    const { stdout, stderr } = await execFileAsync('pnpm', ['vitest', 'run', ...files], {
+    const { stdout, stderr } = await execFileAsync('pnpm', args, {
       cwd,
       signal,
       timeout: BASE_TEST_TIMEOUT_MS,
@@ -146,7 +246,7 @@ async function runTests(
       stderr?: string;
       message?: string;
       killed?: boolean;
-      code?: string;
+      code?: string | number | null;
       name?: string;
     };
     // An AbortError from the phase signal must propagate — it means the whole
@@ -156,8 +256,103 @@ async function runTests(
     }
     const output = `${e.stdout ?? ''}\n${e.stderr ?? ''}`.trim() || (e.message ?? String(err));
     const timedOut = e.killed === true || e.code === 'ETIMEDOUT';
-    return { passed: false, output, timedOut };
+    const exitCode = typeof e.code === 'number' ? e.code : undefined;
+    return { passed: false, output, timedOut, exitCode };
   }
+}
+
+/**
+ * Group repo-relative test files by the package that owns them: the nearest
+ * ancestor directory (walking up from the file, stopping at `root`) holding a
+ * `package.json`. Files owned by the root itself are dropped — the root has
+ * already been shown to have no vitest, so re-running there is pointless.
+ * Returns `[packageDir (repo-relative), files (package-relative)]` pairs in
+ * first-seen order.
+ */
+async function groupByOwningPackage(
+  root: string,
+  files: string[]
+): Promise<Array<{ packageDir: string; files: string[] }>> {
+  const groups = new Map<string, string[]>();
+  for (const file of files) {
+    let dir = dirname(file);
+    let owner: string | undefined;
+    while (dir !== '' && dir !== '.') {
+      try {
+        await stat(join(root, dir, 'package.json'));
+        owner = dir;
+        break;
+      } catch {
+        /* not here — keep walking up */
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    if (owner === undefined) continue;
+    const list = groups.get(owner) ?? [];
+    list.push(relative(owner, file));
+    groups.set(owner, list);
+  }
+  return [...groups.entries()].map(([packageDir, pkgFiles]) => ({
+    packageDir,
+    files: pkgFiles,
+  }));
+}
+
+/**
+ * Run the given test files with vitest in `cwd`.
+ *
+ * First tries the root `pnpm vitest run <files>`. When that fails because the
+ * root has no vitest (a workspace where vitest is only a package devDependency;
+ * pnpm prints `Command "vitest" not found`, exit 254), the files are re-run
+ * through the package that owns each of them — `pnpm --dir <pkg> exec vitest
+ * run <package-relative files>` — which passes vitest's own exit code straight
+ * through. (`--filter <name>` is deliberately NOT used: it wraps a genuine
+ * failure in `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` and exits 0 for an unknown
+ * name.) If no owning package can be found the root outcome is returned, which
+ * the caller classifies as an infra `skip` (`vitest-not-found`), never as a
+ * `branch-failed`/`base-passed` verdict.
+ */
+async function runTests(
+  cwd: string,
+  files: string[],
+  signal: AbortSignal
+): Promise<TestRunOutcome> {
+  const root = await spawnPnpm(cwd, ['vitest', 'run', ...files], signal);
+  if (root.timedOut || !isRunnerNotFound(root.output, root.exitCode)) {
+    return root;
+  }
+
+  const groups = await groupByOwningPackage(cwd, files);
+  if (groups.length === 0) {
+    return root;
+  }
+
+  const outcomes: TestRunOutcome[] = [];
+  for (const group of groups) {
+    const outcome = await spawnPnpm(
+      cwd,
+      ['--dir', group.packageDir, 'exec', 'vitest', 'run', ...group.files],
+      signal
+    );
+    if (outcome.timedOut) {
+      return outcome;
+    }
+    outcomes.push({
+      ...outcome,
+      output: `[pnpm --dir ${group.packageDir} exec vitest run ${group.files.join(' ')}]\n${
+        outcome.output
+      }`,
+    });
+  }
+  const firstFailure = outcomes.find((o) => !o.passed);
+  return {
+    passed: firstFailure === undefined,
+    output: outcomes.map((o) => o.output).join('\n\n'),
+    timedOut: false,
+    exitCode: firstFailure?.exitCode,
+  };
 }
 
 /**
@@ -296,14 +491,21 @@ export async function runFailThenPass(input: FailThenPassInput): Promise<FailThe
 
   // A base run that timed out or infra-failed is a broken base env, never a
   // verdict about the bug — skip rather than report `base-passed` (FR-004/006).
-  if (!baseOutcome.passed && baseOutcome.timedOut) {
+  // `verdictOf` checks infra BEFORE the exit code, so a base `skip` is reported
+  // as a skip with its reason and never silently counts as fail-on-base
+  // satisfied (nor, on an exit-0 no-op run, as base-passed).
+  const baseVerdict = verdictOf(baseOutcome);
+  if (baseVerdict === 'timeout') {
     return { kind: 'skip', reason: 'timeout' };
   }
-  if (!baseOutcome.passed && isInfraFailure(baseOutcome.output)) {
-    return { kind: 'skip', reason: `infra:${infraSignature(baseOutcome.output)} at base ref` };
+  if (baseVerdict === 'infra') {
+    return {
+      kind: 'skip',
+      reason: `infra:${infraSignature(baseOutcome.output, baseOutcome.exitCode)} at base ref`,
+    };
   }
 
-  if (baseOutcome.passed) {
+  if (baseVerdict === 'pass') {
     return {
       kind: 'fail',
       reason: 'base-passed',
@@ -314,16 +516,20 @@ export async function runFailThenPass(input: FailThenPassInput): Promise<FailThe
   }
 
   const branchOutcome = await runTests(checkoutPath, effectiveTestFiles, signal);
-  // A branch run that timed out or infra-failed (e.g. no root vitest → zero
-  // tests collected, FR-005) is a broken branch env, never a `branch-failed`
-  // verdict — skip.
-  if (!branchOutcome.passed && branchOutcome.timedOut) {
+  // A branch run that timed out or infra-failed (e.g. no root vitest and no
+  // owning package with vitest → runner never started, FR-005) is a broken
+  // branch env, never a `branch-failed` verdict — skip.
+  const branchVerdict = verdictOf(branchOutcome);
+  if (branchVerdict === 'timeout') {
     return { kind: 'skip', reason: 'timeout' };
   }
-  if (!branchOutcome.passed && isInfraFailure(branchOutcome.output)) {
-    return { kind: 'skip', reason: `infra:${infraSignature(branchOutcome.output)} on branch` };
+  if (branchVerdict === 'infra') {
+    return {
+      kind: 'skip',
+      reason: `infra:${infraSignature(branchOutcome.output, branchOutcome.exitCode)} on branch`,
+    };
   }
-  if (!branchOutcome.passed) {
+  if (branchVerdict === 'fail') {
     return {
       kind: 'fail',
       reason: 'branch-failed',

--- a/packages/orchestrator/src/worker/label-manager.ts
+++ b/packages/orchestrator/src/worker/label-manager.ts
@@ -86,6 +86,45 @@ export function isHumanGateCompletion(label: string): boolean {
 }
 
 /**
+ * Options for `LabelManager.onResumeStart()`.
+ */
+export interface ResumeStartOptions {
+  /**
+   * Gate suffixes (the "X" in `completed:X`) whose completion label must
+   * SURVIVE the resume strip because the resumed phase consumes it itself.
+   * Every other `completed:<X>` paired with a `waiting-for:<X>` is stripped.
+   * Defaults to `DEFAULT_RESUME_RETAIN_SUFFIXES`.
+   */
+  retainCompletedSuffixes?: readonly string[];
+}
+
+/**
+ * Gate completions that always survive the resume strip: the
+ * `on-remediation-limit` gate's "already satisfied" branch in the phase loop
+ * consumes `completed:remediation-limit` (resets the counter AND removes the
+ * label itself), so stripping it here would discard the operator's answer.
+ */
+export const DEFAULT_RESUME_RETAIN_SUFFIXES: readonly string[] = ['remediation-limit'];
+
+/**
+ * Compute the resume-strip retain set from worker config. Rule:
+ *   - `remediation-limit` — always (consumed + removed by the reset branch).
+ *   - `implementation-review` — ONLY when `ciMergeGateEnabled`: the relocated
+ *     post-validate gate's terminal no-op resume reads
+ *     `completed:validate` + `completed:implementation-review` and would
+ *     re-run `validate` if the answer were stripped.
+ * Everything else (`ci`, `clarification`, `sibling-review`, the artifact
+ * review gates, …) is stripped so the resumed phase can pause again cleanly.
+ */
+export function resolveResumeRetainSuffixes(
+  config: { ciMergeGateEnabled?: boolean },
+): string[] {
+  const retain = [...DEFAULT_RESUME_RETAIN_SUFFIXES];
+  if (config.ciMergeGateEnabled) retain.push('implementation-review');
+  return retain;
+}
+
+/**
  * Callback invoked from `onGateHit` after a pause label pair
  * (`waiting-for:<gate>` + `agent:paused`) has been successfully applied.
  * Used by callers wired to `PhaseTrackerService` to invalidate the paired
@@ -333,8 +372,22 @@ export class LabelManager {
    * Removes stale `waiting-for:*` and `agent:paused` labels that were set
    * when the workflow paused at a gate, and adds `agent:in-progress` to
    * reflect the active workflow state.
+   *
+   * Also strips the paired `completed:<X>` for every `waiting-for:<X>` present
+   * so re-entering the phase can re-activate the gate if needed (e.g. a
+   * resumed `clarify` that asks follow-up questions must pause again; a
+   * re-run `validate` that re-pauses on `waiting-for:ci` must not leave a
+   * stale `completed:ci` for the monitor to pair forever).
+   *
+   * `retainCompletedSuffixes` is the explicit, caller-supplied exception set:
+   * `completed:<X>` for X in that set survives the strip because the resumed
+   * phase consumes it itself (see `resolveResumeRetainSuffixes`). Defaults to
+   * `DEFAULT_RESUME_RETAIN_SUFFIXES` (`remediation-limit` only).
    */
-  async onResumeStart(): Promise<void> {
+  async onResumeStart(options: ResumeStartOptions = {}): Promise<void> {
+    const retain = new Set<string>(
+      options.retainCompletedSuffixes ?? DEFAULT_RESUME_RETAIN_SUFFIXES,
+    );
     await this.retryWithBackoff(async () => {
       await this.ensureRepoLabelsExist();
       const issue = await this.github.getIssue(this.owner, this.repo, this.issueNumber);
@@ -346,30 +399,32 @@ export class LabelManager {
         (l) => l.startsWith('waiting-for:') || l === 'agent:paused',
       );
 
-      // Also remove completed: labels for gates being resumed, so re-entering
-      // the phase can re-activate the gate if needed (e.g., follow-up
-      // clarification questions require another pause cycle).
-      //
-      // #1154 FR-001: human-answer gate completions (`completed:<X>` where X is a
-      // human-gate suffix) MUST survive the resume strip. The remediation-limit
-      // and on-ci-green implementation-review gates re-evaluate AT the resumed
-      // phase and read the surviving `completed:<X>` — stripping it here silently
-      // discards the operator's answer and re-parks the workflow. `isHumanGateCompletion`
-      // + `HUMAN_GATE_SUFFIXES` already exist for exactly this purpose; consult
-      // them so the strip is a no-op for gate completions but still clears the
-      // stale `waiting-for:*` / `agent:paused` labels below.
+      // Strip the paired completed:<X> for each waiting-for:<X> unless the
+      // caller asked to retain it. Only gates whose completion is consumed AT
+      // the resumed phase (and removed there) belong in the retain set — a
+      // blanket "every human gate survives" exemption let `completed:
+      // clarification` skip the follow-up pause and left `completed:ci` live
+      // across re-pauses (see the #1154 post-merge review).
       const gateSuffixes = currentLabels
         .filter((l) => l.startsWith('waiting-for:'))
         .map((l) => l.slice('waiting-for:'.length));
+      const retained: string[] = [];
       for (const suffix of gateSuffixes) {
         const completedLabel = `completed:${suffix}`;
-        if (
-          currentLabels.includes(completedLabel) &&
-          !labelsToRemove.includes(completedLabel) &&
-          !isHumanGateCompletion(completedLabel)
-        ) {
+        if (!currentLabels.includes(completedLabel)) continue;
+        if (retain.has(suffix)) {
+          retained.push(completedLabel);
+          continue;
+        }
+        if (!labelsToRemove.includes(completedLabel)) {
           labelsToRemove.push(completedLabel);
         }
+      }
+      if (retained.length > 0) {
+        this.logger.info(
+          { labels: retained, issue: this.issueNumber },
+          'Resume: retaining completed gate labels consumed by the resumed phase',
+        );
       }
 
       if (labelsToRemove.length > 0) {

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -8,7 +8,7 @@ import type { WorkerConfig } from './config.js';
 import { resolvePhaseTimeoutMs, resolveAgentForPhase, resolveWorkflowOverrides, DEFAULT_VALIDATE_COMMAND } from './config.js';
 import type { ReviewExecutorLike } from './review-executor.js';
 import type { RemediateExecutor } from './remediate-executor.js';
-import { readReviewArtifactSync, readReviewArtifact, writeReviewArtifact, resetRemediationCount, seedRemediationCount, deriveFindingId, type ReviewFinding, type ReviewArtifact, type Severity } from './review-artifact.js';
+import { readReviewArtifactSync, readReviewArtifact, writeReviewArtifact, resetRemediationCount, seedRemediationCount, deriveFindingId, computeVerdict, type ReviewFinding, type ReviewArtifact, type Severity } from './review-artifact.js';
 import { waitForCiGreen } from './ci-merge-readiness.js';
 import type { LabelManager } from './label-manager.js';
 import type { StageCommentManager } from './stage-comment-manager.js';
@@ -54,6 +54,10 @@ const PHASES_REQUIRING_CHANGES: ReadonlySet<WorkflowPhase> = new Set(['implement
  * `maybePostUntrustedNotice`).
  */
 const REMEDIATION_LIMIT_MARKER = '<!-- generacy-remediation-limit -->';
+/** Hidden dedupe marker for the `waiting-for:ci` pause comment. */
+export const CI_PAUSE_MARKER = '<!-- generacy-ci-pause -->';
+/** Prefix of the per-pause fingerprint line: `<!-- generacy-ci-pause verdict=<v> sha=<sha> -->`. */
+const CI_PAUSE_MARKER_PREFIX = '<!-- generacy-ci-pause';
 
 /**
  * #1134 (US2): outcome of the speckit-bugfix targeted-validate classification.
@@ -382,6 +386,7 @@ export class PhaseLoop {
           { startPhase: context.startPhase, runId },
           '#1133: implementation-review gate already satisfied — terminal no-op resume, skipping phase loop',
         );
+        await this.clearRemediationBudgetMirror(context, deps);
         return { results, completed: true, lastPhase: 'validate', gateHit: false };
       }
     }
@@ -1181,6 +1186,18 @@ export class PhaseLoop {
         return { results, completed: false, lastPhase: phase, gateHit: false };
       }
 
+      // 4b. Validate green ⇒ the proof that every validate-origin failure is
+      // fixed. Auto-resolve any still-open `synthetic: 'validate'` finding in
+      // the review sidecar (counterpart of the failure-path synthesis above) so
+      // a stale `changes-required` cannot re-trigger remediate later.
+      if (phase === 'validate' && result.success) {
+        await this.resolveSyntheticValidateFindings(
+          context,
+          resolveWorkflowOverrides(config, deps.settings ?? null, context.item.workflowName)
+            .review.blockingSeverity,
+        );
+      }
+
       // 5. Commit, push, and ensure draft PR exists (before marking complete)
       const commitOutcome = await prManager.commitPushAndEnsurePr(phase);
       const { prUrl, hasChanges } = commitOutcome;
@@ -1396,6 +1413,7 @@ export class PhaseLoop {
             phase,
             reason:
               'Could not resolve the PR head commit SHA; CI merge-readiness cannot be evaluated.',
+            ci: { verdict: 'unknown', headSha: 'unknown' },
             context,
             deps,
             results,
@@ -1432,6 +1450,7 @@ export class PhaseLoop {
           return await this.pauseForCiReadiness({
             phase,
             reason: 'CI did not turn green within the merge-readiness timeout',
+            ci: { verdict: outcome.verdict, source: outcome.source, headSha },
             context,
             deps,
             results,
@@ -1453,7 +1472,8 @@ export class PhaseLoop {
           return await this.pauseForCiReadiness({
             phase,
             reason:
-              'CI is red (not-passed) for the head commit; the merge gate will not open until CI is green.',
+              'CI has not passed for the head commit; the merge gate will not open until CI is green.',
+            ci: { verdict: outcome.verdict, source: outcome.source, headSha },
             context,
             deps,
             results,
@@ -1582,17 +1602,27 @@ export class PhaseLoop {
                 'Add `completed:remediation-limit` to resume with a fresh remediation budget.',
               ].join('\n');
               // #1154 FR-005: dedupe on the hidden marker so a re-parked cap does
-              // not re-post the same comment every resume cycle.
-              const prNumber = prManager.getPrNumber();
+              // not re-post the same comment every resume cycle. The comment is
+              // posted to the ISSUE (`addIssueComment(issueNumber)`), so the
+              // dedupe MUST read the issue's comments — the earlier PR-side read
+              // (`listPrCommentBodies(prNumber)`) never saw the marker and
+              // re-posted on every re-park. Independent of whether a PR exists.
+              // A failed dedupe read must not suppress the gate body — fall
+              // back to posting (a duplicate beats a silent park).
               let alreadyPosted = false;
-              if (prNumber !== undefined) {
-                const existingComments = await context.github.listPrCommentBodies(
+              try {
+                const existingComments = await context.github.getIssueComments(
                   context.item.owner,
                   context.item.repo,
-                  prNumber,
+                  context.item.issueNumber,
                 );
-                alreadyPosted = existingComments.some((b) =>
-                  b.includes(REMEDIATION_LIMIT_MARKER),
+                alreadyPosted = existingComments.some((c) =>
+                  c.body.includes(REMEDIATION_LIMIT_MARKER),
+                );
+              } catch (error) {
+                this.logger.warn(
+                  { error: String(error), phase, gateLabel: gate.gateLabel },
+                  'Remediation-limit comment dedupe read failed — posting without dedupe',
                 );
               }
               if (!alreadyPosted) {
@@ -1712,6 +1742,17 @@ export class PhaseLoop {
         // waiting-for:implementation-review + agent:paused.
         if (gate.condition === 'on-ci-green') {
           await labelManager.onPhaseComplete(phase);
+          // The review↔remediate loop has CONVERGED here (validate green, CI
+          // green) even though the loop returns `completed: false` for the
+          // approval pause. Clear the Redis remediation-budget mirror now: a
+          // later `address-pr-feedback` re-entry (reviewer requests changes at
+          // this gate) clears the disk artifact and must start with a fresh
+          // budget, not inherit the N remediations spent before convergence —
+          // otherwise the gate's `max(disk, redis)` reconcile re-seeds N and the
+          // human's feedback parks at `waiting-for:remediation-limit` with zero
+          // attempts. Non-converged exits (merge-conflicts, ci, failures) keep
+          // the mirror so the cap stays global across those re-entries.
+          await this.clearRemediationBudgetMirror(context, deps);
         }
 
         await labelManager.onGateHit(phase, gate.gateLabel);
@@ -1924,12 +1965,44 @@ export class PhaseLoop {
     }
 
     this.logger.info('Phase loop completed successfully — all phases done');
+    await this.clearRemediationBudgetMirror(context, deps);
     return {
       results,
       completed: true,
       lastPhase: sequence[sequence.length - 1]!,
       gateHit: false,
     };
+  }
+
+  /**
+   * Clear the durable Redis mirror of the remediation budget
+   * (`remediation-count:<owner>:<repo>:<issue>:<branch>`) on a SUCCESSFUL
+   * loop completion (`completed: true`). The mirror must persist across every
+   * non-completing exit (gate pauses, failures, push refusals) so a restart
+   * resumes with the spent budget; but a workflow that converged after N
+   * remediations would otherwise leave N in Redis, and a later re-entry
+   * (e.g. address-pr-feedback, which clears the disk sidecar and re-seeds at
+   * 0) would reconcile `max(disk, redis)` back up to N — parking the human's
+   * feedback at the cap with zero attempts when N ≥ max. Best-effort: a Redis
+   * failure never changes the completion outcome.
+   */
+  private async clearRemediationBudgetMirror(
+    context: WorkerContext,
+    deps: PhaseLoopDeps,
+  ): Promise<void> {
+    if (!deps.phaseTracker) return;
+    const { owner, repo, issueNumber } = context.item;
+    const branch = context.branch ?? 'no-branch';
+    const key = `remediation-count:${owner}:${repo}:${issueNumber}:${branch}`;
+    try {
+      await deps.phaseTracker.clearRaw(key);
+      this.logger.info({ key }, 'Phase loop completed — cleared remediation budget mirror');
+    } catch (error) {
+      this.logger.warn(
+        { key, error: String(error) },
+        'Failed to clear remediation budget mirror on completion — continuing',
+      );
+    }
   }
 
   /**
@@ -1952,7 +2025,10 @@ export class PhaseLoop {
    */
   private async synthesizeValidateChangesRequiredArtifact(
     context: WorkerContext,
-    validateCommand: string,
+    // Retained for call-site stability; the finding id now derives from the
+    // EFFECTIVE command (the `file` field) so a reviewer re-emission with the
+    // same `file` + `title` yields the same deterministic id (INV-4).
+    _validateCommand: string,
     effectiveValidateCommand: string,
     validateEvidence: { stdout: string; stderr: string },
   ): Promise<{ round: number }> {
@@ -1961,12 +2037,18 @@ export class PhaseLoop {
     const round = (prior?.round ?? 0) + 1;
     const head = await context.github.getCurrentCommitSha();
     const finding: ReviewFinding = {
-      id: deriveFindingId(validateCommand, 'validate phase failed'),
+      id: deriveFindingId(effectiveValidateCommand, 'validate phase failed'),
       severity: 'critical',
       // #1158 T013 (FR-008): cite the effective (possibly targeted) command,
       // not the flat `config.validateCommand`.
       file: effectiveValidateCommand,
       title: 'validate phase failed',
+      // No path anchor: `file` is a command string that can never appear in a
+      // review delta. Tag it so `advanceArtifact` resolves it on the reviewer's
+      // re-emission alone, and so a green validate can auto-resolve it
+      // (`resolveSyntheticValidateFindings`). Without this the finding rode
+      // every validate failure to the remediation cap.
+      synthetic: 'validate',
       // #1159 FR-005: raw validate stdout/stderr can contain
       // attacker-influenced content (e.g. a test name or assertion message
       // echoing a PR-controlled string) that lands verbatim in the remediate
@@ -1980,7 +2062,12 @@ export class PhaseLoop {
       status: 'open',
     };
     await writeReviewArtifact(context.checkoutPath, workflowId, {
-      findings: [...(prior?.findings ?? []), finding],
+      // A repeat validate failure re-synthesizes a finding with the SAME
+      // deterministic id (same command + title). Replace any prior copy —
+      // typically the one a review just resolved — rather than appending a
+      // duplicate id, which would break the id-uniqueness invariant the
+      // convergence merge and the poster's thread marker rely on.
+      findings: [...(prior?.findings ?? []).filter((f) => f.id !== finding.id), finding],
       verdict: 'changes-required',
       round,
       lastReviewedCommitSha: head,
@@ -1991,8 +2078,67 @@ export class PhaseLoop {
       // #1156: carry the cross-run ready flag forward (D-7 — same reasoning as
       // the review executor's per-round rewrite).
       markedReadyByEngine: prior?.markedReadyByEngine ?? false,
+      // Carry the scoped-review consumption marker forward so a validate
+      // failure after a merge-conflict re-arm does not re-apply the scope.
+      ...(prior?.consumedReviewScopeHeadSha !== undefined
+        ? { consumedReviewScopeHeadSha: prior.consumedReviewScopeHeadSha }
+        : {}),
     });
     return { round };
+  }
+
+  /**
+   * Validate-SUCCESS counterpart of `synthesizeValidateChangesRequiredArtifact`.
+   * A passing `validate` is the proof that every validate-origin failure is
+   * fixed, so flip any still-open `synthetic: 'validate'` finding in the
+   * sidecar to `resolved` and recompute the verdict. Covers the paths where no
+   * review round gets to confirm the fix — the flag-OFF one-shot remediate
+   * (#1165), a resume that re-enters at `validate`, or a reviewer that omitted
+   * the re-emission — so the stale `changes-required` cannot re-trigger
+   * remediate on the next review entry. No-op when there is no artifact or no
+   * open synthetic validate finding; leaves every other field untouched.
+   * Best-effort: a sidecar I/O failure is logged, never fatal to a green run.
+   */
+  private async resolveSyntheticValidateFindings(
+    context: WorkerContext,
+    blockingSeverity: Severity,
+  ): Promise<void> {
+    const workflowId = `${context.item.owner}/${context.item.repo}#${context.item.issueNumber}`;
+    try {
+      const artifact = await readReviewArtifact(context.checkoutPath, workflowId);
+      if (!artifact) {
+        return;
+      }
+      const stale = artifact.findings.filter(
+        (f) => f.status === 'open' && f.synthetic === 'validate',
+      );
+      if (stale.length === 0) {
+        return;
+      }
+      const findings: ReviewFinding[] = artifact.findings.map((f) =>
+        f.status === 'open' && f.synthetic === 'validate'
+          ? { ...f, status: 'resolved' as const }
+          : f,
+      );
+      // Recompute with the single `computeVerdict` at the per-workflow blocking
+      // severity so this agrees with the review executor: any other open
+      // blocking finding keeps the verdict at changes-required.
+      const verdict = computeVerdict(findings, blockingSeverity);
+      await writeReviewArtifact(context.checkoutPath, workflowId, {
+        ...artifact,
+        findings,
+        verdict,
+      });
+      this.logger.info(
+        { workflowId, resolved: stale.map((f) => f.id), verdict },
+        'validate passed — auto-resolved open synthetic validate findings',
+      );
+    } catch (error) {
+      this.logger.warn(
+        { error: String(error), workflowId },
+        'validate passed but auto-resolving synthetic validate findings failed — continuing',
+      );
+    }
   }
 
   /**
@@ -2672,6 +2818,17 @@ export class PhaseLoop {
   private async pauseForCiReadiness(params: {
     phase: WorkflowPhase;
     reason: string;
+    /**
+     * The real CI readout behind the pause: aggregated verdict (`'unknown'`
+     * when the head SHA could not be resolved), which readout produced it, and
+     * the head SHA evaluated. Reported verbatim in the pause comment and used
+     * as the dedupe fingerprint.
+     */
+    ci: {
+      verdict: 'green' | 'not-passed' | 'pending' | 'unknown';
+      source?: 'check-runs' | 'actions-runs';
+      headSha: string;
+    };
     context: WorkerContext;
     deps: PhaseLoopDeps;
     results: PhaseResult[];
@@ -2685,6 +2842,7 @@ export class PhaseLoop {
     const {
       phase,
       reason,
+      ci,
       context,
       deps,
       results,
@@ -2696,6 +2854,10 @@ export class PhaseLoop {
       currentIndex,
     } = params;
     const { labelManager, stageCommentManager, jobEventEmitter } = deps;
+    this.logger.warn(
+      { phase, ciVerdict: ci.verdict, ciSource: ci.source ?? 'none', headSha: ci.headSha, reason },
+      'CI merge readiness paused',
+    );
 
     jobEventEmitter?.('job:paused', {
       jobId: context.jobId,
@@ -2713,23 +2875,66 @@ export class PhaseLoop {
     await labelManager.onGateHit(phase, 'waiting-for:ci');
 
     // FR-004: best-effort reason comment. A failure here MUST NOT change the
-    // pause outcome or any other step (INV-5).
+    // pause outcome or any other step (INV-5). Reports the REAL verdict and
+    // its source (not a canned "CI is red"), and is deduped on a hidden
+    // marker + verdict/sha fingerprint: when the latest issue comment already
+    // carries the same fingerprint (a re-pause on the same head with the same
+    // verdict — e.g. every `completed:ci` → validate → re-pause cycle), the
+    // comment is not re-posted.
     try {
+      const fingerprint = `${CI_PAUSE_MARKER_PREFIX} verdict=${ci.verdict} sha=${ci.headSha} -->`;
       const body = [
+        CI_PAUSE_MARKER,
+        fingerprint,
         '## CI merge readiness paused',
         '',
         reason,
+        '',
+        `CI verdict: \`${ci.verdict}\` (source: ${ci.source ?? 'none'}) for head \`${ci.headSha}\`.`,
+        ...(ci.source === 'actions-runs'
+          ? [
+              '',
+              '_Verdict read from the `actions/runs` fallback (the `check-runs` readout '
+                + 'was unavailable — the token likely lacks `checks:read`); third-party '
+                + 'required checks are not visible to this readout._',
+            ]
+          : []),
         '',
         'The workflow is paused with `waiting-for:ci` + `agent:paused`. Re-run '
           + 'validation (CI, tests, PR ready-marking, and the merge gate) by '
           + 'adding `completed:ci` once CI is green.',
       ].join('\n');
-      await context.github.addIssueComment(
-        context.item.owner,
-        context.item.repo,
-        context.item.issueNumber,
-        body,
-      );
+      let alreadyPosted = false;
+      try {
+        const existing = await context.github.getIssueComments(
+          context.item.owner,
+          context.item.repo,
+          context.item.issueNumber,
+        );
+        const latest = existing[existing.length - 1];
+        alreadyPosted =
+          latest !== undefined
+          && latest.body.includes(CI_PAUSE_MARKER)
+          && latest.body.includes(fingerprint);
+      } catch (error) {
+        this.logger.warn(
+          { error: String(error), phase },
+          'CI pause comment dedupe read failed — posting without dedupe',
+        );
+      }
+      if (alreadyPosted) {
+        this.logger.info(
+          { phase, ciVerdict: ci.verdict, headSha: ci.headSha },
+          'CI pause comment already posted for this verdict/sha — skipping re-post',
+        );
+      } else {
+        await context.github.addIssueComment(
+          context.item.owner,
+          context.item.repo,
+          context.item.issueNumber,
+          body,
+        );
+      }
     } catch (error) {
       this.logger.warn(
         { error: String(error), phase },

--- a/packages/orchestrator/src/worker/phase-resolver.ts
+++ b/packages/orchestrator/src/worker/phase-resolver.ts
@@ -16,9 +16,11 @@ export const GATE_MAPPING: Record<string, { phase: WorkflowPhase; resumeFrom: Wo
   'manual-validation':      { phase: 'validate',   resumeFrom: 'validate' },
   'remediation-limit':      { phase: 'review',     resumeFrom: 'review' },
   // #1154 FR-004: `waiting-for:ci` is raised during `validate` (CI wait-timeout),
-  // so resume re-runs `validate` to re-verify CI is green on the new head. This
-  // entry also auto-includes `ci` in the derived `HUMAN_GATE_SUFFIXES`, giving
-  // `completed:ci` the same resume-strip exemption as every other gate.
+  // so resume re-runs `validate` to re-verify CI is green on the new head.
+  // NOTE: `completed:ci` is deliberately NOT in the resume-strip retain set
+  // (`resolveResumeRetainSuffixes` in label-manager.ts) — it is consumed by the
+  // resolver before the strip and must not linger, or a later `waiting-for:ci`
+  // re-pause would pair with the stale label and re-enqueue every poll.
   'ci':                     { phase: 'validate',   resumeFrom: 'validate' },
 };
 

--- a/packages/orchestrator/src/worker/pr-feedback-handler.ts
+++ b/packages/orchestrator/src/worker/pr-feedback-handler.ts
@@ -8,6 +8,7 @@ import {
 import type { Comment, GitHubClient, Review, ReviewThread } from '@generacy-ai/workflow-engine';
 import { evaluatePushGuard, type PushGuardDecision } from './push-guard.js';
 import { defaultRemoteBranchExists } from './repo-checkout.js';
+import { isEngineSidecar, isCollapsedEngineStateDir } from './product-diff.js';
 import {
   parseAcknowledgedFindings,
   parseSingleMarkerEntries,
@@ -1059,9 +1060,27 @@ Please proceed with addressing the feedback.`;
       'Staging and committing changes',
     );
 
-    // Stage all changes
+    // Stage everything EXCEPT engine sidecars (#1162). Sidecars under
+    // `.generacy/` now survive the cross-run `git clean` (repo-checkout.ts keeps
+    // them so the review loop can resume), so a whole-index `git add -A` here
+    // would commit them onto the PR branch. Mirror PrManager.commitAndPush:
+    // filter with `isEngineSidecar`/`isCollapsedEngineStateDir`, stage the
+    // filtered set, and commit with an explicit pathspec so a pre-staged sidecar
+    // is never folded in by a whole-index commit.
+    const { staged = [], unstaged = [], untracked = [] } = status;
+    const toStage = [...new Set([...staged, ...unstaged, ...untracked])].filter(
+      (p) => !isEngineSidecar(p) && !isCollapsedEngineStateDir(p),
+    );
+    if (toStage.length === 0) {
+      this.logger.info(
+        { prNumber, issueNumber },
+        'Only engine sidecars changed — nothing product-level to commit, skipping commit/push',
+      );
+      return false;
+    }
+
     try {
-      await github.stageAll();
+      await github.stageFiles(toStage);
     } catch (error) {
       this.logger.error(
         { error: String(error), prNumber },
@@ -1078,7 +1097,7 @@ Automated feedback addressing for issue #${issueNumber}.
 Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>`;
 
     try {
-      await github.commit(commitMessage);
+      await github.commit(commitMessage, toStage);
     } catch (error) {
       this.logger.error(
         { error: String(error), prNumber },

--- a/packages/orchestrator/src/worker/pr-manager.ts
+++ b/packages/orchestrator/src/worker/pr-manager.ts
@@ -4,7 +4,7 @@ import type { WorkflowPhase, Logger, CommitResult } from './types.js';
 import { parsePRUrl } from './linked-pr-url-parser.js';
 import { evaluatePushGuard, type PushGuardDecision } from './push-guard.js';
 import { defaultRemoteBranchExists } from './repo-checkout.js';
-import { isEngineSidecar } from './product-diff.js';
+import { isEngineSidecar, isCollapsedEngineStateDir } from './product-diff.js';
 import { readReviewArtifact, setMarkedReadyByEngine } from './review-artifact.js';
 
 /**
@@ -143,10 +143,14 @@ export class PrManager {
       // sidecar that some other actor pre-staged into the index is never folded
       // into the commit by the whole-index `git commit` — the "never committed"
       // guarantee (FR-001/SC-001) holds even against a dirty index.
+      //
+      // A collapsed `.generacy/` directory entry (a status backend that does not
+      // expand untracked directories) is skipped too: its contents are opaque to
+      // the sidecar filter, and staging it would commit every sidecar at once.
       const status = await this.github.getStatus();
       const { staged = [], unstaged = [], untracked = [] } = status;
       const toStage = [...new Set([...staged, ...unstaged, ...untracked])].filter(
-        (p) => !isEngineSidecar(p),
+        (p) => !isEngineSidecar(p) && !isCollapsedEngineStateDir(p),
       );
       if (toStage.length > 0) {
         // Stage first so untracked members of `toStage` are known to git before

--- a/packages/orchestrator/src/worker/product-diff.ts
+++ b/packages/orchestrator/src/worker/product-diff.ts
@@ -38,6 +38,40 @@ export function isEngineSidecar(p: string): boolean {
   return ENGINE_SIDECAR_PREFIXES.some((prefix) => p.startsWith(prefix));
 }
 
+/** The engine's bookkeeping directory; every `ENGINE_SIDECAR_PREFIXES` entry lives under it. */
+export const ENGINE_STATE_DIR = '.generacy';
+
+/**
+ * `git clean -e` exclude patterns derived from `ENGINE_SIDECAR_PREFIXES`, so the
+ * cross-run checkout reset (`RepoCheckout.switchBranch` / `updateRepo`) spares
+ * exactly the sidecars the staging filter refuses to commit. Without this every
+ * re-entry (new run, address-pr-feedback, merge-conflict re-arm) wiped the
+ * review artifact: the round restarted at 1 (so `isRoundAlreadyPosted` suppressed
+ * every later review post), `markedReadyByEngine` was lost, and open findings +
+ * `lastReviewedCommitSha` were lost.
+ *
+ * Patterns are gitignore-style, anchored at the repo root by their embedded
+ * slash — `.generacy/review-findings-*` spares `.generacy/review-findings-<id>.json`
+ * but still lets `git clean` remove any other untracked file under `.generacy/`
+ * (e.g. a stray `.generacy/epics/draft.md` from a previous run).
+ */
+export function engineSidecarCleanExcludes(): string[] {
+  return ENGINE_SIDECAR_PREFIXES.map((prefix) => `${prefix}*`);
+}
+
+/**
+ * True when `p` is a *collapsed* `.generacy` directory entry (`.generacy` or
+ * `.generacy/`) rather than a file path. `git status --porcelain` without
+ * `--untracked-files=all` reports a wholly-untracked directory as one `?? .generacy/`
+ * line; `isEngineSidecar` cannot see the files inside it, so staging the entry
+ * would commit every sidecar at once — the original #1162 failure, reachable in
+ * any target repo with no tracked `.generacy/config.yaml`. The staging filter
+ * skips such entries (belt-and-braces to `getStatus` expanding untracked dirs).
+ */
+export function isCollapsedEngineStateDir(p: string): boolean {
+  return p === ENGINE_STATE_DIR || p === `${ENGINE_STATE_DIR}/`;
+}
+
 /**
  * Path prefixes excluded from the "product diff" check.
  *

--- a/packages/orchestrator/src/worker/repo-checkout.ts
+++ b/packages/orchestrator/src/worker/repo-checkout.ts
@@ -3,8 +3,23 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { join, dirname } from 'node:path';
 import type { Logger } from './types.js';
+import { engineSidecarCleanExcludes } from './product-diff.js';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * `git clean` argv that discards leftover untracked files from a previous run
+ * while sparing the engine's bookkeeping sidecars under `.generacy/` (#1162).
+ *
+ * The review artifact, pause context, external-feedback seed and workflow state
+ * are deliberately untracked (never committed to the PR branch), so a bare
+ * `git clean -fd` on cross-run re-entry deleted them — resetting the review
+ * round to 1, dropping `markedReadyByEngine` and losing open findings. Both
+ * reset sites (`switchBranch`, `updateRepo`) MUST use this helper.
+ */
+export function sidecarPreservingCleanArgs(): string[] {
+  return ['clean', '-fd', ...engineSidecarCleanExcludes().flatMap((pattern) => ['-e', pattern])];
+}
 
 /**
  * Default `git.remoteBranchExists` helper for the pre-push guard's production
@@ -127,9 +142,10 @@ export class RepoCheckout {
   async switchBranch(checkoutPath: string, branch: string): Promise<void> {
     this.logger.info({ checkoutPath, branch }, 'Switching to branch');
 
-    // Discard any leftover dirty state from previous worker runs
+    // Discard any leftover dirty state from previous worker runs — but keep the
+    // engine sidecars (#1162; see `sidecarPreservingCleanArgs`).
     await execFileAsync('git', ['reset', '--hard', 'HEAD'], { cwd: checkoutPath });
-    await execFileAsync('git', ['clean', '-fd'], { cwd: checkoutPath });
+    await execFileAsync('git', sidecarPreservingCleanArgs(), { cwd: checkoutPath });
 
     // #1051 FR-001: `--prune` removes stale local tracking refs for branches
     // that were deleted upstream (e.g. after a merged PR with --delete-branch).
@@ -244,10 +260,11 @@ export class RepoCheckout {
       'Updating existing checkout',
     );
 
-    // Discard any leftover dirty state from previous worker runs
+    // Discard any leftover dirty state from previous worker runs — but keep the
+    // engine sidecars (#1162; see `sidecarPreservingCleanArgs`).
     this.logger.debug({ checkoutPath }, 'Discarding dirty state before branch switch');
     await execFileAsync('git', ['reset', '--hard', 'HEAD'], { cwd: checkoutPath });
-    await execFileAsync('git', ['clean', '-fd'], { cwd: checkoutPath });
+    await execFileAsync('git', sidecarPreservingCleanArgs(), { cwd: checkoutPath });
 
     this.logger.debug({ checkoutPath }, 'Fetching from origin');
     // #1051 FR-001: `--prune` removes stale local tracking refs for branches

--- a/packages/orchestrator/src/worker/review-artifact.ts
+++ b/packages/orchestrator/src/worker/review-artifact.ts
@@ -30,6 +30,7 @@ export type FindingStatus = 'open' | 'resolved';
 
 const SeveritySchema = z.enum(['critical', 'major', 'minor']);
 const FindingStatusSchema = z.enum(['open', 'resolved']);
+const SyntheticFindingKindSchema = z.enum(['validate', 'external-body']);
 
 export const ReviewFindingSchema = z.object({
   // #1161 (INV-4): stable per-finding identity, deterministic from `(file, title)`
@@ -44,9 +45,22 @@ export const ReviewFindingSchema = z.object({
   detail: z.string().min(1),
   round: z.number().int().positive(),
   status: FindingStatusSchema,
+  // Engine-synthesized findings that carry no repository-path anchor:
+  //  - `'validate'`: the phase loop's validate-failure synthesis
+  //    (`synthesizeValidateChangesRequiredArtifact`), whose `file` holds the
+  //    effective validate command;
+  //  - `'external-body'`: a body-only external review comment seeded by
+  //    `SeedAwareReviewExecutor`, whose `file` is the `(pr-review)` placeholder.
+  // `advanceArtifact`'s evidence rule (`file ∈ delta`) can never hold for these,
+  // so a synthetic finding resolves on the reviewer's re-emission alone; the
+  // validate-SUCCESS path additionally auto-resolves open `'validate'` ones.
+  // Optional with no default so pre-existing sidecars parse unchanged; absent ⇒
+  // a real, path-anchored finding.
+  synthetic: SyntheticFindingKindSchema.optional(),
 });
 
 export type ReviewFinding = z.infer<typeof ReviewFindingSchema>;
+export type SyntheticFindingKind = z.infer<typeof SyntheticFindingKindSchema>;
 
 /**
  * #1161 (INV-4): deterministic per-finding identity. `sha256(file + '\0' + title)`
@@ -81,6 +95,14 @@ export const ReviewArtifactSchema = z.object({
   // and must still parse. Only ever written `true` by the engine's own
   // `markReadyForReview`, so reconstruction can never demote a human-ready PR.
   markedReadyByEngine: z.boolean().default(false),
+  // Resolution-scoped review consumption marker. A merge-conflict re-arm pins a
+  // fixed `reviewScope` on the `WorkerContext` that nothing clears; the executor
+  // applies the scope exactly once — on the first round whose
+  // `reviewScope.headSha` differs from this value — then stamps it here so every
+  // later round falls back to the `lastReviewedCommitSha`..HEAD delta (which
+  // spans the remediation commits). Optional: absent on pre-existing sidecars
+  // and on every artifact written outside a scoped round.
+  consumedReviewScopeHeadSha: z.string().min(1).optional(),
 });
 
 export type ReviewArtifact = z.infer<typeof ReviewArtifactSchema>;

--- a/packages/orchestrator/src/worker/review-charter.ts
+++ b/packages/orchestrator/src/worker/review-charter.ts
@@ -34,6 +34,11 @@ export interface ReviewCharterInput {
    * the last reviewed commit, enumerates the still-open findings to confirm, and
    * restricts NEW findings to `blockingSeverity` or higher. Absent ⇒ round-1
    * whole-PR review (data-model "Round-1 special case").
+   *
+   * May be combined with `diffWindow`: a merge-conflict re-arm whose scope is
+   * applied on a round >= 2 is BOTH resolution-scoped (inspect only the
+   * conflicted paths / range) AND a verification pass (the still-open prior
+   * findings are carried into the charter for confirmation).
    */
   verification?: {
     /** `buildVerificationPrompt` output — the still-open-findings framing. */
@@ -55,7 +60,39 @@ export function buildReviewCharter(input: ReviewCharterInput): string {
 
   lines.push(`# Code review — round ${round}`);
   lines.push('');
-  if (verification) {
+  if (verification && diffWindow) {
+    // Scoped verification pass: a merge-conflict resolution re-arm applied on a
+    // round with a prior artifact. The review target is the resolution window
+    // (conflicted-path allowlist when known, else the exact range), and the
+    // still-open prior findings are carried in below for confirmation.
+    if (diffWindow.conflictedPaths && diffWindow.conflictedPaths.length > 0) {
+      lines.push(
+        'You are performing a VERIFICATION re-review of a merge-conflict resolution. ' +
+          'Inspect ONLY these conflicted paths — the files that had conflict markers ' +
+          'the resolution had to reconcile — for defects: logic errors, regressions, ' +
+          'broken invariants, security issues, and incorrect handling of edge cases ' +
+          'introduced by the resolution. Ignore all other files, including changes ' +
+          'brought in from the merged-in base branch.',
+      );
+      lines.push('');
+      lines.push('Conflicted paths:');
+      lines.push('');
+      for (const path of diffWindow.conflictedPaths) {
+        lines.push(`- ${path}`);
+      }
+    } else {
+      lines.push(
+        'You are performing a VERIFICATION re-review of a merge-conflict resolution. ' +
+          `Inspect ONLY the diff in the range \`${diffWindow.baseSha}..${diffWindow.headSha}\` ` +
+          '(the merge commit that resolved the conflict, relative to the pre-merge ' +
+          'branch tip) for defects: logic errors, regressions, broken invariants, ' +
+          'security issues, and incorrect handling of edge cases introduced by the ' +
+          'resolution. Ignore files and changes outside this range.',
+      );
+    }
+    lines.push('');
+    lines.push(verification.prompt);
+  } else if (verification) {
     // #1126 (activated #1161) — convergence verification pass (round >= 2).
     // Delta-scoped: name ONLY the files changed since the last reviewed commit,
     // then embed the still-open-findings framing produced by
@@ -146,6 +183,20 @@ export function buildReviewCharter(input: ReviewCharterInput): string {
         'engine ties your confirmation to the original finding, so do not paraphrase ' +
         'either. A finding you simply omit is treated as STILL OPEN, not resolved — ' +
         'when in doubt, re-emit it with `status: "open"`.',
+    );
+    lines.push('');
+    // Synthetic (engine-generated) findings have no path anchor, so the
+    // engine cannot use "its file is in the delta" as evidence; your explicit
+    // re-emission is the only signal. Without it they ride every round to the
+    // remediation cap.
+    lines.push(
+      'This applies equally to findings tagged `[synthetic: validate]` (synthesized ' +
+        'from a failing `validate` run; `file` is the validate command, not a path) and ' +
+        '`[synthetic: external-body]` (seeded from a PR-level review comment; `file` is ' +
+        'the `(pr-review)` placeholder). There is no file to open for these — judge ' +
+        'whether the changes since the last review address the failure or feedback ' +
+        'described in the finding detail, and if so re-emit the finding with the EXACT ' +
+        'SAME `file` and `title` and `status: "resolved"`.',
     );
     lines.push('');
     // The verification pass must not raise fresh advisory noise; only genuine new

--- a/packages/orchestrator/src/worker/review-executor.ts
+++ b/packages/orchestrator/src/worker/review-executor.ts
@@ -90,25 +90,49 @@ export class ReviewExecutor implements ReviewExecutorLike {
 
     // 2. Determine the review round from any prior engine-written artifact.
     //    Read BEFORE the reviewScope branch (#1164 FR-001) so scope usage can be
-    //    gated on round 1 only.
+    //    gated on whether THIS scope was already consumed.
     const priorRound = await readReviewArtifact(checkoutPath, workflowId);
     const round = (priorRound?.round ?? 0) + 1;
 
-    // #1131/#1164: resolution-scoped review, honored on round 1 only. A
+    // #1131/#1164: resolution-scoped review, honored exactly once per scope. A
     // merge-conflict re-arm supplies a fixed `reviewScope`; nothing clears it,
-    // so applying it on round 2+ would pin every re-review to the original
+    // so applying it on every round would pin each re-review to the original
     // pre-remediation window (making the remediation commits invisible) and the
-    // same findings would re-report every round until the remediation cap. Gate
-    // scope usage on `!priorRound` — round 2+ falls back to the standard #1126
-    // delta (`lastReviewedCommitSha`..HEAD), which spans the remediation commits.
-    // An empty scoped window short-circuits to a synthetic success (FR-011,
-    // SC-004) and lets the loop advance to `validate`. Absent scope ⇒ whole-PR
-    // review, byte-identical to pre-#1131 (FR-010).
+    // same findings would re-report every round until the remediation cap.
+    //
+    // The #1164 gate was `!priorRound` — but on the real path conflicts surface
+    // at validate entry (`runPreValidateBaseMerge`), i.e. AFTER round 1 has
+    // persisted the sidecar, so the scoped review never ran and the re-review
+    // was a plain verification pass whose delta spanned the whole upstream
+    // base merge. Gate instead on "this scope not yet consumed": apply iff
+    // `reviewScope.headSha !== prior.consumedReviewScopeHeadSha`, then persist
+    // the headSha on the artifact (step 11) so round N+1 falls back to the
+    // standard #1126 delta (`lastReviewedCommitSha`..HEAD), which spans the
+    // remediation commits — preserving the #1164 cap-burn fix. With a prior
+    // artifact the scoped round is ALSO a verification pass (the still-open
+    // prior findings ride along in the charter, step 3).
+    //
+    // An empty scoped window with NO prior artifact short-circuits to a
+    // synthetic success (FR-011, SC-004) and lets the loop advance to
+    // `validate`. With a prior artifact it instead falls through to the normal
+    // verification pass (the scope is still recorded as consumed) — a
+    // short-circuit there would leave a `changes-required` prior untouched and
+    // re-trigger remediate every round. Absent scope ⇒ whole-PR review,
+    // byte-identical to pre-#1131 (FR-010).
     const { reviewScope } = context;
-    const scopedReview = priorRound ? undefined : reviewScope;
+    const scopeAlreadyConsumed =
+      reviewScope !== undefined &&
+      priorRound?.consumedReviewScopeHeadSha === reviewScope.headSha;
+    let scopedReview = scopeAlreadyConsumed ? undefined : reviewScope;
+    if (scopeAlreadyConsumed) {
+      this.logger.info(
+        { headSha: reviewScope?.headSha, round, workflowId },
+        'Resolution-scoped review already consumed for this scope — falling back to the delta review',
+      );
+    }
     if (scopedReview) {
       const isEmpty = await this.isEmptyWindow(checkoutPath, scopedReview);
-      if (isEmpty) {
+      if (isEmpty && !priorRound) {
         this.logger.info(
           { baseSha: scopedReview.baseSha, headSha: scopedReview.headSha, workflowId },
           'Resolution-scoped review window is empty — skipping review, advancing to validate',
@@ -120,6 +144,13 @@ export class ReviewExecutor implements ReviewExecutorLike {
           durationMs: Date.now() - startedAt,
           output: [],
         };
+      }
+      if (isEmpty) {
+        this.logger.info(
+          { baseSha: scopedReview.baseSha, headSha: scopedReview.headSha, round, workflowId },
+          'Resolution-scoped review window is empty with a prior artifact — running the delta verification pass instead',
+        );
+        scopedReview = undefined;
       }
     }
 
@@ -137,7 +168,7 @@ export class ReviewExecutor implements ReviewExecutorLike {
       markedReadyByEngine: false,
     };
     const prBaseRef = await this.resolvePrBaseRef(context);
-    const delta = await computeReviewDelta({
+    const rawDelta = await computeReviewDelta({
       github: context.github,
       artifact: priorForDelta,
       prBaseRef,
@@ -150,6 +181,16 @@ export class ReviewExecutor implements ReviewExecutorLike {
           }
         : {}),
     });
+    // #1164 FR-003: when the scope carries a conflicted-path allowlist, the raw
+    // `baseSha..headSha` parent-1 diff also lists everything the merged-in base
+    // brought along. Restrict the delta to the allowlist so both the charter's
+    // file list and `advanceArtifact`'s evidence rule see only the files the
+    // agent was actually told to inspect.
+    const scopedAllowlist = scopedReview?.conflictedPaths;
+    const delta =
+      scopedAllowlist && scopedAllowlist.length > 0
+        ? { ...rawDelta, files: [...scopedAllowlist] }
+        : rawDelta;
 
     // 3. Build the in-process charter naming the agent's sidecar write target.
     //    #1155: the agent writes the *candidate* path; the engine reads it and
@@ -158,6 +199,9 @@ export class ReviewExecutor implements ReviewExecutorLike {
     //    verification-framed: `buildVerificationPrompt` output is fed into the
     //    charter — NOT discarded (#1126/#1161, FR-005 / INV-C3). Round 1 keeps
     //    the whole-PR profile (data-model "Round-1 special case").
+    //    A scoped round with a prior artifact passes BOTH `diffWindow` and
+    //    `verification` — the charter then names the resolution window AND the
+    //    still-open prior findings to confirm.
     const sidecarRelPath = getReviewCandidateRelPath(workflowId);
     const verification = priorRound
       ? {
@@ -343,6 +387,9 @@ export class ReviewExecutor implements ReviewExecutorLike {
     const verdict = computeVerdict(merged, blockingSeverity);
 
     // 10. Stamp the commit reviewed (INV-C2 — the next round's delta base).
+    //     On a scoped round HEAD is the resolution merge commit the re-arm
+    //     checked out (`reviewScope.headSha`), so the next round's delta starts
+    //     AFTER the upstream merge and never re-spans it.
     const lastReviewedCommitSha = await context.github.getCurrentCommitSha();
 
     // 11. Persist the engine-authoritative artifact atomically (round advances
@@ -358,6 +405,14 @@ export class ReviewExecutor implements ReviewExecutorLike {
       lastReviewedCommitSha,
       remediationCount: priorRound?.remediationCount ?? 0,
       markedReadyByEngine: priorRound?.markedReadyByEngine ?? false,
+      // Mark the supplied scope consumed (whether it was applied this round or
+      // already recorded on the prior) so it is never re-applied; carry any
+      // prior marker forward when no scope was supplied.
+      ...(reviewScope !== undefined
+        ? { consumedReviewScopeHeadSha: reviewScope.headSha }
+        : priorRound?.consumedReviewScopeHeadSha !== undefined
+          ? { consumedReviewScopeHeadSha: priorRound.consumedReviewScopeHeadSha }
+          : {}),
     });
 
     // 12. Clear the candidate so it cannot be re-ingested on a later round.

--- a/packages/orchestrator/src/worker/review/__tests__/findings-advance.test.ts
+++ b/packages/orchestrator/src/worker/review/__tests__/findings-advance.test.ts
@@ -226,3 +226,69 @@ describe('advanceArtifact (FR-006 / SC-002 / SC-004)', () => {
     expect(merged.filter((f) => f.id === 'dup')).toHaveLength(1);
   });
 });
+
+describe('advanceArtifact — synthetic findings resolve on re-emission regardless of delta', () => {
+  // A validate-failure synthesis stores the validate COMMAND in `file`; a
+  // body-only external finding stores the `(pr-review)` placeholder. Neither
+  // can ever appear in `delta.files`, so the plain evidence rule carried them
+  // open forever and every validate failure rode to the remediation cap.
+  it('resolves an addressed synthetic:validate finding whose file is not in the delta', () => {
+    const prior = artifact({
+      findings: [
+        finding({
+          id: 'v1',
+          file: 'pnpm test && pnpm build',
+          title: 'validate phase failed',
+          synthetic: 'validate',
+        }),
+      ],
+    });
+    const merged = advanceArtifact(
+      prior,
+      delta({ files: ['src/fixed.ts'] }),
+      [finding({ id: 'v1', file: 'pnpm test && pnpm build', status: 'resolved', synthetic: undefined })],
+      [],
+      'critical',
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.status).toBe('resolved');
+    // The synthetic tag survives the transition.
+    expect(merged[0]?.synthetic).toBe('validate');
+    expect(computeVerdict(merged, 'critical')).toBe('clean');
+  });
+
+  it('resolves an addressed synthetic:external-body finding whose file is the placeholder', () => {
+    const prior = artifact({
+      findings: [finding({ id: 'e1', file: '(pr-review)', synthetic: 'external-body' })],
+    });
+    const merged = advanceArtifact(
+      prior,
+      delta({ files: ['src/a.ts'] }),
+      [finding({ id: 'e1', file: '(pr-review)', status: 'resolved' })],
+      [],
+      'critical',
+    );
+    expect(merged[0]?.status).toBe('resolved');
+  });
+
+  it('keeps an UNaddressed synthetic finding open (anti-vanish still applies)', () => {
+    const prior = artifact({
+      findings: [finding({ id: 'v1', file: 'pnpm test', synthetic: 'validate' })],
+    });
+    const merged = advanceArtifact(prior, delta({ files: ['src/a.ts'] }), [], [], 'critical');
+    expect(merged[0]?.status).toBe('open');
+    expect(computeVerdict(merged, 'critical')).toBe('changes-required');
+  });
+
+  it('does not relax the delta rule for a non-synthetic finding outside the delta', () => {
+    const prior = artifact({ findings: [finding({ id: 'r1', file: 'src/a.ts' })] });
+    const merged = advanceArtifact(
+      prior,
+      delta({ files: ['src/b.ts'] }),
+      [finding({ id: 'r1', file: 'src/a.ts', status: 'resolved' })],
+      [],
+      'critical',
+    );
+    expect(merged[0]?.status).toBe('open');
+  });
+});

--- a/packages/orchestrator/src/worker/review/__tests__/verification-prompt.test.ts
+++ b/packages/orchestrator/src/worker/review/__tests__/verification-prompt.test.ts
@@ -59,3 +59,29 @@ describe('buildVerificationPrompt (FR-004 / SC-006)', () => {
     expect(out).toContain('Open findings: none.');
   });
 });
+
+describe('buildVerificationPrompt — synthetic findings', () => {
+  it('tags a synthetic finding and explains how to confirm it', () => {
+    const out = buildVerificationPrompt({
+      round: 3,
+      openFindings: [
+        finding({
+          id: 'v1',
+          file: 'pnpm test && pnpm build',
+          line: undefined,
+          title: 'validate phase failed',
+          synthetic: 'validate',
+        }),
+      ],
+      charter: 'verification',
+    });
+    expect(out).toContain('validate phase failed (pnpm test && pnpm build) [synthetic: validate]');
+    expect(out).toContain('`[synthetic: validate]`');
+    expect(out).toContain('`status: "resolved"`');
+  });
+
+  it('does not emit the synthetic explainer when no finding is synthetic', () => {
+    const out = buildVerificationPrompt({ round: 2, openFindings: [finding()], charter: 'verification' });
+    expect(out).not.toContain('[synthetic:');
+  });
+});

--- a/packages/orchestrator/src/worker/review/findings-advance.ts
+++ b/packages/orchestrator/src/worker/review/findings-advance.ts
@@ -26,6 +26,12 @@ export function filterNewFindings(
  *
  * 1. `open` finding whose file is in `delta.changedFiles` and whose id matches a
  *    `reviewerAddressed` finding ⇒ `resolved`.
+ * 1b. `open` finding carrying a `synthetic` kind (validate-failure synthesis /
+ *    body-only external feedback) whose id matches a `reviewerAddressed`
+ *    finding ⇒ `resolved` REGARDLESS of delta membership. Its `file` is a
+ *    command string or placeholder that can never be a changed path, so the
+ *    delta rule would carry it open forever and ride every validate failure to
+ *    the remediation cap; the reviewer's explicit re-emission is the evidence.
  * 2. `open` findings not in the delta ⇒ unchanged (Q2 — evidence-based;
  *    anti-vanish carry-forward, SC-005).
  * 3. `resolved` findings ⇒ never touched (Q1 — terminal).
@@ -45,7 +51,11 @@ export function advanceArtifact(
 
   const priorFindings = prior?.findings ?? [];
   const transitioned: ReviewFinding[] = priorFindings.map((f) => {
-    if (f.status === 'open' && deltaFiles.has(f.file) && addressed.has(f.id)) {
+    if (
+      f.status === 'open' &&
+      addressed.has(f.id) &&
+      (f.synthetic !== undefined || deltaFiles.has(f.file))
+    ) {
       return { ...f, status: 'resolved' as const };
     }
     // resolved stays resolved (Q1); open-outside-delta stays open (Q2).

--- a/packages/orchestrator/src/worker/review/verification-prompt.ts
+++ b/packages/orchestrator/src/worker/review/verification-prompt.ts
@@ -40,11 +40,33 @@ export function buildVerificationPrompt(parts: VerificationPromptParts): string 
     lines.push('Open findings: none.');
   } else {
     lines.push('Open findings to verify:');
+    let hasSynthetic = false;
     for (const f of parts.openFindings) {
       const location = f.line != null ? `${f.file}:${f.line}` : f.file;
       lines.push('');
-      lines.push(`- [${f.severity}] ${f.title} (${location})`);
+      if (f.synthetic !== undefined) {
+        // Engine-synthesized, no path anchor: the `file` field holds the failing
+        // validate command / the `(pr-review)` placeholder. Flag it so the agent
+        // knows the "location" is not a file to open, and re-emits it verbatim.
+        hasSynthetic = true;
+        lines.push(`- [${f.severity}] ${f.title} (${location}) [synthetic: ${f.synthetic}]`);
+      } else {
+        lines.push(`- [${f.severity}] ${f.title} (${location})`);
+      }
       lines.push(`  ${f.detail}`);
+    }
+    if (hasSynthetic) {
+      lines.push('');
+      lines.push(
+        'Findings tagged `[synthetic: validate]` were synthesized by the engine from a ' +
+          'failing `validate` run — their `file` is the validate command that failed, not ' +
+          'a repository path. Findings tagged `[synthetic: external-body]` were seeded from ' +
+          'a PR-level review comment with no file anchor — their `file` is the `(pr-review)` ' +
+          'placeholder. For each, judge whether the changes since the last review address ' +
+          'the failure or feedback described in its detail. If they do, re-emit the finding ' +
+          'with the EXACT SAME `file` and `title` and `status: "resolved"`; if not, re-emit ' +
+          'it with `status: "open"`.',
+      );
     }
   }
 

--- a/packages/orchestrator/src/worker/seed-aware-review-executor.ts
+++ b/packages/orchestrator/src/worker/seed-aware-review-executor.ts
@@ -79,6 +79,11 @@ export class SeedAwareReviewExecutor implements ReviewExecutorLike {
         id: deriveFindingId(file, title),
         severity: SEEDED_FINDING_SEVERITY,
         file,
+        // A body-only comment has no path anchor: its `file` is the placeholder,
+        // which can never appear in a review delta. Mark it synthetic so
+        // `advanceArtifact` resolves it on the reviewer's re-emission alone
+        // instead of carrying it open to the remediation cap.
+        ...(f.path === undefined ? { synthetic: 'external-body' as const } : {}),
         ...(f.line !== undefined ? { line: f.line } : {}),
         title,
         // #1159 FR-004: the review comment body is attacker-controllable content

--- a/packages/workflow-engine/src/actions/github/client/__tests__/gh-cli.get-status.test.ts
+++ b/packages/workflow-engine/src/actions/github/client/__tests__/gh-cli.get-status.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for GhCliGitHubClient.getStatus porcelain invocation + parsing.
+ *
+ * `git status --porcelain` without `--untracked-files=all` collapses a wholly
+ * untracked directory into a single `?? dir/` entry, hiding the files inside
+ * from path-based consumers. The orchestrator's engine-sidecar staging filter
+ * (#1162) matches on file paths under `.generacy/`, so a collapsed `?? .generacy/`
+ * entry was staged wholesale — committing every sidecar. `getStatus` must ask
+ * git for every untracked file individually.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../cli-utils.js', () => ({
+  executeCommand: vi.fn(),
+  parseJSONSafe: vi.fn((input: string) => {
+    try { return JSON.parse(input); } catch { return null; }
+  }),
+}));
+
+import { executeCommand } from '../../../cli-utils.js';
+import { GhCliGitHubClient } from '../gh-cli.js';
+
+const mockExecuteCommand = vi.mocked(executeCommand);
+
+function ok(stdout: string) {
+  return { exitCode: 0, stdout, stderr: '' };
+}
+
+describe('GhCliGitHubClient.getStatus', () => {
+  beforeEach(() => {
+    mockExecuteCommand.mockReset();
+  });
+
+  it('runs `git status --porcelain --untracked-files=all` in the workdir', async () => {
+    mockExecuteCommand
+      .mockResolvedValueOnce(ok('feature\n'))   // branch --show-current
+      .mockResolvedValueOnce(ok(''))            // status
+      .mockResolvedValueOnce(ok('0\n'));        // rev-list --count
+    const client = new GhCliGitHubClient('/tmp/checkout');
+
+    await client.getStatus();
+
+    expect(mockExecuteCommand.mock.calls[1]).toEqual([
+      'git',
+      ['status', '--porcelain', '--untracked-files=all'],
+      { cwd: '/tmp/checkout' },
+    ]);
+  });
+
+  it('reports each untracked file under an untracked directory individually', async () => {
+    // What git emits WITH --untracked-files=all for a wholly-untracked .generacy/.
+    mockExecuteCommand
+      .mockResolvedValueOnce(ok('feature\n'))
+      .mockResolvedValueOnce(ok([
+        ' M src/modified.ts',
+        'A  src/added.ts',
+        'MM src/both.ts',
+        '?? .generacy/review-findings-o_r_42.json',
+        '?? .generacy/pause-context-o_r_42.json',
+        '?? src/new.ts',
+      ].join('\n') + '\n'))
+      .mockResolvedValueOnce(ok('0\n'));
+    const client = new GhCliGitHubClient('/tmp/checkout');
+
+    const status = await client.getStatus();
+
+    expect(status.untracked).toEqual([
+      '.generacy/review-findings-o_r_42.json',
+      '.generacy/pause-context-o_r_42.json',
+      'src/new.ts',
+    ]);
+    expect(status.untracked).not.toContain('.generacy/');
+    expect(status.unstaged).toEqual(['src/modified.ts', 'src/both.ts']);
+    expect(status.staged).toEqual(['src/added.ts', 'src/both.ts']);
+    expect(status.has_changes).toBe(true);
+    expect(status.branch).toBe('feature');
+  });
+});

--- a/packages/workflow-engine/src/actions/github/client/gh-cli.ts
+++ b/packages/workflow-engine/src/actions/github/client/gh-cli.ts
@@ -1275,7 +1275,16 @@ export class GhCliGitHubClient implements GitHubClient {
     const branchResult = await executeCommand('git', ['branch', '--show-current'], { cwd: this.workdir });
     const branch = branchResult.stdout.trim();
 
-    const statusResult = await executeCommand('git', ['status', '--porcelain'], { cwd: this.workdir });
+    // `--untracked-files=all`: report every untracked file individually. The
+    // default collapses a wholly-untracked directory into one `?? dir/` entry,
+    // which hides the files inside from path-based consumers (e.g. the
+    // orchestrator's engine-sidecar staging filter, #1162 — a bare `.generacy/`
+    // entry would be staged wholesale, committing every sidecar).
+    const statusResult = await executeCommand(
+      'git',
+      ['status', '--porcelain', '--untracked-files=all'],
+      { cwd: this.workdir },
+    );
     const lines = statusResult.stdout.split('\n').filter(l => l);
 
     const staged: string[] = [];

--- a/packages/workflow-engine/tests/actions/github/get-status-untracked-dir.integration.test.ts
+++ b/packages/workflow-engine/tests/actions/github/get-status-untracked-dir.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Real-git integration test for GhCliGitHubClient.getStatus (#1162).
+ *
+ * A wholly-untracked `.generacy/` directory must surface as one entry per file
+ * (`.generacy/review-findings-x.json`, ...) rather than a collapsed `.generacy/`
+ * directory entry, so path-prefix consumers (the orchestrator's engine-sidecar
+ * staging filter) can see — and skip — each sidecar.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GhCliGitHubClient } from '../../../src/actions/github/client/gh-cli.js';
+
+const execFileAsync = promisify(execFile);
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'test',
+  GIT_AUTHOR_EMAIL: 'test@example.com',
+  GIT_COMMITTER_NAME: 'test',
+  GIT_COMMITTER_EMAIL: 'test@example.com',
+};
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd, env: GIT_ENV });
+}
+
+describe('GhCliGitHubClient.getStatus — untracked directory expansion (real git)', () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'gh-cli-get-status-'));
+    await git(repo, 'init', '-q', '-b', 'main');
+    await writeFile(join(repo, 'README.md'), 'hello\n');
+    await git(repo, 'add', 'README.md');
+    await git(repo, 'commit', '-q', '-m', 'init');
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('lists every file inside a wholly-untracked .generacy/ directory', async () => {
+    await mkdir(join(repo, '.generacy'), { recursive: true });
+    await writeFile(join(repo, '.generacy', 'review-findings-x.json'), '{}');
+    await writeFile(join(repo, '.generacy', 'pause-context-x.json'), '{}');
+    await writeFile(join(repo, 'new.ts'), 'export {};\n');
+    await writeFile(join(repo, 'README.md'), 'edited\n');
+
+    const status = await new GhCliGitHubClient(repo).getStatus();
+
+    expect(status.branch).toBe('main');
+    expect(status.has_changes).toBe(true);
+    expect(status.untracked.sort()).toEqual([
+      '.generacy/pause-context-x.json',
+      '.generacy/review-findings-x.json',
+      'new.ts',
+    ]);
+    expect(status.untracked).not.toContain('.generacy/');
+    expect(status.unstaged).toEqual(['README.md']);
+    expect(status.staged).toEqual([]);
+  });
+});

--- a/packages/workflow-engine/tests/handlers/sibling-fanout.test.ts
+++ b/packages/workflow-engine/tests/handlers/sibling-fanout.test.ts
@@ -110,8 +110,8 @@ function setupFullFlowMocks(opts: {
       return success('feature-branch\n');
     }
 
-    // git status --porcelain
-    if (cmd === 'git' && argsStr === 'status --porcelain') {
+    // git status --porcelain --untracked-files=all
+    if (cmd === 'git' && argsStr === 'status --porcelain --untracked-files=all') {
       if (siblingDirty && callIndex <= 3) return success(' M file.ts\n');
       return success('');
     }
@@ -302,7 +302,7 @@ describe('siblingFanoutHandler', () => {
         const argsStr = (args as string[]).join(' ');
 
         if (cmd === 'git' && argsStr === 'branch --show-current') return success('feature-branch\n');
-        if (cmd === 'git' && argsStr === 'status --porcelain') {
+        if (cmd === 'git' && argsStr === 'status --porcelain --untracked-files=all') {
           if (callCount <= 3) return success(' M file.ts\n');
           return success('');
         }
@@ -372,7 +372,7 @@ describe('siblingFanoutHandler', () => {
           workdirContext = cwd;
           return success('feature-branch\n');
         }
-        if (cmd === 'git' && argsStr === 'status --porcelain') {
+        if (cmd === 'git' && argsStr === 'status --porcelain --untracked-files=all') {
           // Both siblings have changes
           return success(' M file.ts\n');
         }


### PR DESCRIPTION
## Summary

Second-wave fixes from the post-merge review of epic #1153 (review/remediate follow-ups). Every item below was verified against the code before fixing and is covered by new unit and composed-integration tests.

- **Resume strip** — explicit retain set (`resolveResumeRetainSuffixes`): only `completed:remediation-limit` (+ `completed:implementation-review` when `ciMergeGateEnabled`) survive `onResumeStart`; `completed:ci` / `completed:clarification` / `completed:sibling-review` are stripped again, so clarify follow-ups re-pause and a CI re-pause can't pair with a stale answer label.
- **CI merge gate** — actions-runs `green` trusted again (blind spot logged); the pause comment carries `<!-- generacy-ci-pause -->` + a verdict/sha fingerprint and reports the real verdict + source; same-fingerprint re-pauses don't re-post.
- **Remediation-limit comment dedupe** now reads issue comments (it posts issue comments).
- **Redis remediation budget** cleared on `completed: true` and at the on-ci-green approval pause (loop converged), kept across non-converging exits.
- **Synthetic findings** — `ReviewFinding.synthetic?: 'validate' | 'external-body'`; resolve on `addressed` regardless of delta; validate-origin findings auto-resolve on a green validate. Composed test proves validate-fail → remediate → converge without hitting the cap.
- **Scoped review** gated on `consumedReviewScopeHeadSha` (not "no prior artifact"); a scoped round with a prior artifact is allowlisted *and* a verification pass.
- **Sidecars** — `git clean -fd -e <prefix>*` at both checkout refresh sites; `getStatus --untracked-files=all`; collapsed-`.generacy/` skip in `PrManager` and the legacy `PrFeedbackHandler` (now `stageFiles` + pathspec commit, no `git add -A`).
- **fail-then-pass** — classifier reordered against captured real vitest/pnpm output; `pnpm --dir <pkg> exec vitest` fallback for repos without root vitest (`--filter` exits 0 on no match).
- Test hygiene: six suites re-pointed from the deleted `review-findings-artifact.js` to the live schema.

## Verification

`pnpm -r build` + `tsc --noEmit` clean; lint 0 errors. Unit: orchestrator 3,431 / workflow-engine 1,069 / config 180 / cockpit 511 / plugin 151 green. Integration: all review/remediate suites green (the two Redis-backed queue-adapter files need a live Redis and are untouched).

Counterparts: agency (auto.md D.14 `waiting-for:ci` row, G.9 marker fetch) and generacy-cloud (gate-type enum 8→10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
