### PR TITLE
fix(orchestrator): capture agent messages in CLI-phase failure comments

### DIFF
--- a/.changeset/capture-cli-failure-output-tail.md
+++ b/.changeset/capture-cli-failure-output-tail.md
@@ -1,0 +1,15 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+Capture the agent's real messages in CLI-phase failure comments. The worker's
+`OutputCapture` stores every Claude CLI stream-json line as a `type: 'text'`
+chunk whose `data` is the raw envelope, so the agent's prose lives at
+`data.message.content[].text` (assistant turns) or `data.result` (final turn) —
+not at a flat `data.text`. `synthesizeOutputTail` only read `data.text`, so every
+CLI-phase failure comment (e.g. `implement` failing `no-product-code-changes`)
+rendered an empty or one-line "output (last N lines)" tail even when the agent
+had explained itself at length. Extract text from all three envelope shapes so
+the diagnostic tail carries the agent's last message — the "why it stopped"
+narrative that is the whole point of the failure comment — while still skipping
+structural tool/lifecycle chunks and de-duplicating the trailing `result` echo.

--- a/packages/orchestrator/src/worker/__tests__/output-tail-synthesis.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/output-tail-synthesis.test.ts
@@ -56,6 +56,71 @@ describe('synthesizeOutputTail', () => {
     expect(synthesizeOutputTail(chunks)).toBe('kept\nalso kept');
   });
 
+  it('extracts prose from assistant-envelope chunks (data.message.content[].text)', () => {
+    // Real stream-json shape: OutputCapture stores the whole envelope as
+    // `data` with the chunk typed 'text'. The agent's text is nested.
+    const assistantChunk = (text: string): OutputChunk => ({
+      type: 'text',
+      data: {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text }] },
+      },
+      timestamp: '2026-07-09T00:00:00.000Z',
+    });
+    const chunks: OutputChunk[] = [
+      nonTextChunk('init'),
+      assistantChunk('working on T007'),
+      assistantChunk('Implementation complete. All 37 tasks done.'),
+    ];
+    expect(synthesizeOutputTail(chunks)).toBe(
+      'working on T007\nImplementation complete. All 37 tasks done.',
+    );
+  });
+
+  it('concatenates multiple text blocks within one assistant message and skips tool_use blocks', () => {
+    const chunks: OutputChunk[] = [
+      {
+        type: 'text',
+        data: {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: 'first block' },
+              { type: 'tool_use', name: 'Write', input: {} },
+              { type: 'text', text: 'second block' },
+            ],
+          },
+        },
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ];
+    expect(synthesizeOutputTail(chunks)).toBe('first block\nsecond block');
+  });
+
+  it('includes a result-envelope string only when it is not a duplicate of the last assistant text', () => {
+    const finalText = 'Implementation complete.';
+    const withDuplicateResult: OutputChunk[] = [
+      {
+        type: 'text',
+        data: { type: 'assistant', message: { content: [{ type: 'text', text: finalText }] } },
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+      {
+        type: 'text',
+        data: { type: 'result', subtype: 'success', result: finalText },
+        timestamp: '2026-07-09T00:00:00.000Z',
+      },
+    ];
+    // Duplicate result is dropped → the message appears once.
+    expect(synthesizeOutputTail(withDuplicateResult)).toBe(finalText);
+
+    // Result-only (no assistant text) → the result string is the tail.
+    const resultOnly: OutputChunk[] = [
+      { type: 'text', data: { type: 'result', result: 'terminal summary' }, timestamp: '2026-07-09T00:00:00.000Z' },
+    ];
+    expect(synthesizeOutputTail(resultOnly)).toBe('terminal summary');
+  });
+
   it('bounds adversarial 10 000 x 500-byte text chunks to ≤ 4200 bytes with truncation marker (SC-002)', () => {
     const bigLine = 'x'.repeat(500);
     const chunks: OutputChunk[] = Array.from({ length: 10_000 }, () => textChunk(bigLine));

--- a/packages/orchestrator/src/worker/output-tail-synthesis.ts
+++ b/packages/orchestrator/src/worker/output-tail-synthesis.ts
@@ -5,20 +5,69 @@ import { boundOutputTail } from './output-tail.js';
  * Synthesize a bounded output tail for a CLI phase's PhaseResult from its
  * parsed OutputChunk[] transcript.
  *
- * Joins the `data.text` string of every chunk with `type === 'text'` in stored
- * order (Claude CLI emits these in write order via `processChunk`), separated
- * by newlines, then feeds through `boundOutputTail` for the 4 KiB cap.
+ * The worker's `OutputCapture` stores every Claude CLI stdout line as a chunk
+ * whose `data` is the RAW stream-json envelope: any top-level `type` it does not
+ * recognize — including `assistant` and `result` — is mapped to the OutputChunk
+ * `type: 'text'` while the full envelope is kept verbatim as `data`. The agent's
+ * actual prose therefore lives at one of three shapes, NOT at a flat `data.text`:
  *
- * Non-text chunks (`init`, `tool_use`, `tool_result`, `complete`, `error`) are
- * skipped — their content is either structural or already-summarized event JSON,
- * which would clutter the tail without adding diagnostic value.
+ *   1. `{ text: string }`
+ *        — legacy / non-JSON / `SPECKIT_IMPLEMENT_PARTIAL` sentinel lines.
+ *   2. `{ type: 'assistant', message: { content: [ { type: 'text', text } ] } }`
+ *        — assistant turns (the model's messages, incl. its final "why I stopped"
+ *          narrative — the single most useful line when a phase fails).
+ *   3. `{ type: 'result', result: string }`
+ *        — the CLI's final turn text (usually a duplicate of the last assistant
+ *          text block).
+ *
+ * Reading only `data.text` (the pre-fix behavior) captured NONE of the real
+ * assistant/result prose, so failure comments rendered an empty or one-line
+ * tail even when the agent had explained itself at length. Extract text from all
+ * three shapes so the diagnostic tail carries the agent's last message, then
+ * feed through `boundOutputTail` for the 4 KiB / last-30-lines cap. Structural
+ * chunks (`init`, `tool_use`, `tool_result`, `complete`, `error`) contribute
+ * nothing.
  */
 export function synthesizeOutputTail(chunks: OutputChunk[]): string {
   const texts: string[] = [];
   for (const chunk of chunks) {
-    if (chunk.type !== 'text') continue;
-    const data = chunk.data as { text?: unknown } | null | undefined;
-    if (data && typeof data.text === 'string') texts.push(data.text);
+    const data = chunk.data;
+    if (data == null || typeof data !== 'object') continue;
+    const d = data as Record<string, unknown>;
+
+    // Shape 1 — flat text (legacy / non-JSON / sentinel lines).
+    if (typeof d.text === 'string') {
+      texts.push(d.text);
+      continue;
+    }
+
+    // Shape 2 — assistant envelope: concatenate its `text` content blocks.
+    if (d.type === 'assistant') {
+      const message = d.message as { content?: unknown } | null | undefined;
+      const content = message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block != null &&
+            typeof block === 'object' &&
+            (block as Record<string, unknown>).type === 'text' &&
+            typeof (block as Record<string, unknown>).text === 'string'
+          ) {
+            texts.push((block as Record<string, unknown>).text as string);
+          }
+        }
+      }
+      continue;
+    }
+
+    // Shape 3 — result envelope: include only when it adds something over the
+    // last assistant text block it typically duplicates.
+    if (d.type === 'result' && typeof d.result === 'string') {
+      if (texts.length === 0 || texts[texts.length - 1] !== d.result) {
+        texts.push(d.result);
+      }
+      continue;
+    }
   }
   return boundOutputTail(texts.join('\n'));
 }


