### PR TITLE
fix(orchestrator): grant completed:review only on a clean verdict

### DIFF
--- a/.changeset/gate-completed-review-on-clean-verdict.md
+++ b/.changeset/gate-completed-review-on-clean-verdict.md
@@ -1,0 +1,19 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+Grant `completed:review` only on a clean review verdict. The phase loop granted
+`completed:review` on every successful review-phase execution — before the
+verdict was inspected — so a `changes-required` review (about to remediate and
+re-review) was labelled "review completed" while its findings were still open.
+That misreported progress (cockpit's `STAGE_COMPLETE_PIPELINE_ORDER` treats
+`completed:review` as a stage-complete marker) and set the label-derived-resume
+trap the merge-conflict path already carries an explicit-`startPhase` workaround
+for (a resume could resolve straight past an open review into `validate`).
+
+The review verdict is now read up front and the grant is gated on it: a
+`changes-required` pass clears `phase:review` without granting `completed:review`
+(new `LabelManager.onPhaseExecutedWithoutCompletion`), and the clean grant lands
+on the converging pass. The cap/remediate/verdict logic keys on the review
+sidecar (`verdict` / `remediationCount` / `round`), never on this label, so
+withholding it is behavior-safe.

--- a/packages/orchestrator/src/__tests__/pr-feedback-external-remediate.integration.test.ts
+++ b/packages/orchestrator/src/__tests__/pr-feedback-external-remediate.integration.test.ts
@@ -182,6 +182,7 @@ function baseDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onRepeatedError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/address-pr-feedback-route.budget-persistence.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/address-pr-feedback-route.budget-persistence.test.ts
@@ -64,6 +64,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/address-pr-feedback-route.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/address-pr-feedback-route.integration.test.ts
@@ -65,6 +65,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/address-pr-feedback-route.remediation-cap.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/address-pr-feedback-route.remediation-cap.test.ts
@@ -57,6 +57,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/helpers/bugfix-harness.ts
+++ b/packages/orchestrator/src/worker/__tests__/helpers/bugfix-harness.ts
@@ -439,6 +439,7 @@ export function createBugfixDeps(options: BugfixDepsOptions = {}): BugfixDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/helpers/review-composition-harness.ts
+++ b/packages/orchestrator/src/worker/__tests__/helpers/review-composition-harness.ts
@@ -214,6 +214,7 @@ export async function createReviewCompositionHarness(
       labelManager: {
         onPhaseStart: vi.fn().mockResolvedValue(undefined),
         onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+        onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
         onError: vi.fn().mockResolvedValue(undefined),
         onGateHit: vi.fn().mockResolvedValue(undefined),
       } as unknown as PhaseLoopDeps['labelManager'],

--- a/packages/orchestrator/src/worker/__tests__/phase-loop-provider-switch.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop-provider-switch.test.ts
@@ -59,6 +59,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop-repeat-failure.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop-repeat-failure.test.ts
@@ -71,6 +71,7 @@ function createDeps(): DepsHandles {
       labelManager: {
         onPhaseStart: vi.fn().mockResolvedValue(undefined),
         onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+        onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
         onError,
         onRepeatedError,
         onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/phase-loop-review-remediate.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop-review-remediate.test.ts
@@ -30,6 +30,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.ci-merge-gate.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.ci-merge-gate.test.ts
@@ -57,6 +57,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.ci-wait-timeout.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.ci-wait-timeout.test.ts
@@ -54,6 +54,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.flag-off-validate-fix.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.flag-off-validate-fix.test.ts
@@ -90,6 +90,7 @@ function makeDeps(opts: DepsOptions): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onRepeatedError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.merge-conflict-scoped-review.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.merge-conflict-scoped-review.integration.test.ts
@@ -74,6 +74,7 @@ function createMockDeps(github: GitHubClient): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,
@@ -301,6 +302,7 @@ describe('#1164 T009 — scoped-review remediation converges (SC-001/FR-002)', (
       labelManager: {
         onPhaseStart: vi.fn().mockResolvedValue(undefined),
         onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+        onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
         onError: vi.fn().mockResolvedValue(undefined),
         onGateHit: vi.fn().mockResolvedValue(undefined),
         onRepeatedError: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.merge.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.merge.test.ts
@@ -38,6 +38,7 @@ function createMockDeps(baseMergeRunner?: BaseMergeRunner): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.prevalidate-command.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.prevalidate-command.test.ts
@@ -36,6 +36,7 @@ function createDeps(runPreValidateInstall: ReturnType<typeof vi.fn>): PhaseLoopD
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.product-diff.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.product-diff.test.ts
@@ -21,6 +21,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediate-skip-revert.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediate-skip-revert.test.ts
@@ -109,6 +109,7 @@ function makeDeps(
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onRepeatedError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediate-timeout.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediate-timeout.integration.test.ts
@@ -193,6 +193,7 @@ describe('#1128 — SC-006 remediate timeout integration', () => {
       labelManager: {
         onPhaseStart: vi.fn().mockResolvedValue(undefined),
         onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+        onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
         onError: vi.fn().mockResolvedValue(undefined),
         onGateHit: vi.fn().mockResolvedValue(undefined),
       } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediate.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediate.test.ts
@@ -53,6 +53,7 @@ function createMockDeps(labelSink: LabelSink): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn(async (_phase: WorkflowPhase, gateLabel: string) => {
         labelSink.seen.push(gateLabel);

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-comment-dedupe.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-comment-dedupe.test.ts
@@ -92,6 +92,7 @@ function baseDeps(prNumber: number | undefined = PR_NUMBER): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onRepeatedError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-persist.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.remediation-persist.test.ts
@@ -111,6 +111,7 @@ function baseDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onRepeatedError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.review-remediate.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.review-remediate.integration.test.ts
@@ -54,6 +54,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.review-side-effects.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.review-side-effects.integration.test.ts
@@ -33,6 +33,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as never,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.review.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.review.test.ts
@@ -49,6 +49,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,
@@ -242,6 +243,43 @@ describe('#1124 — review executor verdict seam + remediation cap', () => {
     expect(phaseStartOrder(deps)).toEqual(['implement', 'review', 'remediate', 'review', 'validate']);
     expect(deps.labelManager.onPhaseComplete).toHaveBeenCalledWith('remediate');
     expect(deps.labelManager.onGateHit).not.toHaveBeenCalled();
+  });
+
+  it('completed:review is gated on a clean verdict: a changes-required pass clears phase:review without granting completed:review, and only the converging clean pass grants it', async () => {
+    // round 1 → changes-required (loops through remediate), round 2 → clean.
+    const { executor } = makeReviewExecutor(checkoutPath, (r) => (r === 1 ? 'changes-required' : 'clean'));
+    deps.reviewExecutor = executor;
+    deps.remediateTrigger = remediateTrigger;
+    // Wire the production-shaped findings reader so the gate activates (it is a
+    // no-op when unwired — the pre-fix fallback).
+    deps.readFindingsArtifact = async (ctx) => {
+      const artifact = readReviewArtifactSync(
+        ctx.checkoutPath,
+        `${ctx.item.owner}/${ctx.item.repo}#${ctx.item.issueNumber}`,
+      );
+      return artifact ? { artifact, blockingSeverity: 'major' as const } : null;
+    };
+    const config = createConfig({ reviewPhaseEnabled: true });
+    const sequence = getPhaseSequence('speckit-feature', true) as WorkflowPhase[];
+
+    const result = await phaseLoop.executeLoop(createMockContext(checkoutPath), config, deps, sequence);
+
+    expect(result.completed).toBe(true);
+    expect(phaseStartOrder(deps)).toEqual(['implement', 'review', 'remediate', 'review', 'validate']);
+
+    const completeCalls = (deps.labelManager.onPhaseComplete as any).mock.calls.map((c: unknown[]) => c[0]);
+    const noCompleteCalls = (deps.labelManager.onPhaseExecutedWithoutCompletion as any).mock.calls.map(
+      (c: unknown[]) => c[0],
+    );
+
+    // The changes-required (round 1) review executed WITHOUT completion...
+    expect(noCompleteCalls).toEqual(['review']);
+    // ...and completed:review is granted exactly once — on the clean round-2 pass.
+    expect(completeCalls.filter((p: WorkflowPhase) => p === 'review')).toEqual(['review']);
+    // Sibling phases still complete normally.
+    expect(completeCalls).toContain('implement');
+    expect(completeCalls).toContain('remediate');
+    expect(completeCalls).toContain('validate');
   });
 
   it('FR-011: exhausting maxRemediations fires the on-remediation-limit gate and pauses', async () => {

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.targeted-validate.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.targeted-validate.test.ts
@@ -74,6 +74,7 @@ function createDeps(runValidatePhase: ReturnType<typeof vi.fn>): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.test.ts
@@ -44,6 +44,7 @@ function createMockDeps(): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.validate-command.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.validate-command.test.ts
@@ -53,6 +53,7 @@ function createDeps(runValidatePhase: ReturnType<typeof vi.fn>): PhaseLoopDeps {
     labelManager: {
       onPhaseStart: vi.fn().mockResolvedValue(undefined),
       onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+      onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
       onError: vi.fn().mockResolvedValue(undefined),
       onGateHit: vi.fn().mockResolvedValue(undefined),
     } as any,

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.validate-fingerprint.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.validate-fingerprint.test.ts
@@ -101,6 +101,7 @@ function createDeps(checkoutPath: string, priorCount: number, workflowId: string
       labelManager: {
         onPhaseStart: vi.fn().mockResolvedValue(undefined),
         onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+        onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
         onError,
         onRepeatedError,
         onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/__tests__/phase-loop.validate-remediate.integration.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/phase-loop.validate-remediate.integration.test.ts
@@ -113,6 +113,7 @@ function createDeps(
           phaseStarts.push(phase);
         }),
         onPhaseComplete: vi.fn().mockResolvedValue(undefined),
+        onPhaseExecutedWithoutCompletion: vi.fn().mockResolvedValue(undefined),
         onError,
         onRepeatedError,
         onGateHit: vi.fn().mockResolvedValue(undefined),

--- a/packages/orchestrator/src/worker/label-manager.ts
+++ b/packages/orchestrator/src/worker/label-manager.ts
@@ -247,6 +247,37 @@ export class LabelManager {
   }
 
   /**
+   * Called when a phase executed successfully but must NOT be marked complete —
+   * i.e. it will loop rather than advance. Removes the `phase:<current>`
+   * in-progress label WITHOUT granting `completed:<current>`.
+   *
+   * The `review` phase uses this when its verdict is `changes-required`: the
+   * phase ran (so `phase:review` must go), but review has not reached a clean
+   * verdict, so `completed:review` must not be granted. Granting it would both
+   * misreport progress (cockpit `STAGE_COMPLETE_PIPELINE_ORDER` treats
+   * `completed:review` as a stage-complete marker) and let a label-derived
+   * resume resolve straight past the open review into `validate`
+   * (claude-cli-worker's merge-conflict path documents exactly this trap). The
+   * `completed:review` grant instead happens on the converging clean pass via
+   * `onPhaseComplete`. The cap/remediate/verdict logic is sidecar-based
+   * (`verdict` / `remediationCount` / `round`) and never keys on this label, so
+   * withholding it is safe.
+   */
+  async onPhaseExecutedWithoutCompletion(phase: WorkflowPhase): Promise<void> {
+    const phaseLabel = `phase:${phase}`;
+    await this.retryWithBackoff(async () => {
+      await this.ensureRepoLabelsExist();
+
+      this.logger.info(
+        { phase, issue: this.issueNumber },
+        `Phase executed without completion: removing ${phaseLabel} (no completed:${phase} — verdict not clean)`,
+      );
+
+      await this.github.removeLabels(this.owner, this.repo, this.issueNumber, [phaseLabel]);
+    }, { site: 'phase-executed-no-completion', labelOp: `removeLabels([${phaseLabel}])` });
+  }
+
+  /**
    * Called when a gate is hit and the workflow must pause for human review.
    *
    * Adds `waiting-for:<gate>` and `agent:paused` labels, removes `phase:<current>`.

--- a/packages/orchestrator/src/worker/phase-loop.ts
+++ b/packages/orchestrator/src/worker/phase-loop.ts
@@ -1782,13 +1782,39 @@ export class PhaseLoop {
         return { results, completed: false, lastPhase: phase, gateHit: true };
       }
 
+      // `completed:review` must mean "review reached a CLEAN verdict", not
+      // merely "the review phase executed". A `changes-required` verdict means
+      // the loop is about to remediate + re-review, so granting completed:review
+      // here would (a) misreport progress (cockpit STAGE_COMPLETE_PIPELINE_ORDER
+      // treats it as a stage-complete marker) and (b) let a label-derived resume
+      // resolve straight past the open review into `validate` (the merge-conflict
+      // path in claude-cli-worker documents exactly this trap). Read the verdict
+      // up front so the grant can be gated on it. Verdict is strictly
+      // `clean` | `changes-required`, so `!== 'clean'` aligns with the
+      // remediateTrigger and on-remediation-limit gate, both of which key on the
+      // sidecar — never on this label — so withholding the label is safe.
+      const reviewArtifactRead =
+        phase === 'review' && result.success && deps.readFindingsArtifact
+          ? await deps.readFindingsArtifact(context)
+          : null;
+
       // 6b. #958 FR-008 — grant `completed:<phase>` only after every gate
       // evaluation returned "skip" (either not active, or already satisfied).
       // The pre-#958 placement (before gate check) meant any code path that
       // skipped the gate left the advance-authorizing label in place. This
       // ordering also lets `LabelManager.onGateHit` drop its dead-code
       // retract-the-completed-label branch (T012).
-      await labelManager.onPhaseComplete(phase);
+      if (
+        phase === 'review'
+        && reviewArtifactRead
+        && reviewArtifactRead.artifact.verdict !== 'clean'
+      ) {
+        // Review ran but requires changes — clear phase:review WITHOUT granting
+        // completed:review; the clean grant lands on the converging pass.
+        await labelManager.onPhaseExecutedWithoutCompletion(phase);
+      } else {
+        await labelManager.onPhaseComplete(phase);
+      }
 
       // 7. Record phase completion time
       const phaseTs = phaseTimestamps.get(phase);
@@ -1823,7 +1849,9 @@ export class PhaseLoop {
         && deps.readFindingsArtifact
         && deps.reviewPoster
       ) {
-        const read = await deps.readFindingsArtifact(context);
+        // Reuse the artifact already read above for the completed:review gating
+        // (same canonical sidecar) instead of reading it a second time.
+        const read = reviewArtifactRead;
         if (read) {
           const { artifact, blockingSeverity } = read;
           await deps.reviewPoster.postRound(artifact.findings, artifact.round, blockingSeverity);

--- a/packages/orchestrator/src/worker/terminal-label-op-error.ts
+++ b/packages/orchestrator/src/worker/terminal-label-op-error.ts
@@ -10,6 +10,7 @@ export type TerminalLabelOpSite =
   | 'gate-hit'
   | 'phase-start'
   | 'phase-complete'
+  | 'phase-executed-no-completion'
   | 'error'
   | 'error-repeated'
   | 'resume-start'


### PR DESCRIPTION
## Problem

`completed:review` was granted by an **unconditional** `labelManager.onPhaseComplete('review')` on any successful review-phase execution — **before** the verdict was inspected (the blocking-findings check that fires remediate runs later). So a `changes-required` review, which is about to `remediate` and re-review, was labelled "review completed" while its findings were still open.

Observed live on doc-intel#26 (engine-native review/remediate, flag-ON):

```
15:52:50  phase:review
15:55:36  completed:review    ← granted here
15:55:41  phase:remediate     ← immediately remediates ⇒ that review had BLOCKING findings
```

Two concrete harms:
- **Misreported progress** — cockpit's `STAGE_COMPLETE_PIPELINE_ORDER` (packages/cockpit/src/state/precedence.ts) treats `completed:review` as a stage-complete marker, so status reads the issue as further along than it is.
- **Label-derived resume trap** — `claude-cli-worker.ts` already documents it: *"a conflict during `validate`, after `review` already ran, carries `completed:review` and would resolve straight back to `validate`"* and carries an explicit-`startPhase` workaround for exactly that. A premature grant is the root cause that workaround patches.

## Fix

Read the review verdict up front and gate the grant on it:
- `changes-required` → clear `phase:review` **without** granting `completed:review` (new `LabelManager.onPhaseExecutedWithoutCompletion`); the clean grant lands on the converging pass.
- `clean` → `onPhaseComplete('review')` as before.

Verdict is strictly `clean | changes-required`, so `!== 'clean'` aligns with `remediateTrigger` and the `on-remediation-limit` gate. Both of those — and the whole cap/remediate loop — key on the **review sidecar** (`verdict` / `remediationCount` / `round`), never on this label, so withholding the label is behavior-safe. The hoisted read is reused by the existing `#1125` review side-effect block (no extra sidecar read).

The findings reader being unwired (flag-off / non-worker paths) falls back to the prior `onPhaseComplete` behavior, so no behavior change there.

## Tests

- New `phase-loop.review` case: a `changes-required` pass calls `onPhaseExecutedWithoutCompletion('review')` and does **not** grant `completed:review`; the converging clean pass grants it exactly once; sibling phases still complete.
- Added the new mock method where a bespoke `labelManager` double is used.
- Full worker suite green: **1427/1427**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)