### PR DESCRIPTION
## Problem

When a CLI phase fails (e.g. `implement` failing `no-product-code-changes`), the failure comment posted to the issue rendered an empty or one-line `output (last N lines)` block — even when the agent had written a long final message explaining what it did / why it stopped. This defeated the diagnostic purpose of the comment.

**Root cause:** the worker's `OutputCapture` maps every Claude CLI `--output-format stream-json` line to a `type: 'text'` `OutputChunk` but keeps the **raw envelope** as `data`. The agent's actual prose therefore lives at:

- `data.message.content[].text` — assistant turns
- `data.result` — the CLI's final turn text

…not at a flat `data.text`. `synthesizeOutputTail` only read `data.text`, so it extracted **none** of the real assistant/result prose (matching the sibling `conversation/output-parser.ts`, which already parses the envelope correctly).

Concrete example (doc-intel#26): the agent's final message was *"Implementation of issue #26 is complete. All 37 tasks are done and every gate is green…"* — yet the guard reported `Own-commit files: []`. That contradiction is exactly what an operator needs to see, and it was being dropped.

## Fix

`synthesizeOutputTail` now extracts text from all three envelope shapes (flat `text`, assistant `message.content[].text`, `result`), skips structural tool/lifecycle chunks, and de-duplicates the trailing `result` echo of the last assistant message. The shell-path (`buildErrorEvidence` with a real `error.output` ring buffer) is unchanged.

## Tests

- Added 3 cases: assistant-envelope extraction, multi-block + `tool_use` skip within one message, and `result` dedup / result-only.
- `155/155` pass across the failure-evidence path (output-tail-synthesis, stage-comment-manager, phase-loop, failure-fingerprint, cli-spawner, merge-conflict-evidence). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)