### PR TITLE
fix(orchestrator): key the clarify question-heading discriminator on trailing content (#1189)

### DIFF
--- a/.changeset/1189-clarify-gate-self-answer.md
+++ b/.changeset/1189-clarify-gate-self-answer.md
@@ -1,0 +1,9 @@
+---
+"@generacy-ai/orchestrator": patch
+---
+
+Fix the clarify gate silently self-answering and skipping (#1189).
+
+The FR-004 discriminator that distinguishes a question comment from a cockpit answer block required a colon after `Q<n>` (`### Q1: Topic`). A clarification batch posted with a different separator — `### Q1 — Topic` — therefore fell on the answer-block side of the test: the fail-closed guard never fired, `parseAnswersFromComments` captured each question's own topic as its answer, `clarifications.md` was written with `**Answer**: — <question title>`, every question read as answered, and the `on-questions` gate was skipped. The workflow then ran plan → tasks → implement on unanswered design questions, and because integration only ever replaces the literal `*Pending*`, a real answer posted afterwards could never land.
+
+The discriminator now keys on whether the `Q<n>` heading line carries any trailing content, which is the property that actually separates the two shapes: a question comment always names its topic on the heading line, while a cockpit answer block writes a bare `### Q1` and puts the answer on the next line. A bare heading (with or without trailing whitespace) still does not match, so legitimate cockpit integrations are unaffected.

--- a/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
+++ b/packages/orchestrator/src/worker/__tests__/clarification-poster.test.ts
@@ -2095,6 +2095,57 @@ describe('negative regressions (#949, T015-T017)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1189: em-dash question headings must trip the FR-004 discriminator
+// ---------------------------------------------------------------------------
+describe('#1189: question-heading discriminator is separator-agnostic', () => {
+  const logger = createMockLogger();
+
+  it('an em-dash question comment (`### Q1 - Topic`) sets sourceHadQuestionHeadings', () => {
+    // Verbatim shape of the comment that caused #1189 on generacy#1187: the
+    // agent composed its own question batch with em-dash headings instead of
+    // the engine's `### Q<n>: <topic>`. The pre-#1189 colon-only discriminator
+    // did not fire, so each question's TOPIC was captured as its ANSWER and the
+    // `on-questions` gate was silently skipped.
+    const body = [
+      '## Clarification questions (speckit `/clarify`)',
+      '',
+      '### Q1 \u2014 Sentinel authority vs tasks.md',
+      '**Context**: FR-001 gates the fallback on `implementResult === undefined`.',
+      '**Question**: Trust the sentinel, or re-enter implement?',
+    ].join('\n');
+
+    const answers = parseAnswersFromComments([{ id: 601, body }], [1], logger);
+
+    // The block still parses (the opener grammar is unchanged) — what matters
+    // is that it is FLAGGED, so `integrateGitHubAnswers` takes the FR-004
+    // fail-closed branch rather than writing the topic in as an answer.
+    expect(answers.get(1)?.sourceHadQuestionHeadings).toBe(true);
+  });
+
+  it('a bare cockpit answer delimiter (`### Q1` + answer on the next line) does NOT set it', () => {
+    // Guards the no-false-positive property the required colon used to
+    // provide: widening the discriminator must not make every legitimate
+    // cockpit integration look like a question comment.
+    const body = ['### Q1', '**Answer:** B', '', '### Q2  ', '**Answer:** A'].join('\n');
+
+    const answers = parseAnswersFromComments([{ id: 602, body }], [1, 2], logger);
+
+    expect(answers.get(1)?.sourceHadQuestionHeadings).toBe(false);
+    // Trailing whitespace after `### Q2` must not read as trailing content.
+    expect(answers.get(2)?.sourceHadQuestionHeadings).toBe(false);
+    expect(answers.get(1)?.answer).toBe('B');
+    expect(answers.get(2)?.answer).toBe('A');
+  });
+
+  it("the engine's own colon shape (`### Q1: Topic`) keeps setting it", () => {
+    const body = ['### Q1: Fix approach', '**Context**: whichever.'].join('\n');
+    const answers = parseAnswersFromComments([{ id: 603, body }], [1], logger);
+    expect(answers.get(1)?.sourceHadQuestionHeadings).toBe(true);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
 // T018: FR-013 — cockpit-format answer from untrusted author produces explainer
 // ---------------------------------------------------------------------------
 describe('FR-013: cockpit-format answer from untrusted author produces explainer (#949, T018)', () => {

--- a/packages/orchestrator/src/worker/clarification-poster.ts
+++ b/packages/orchestrator/src/worker/clarification-poster.ts
@@ -614,16 +614,32 @@ export function parseAnswersFromComments(
     const { stripped } = stripQuotedLines(comment.body);
     const body = stripped;
 
-    // FR-004 discriminator (#949 Q5→C): the colon here is DELIBERATE and
-    // load-bearing. It separates engine-authored question comments (which
-    // use `### Q1: Topic` shape, per `formatComment` above) from cockpit
-    // answer-block delimiters (which use `### Q1` — NO colon). Removing the
-    // colon or folding this pattern into `QN_OPENER_PATTERN` would cause the
-    // `TRANSITION_WITH_QUESTION_HEADINGS` warn (in the caller) to fire on
-    // every legitimate cockpit integration — a 100%-rate false positive.
-    // Keep colon-required. Computed on the quote-stripped body so a quoted
-    // `> ### Q1:` heading does not read as a live transition signal.
-    const sourceHadQuestionHeadings = /(?:^|\n)###\s+Q\d+:/.test(body);
+    // FR-004 discriminator (#949 Q5→C, widened by #1189): what separates an
+    // engine/agent-authored QUESTION comment from a cockpit ANSWER-block
+    // delimiter is whether the `Q<n>` heading line carries trailing content.
+    //
+    // A cockpit answer block writes a BARE heading and puts the answer on the
+    // following line:
+    //     ### Q1
+    //     **Answer:** B
+    // A question comment always names the topic on the heading line itself:
+    //     ### Q1: Topic          (engine `formatComment` shape)
+    //     ### Q1 — Topic         (agent-composed shape — #1189)
+    //
+    // The original pattern required a COLON, so the em-dash shape fell on the
+    // answer-block side of the discriminator: the guard never fired, the
+    // question comment was parsed as answers, and each question's own topic
+    // was written into `clarifications.md` as its answer — silently skipping
+    // the `on-questions` gate (#1189).
+    //
+    // Requiring "at least one non-whitespace character after `Q<n>`" keeps the
+    // no-false-positive property the colon was protecting: a bare `### Q1`
+    // (optionally followed by trailing spaces) still does NOT match, so every
+    // legitimate cockpit integration is unaffected. Computed on the
+    // quote-stripped body so a quoted `> ### Q1:` heading does not read as a
+    // live transition signal.
+    const sourceHadQuestionHeadings =
+      /(?:^|\n)#{1,6}[ \t]+(?:\*\*)?Q\d+(?:\*\*)?[ \t]*[^\s]/.test(body);
 
     // FR-005: opener is line-anchored via `(?:^|\n)` inside QN_OPENER_PATTERN
     // so mid-prose references like "as per Q1: yes" do not capture as


### PR DESCRIPTION
Fixes #1189.

## Root cause

The FR-004 discriminator that decides whether a comment is a *question* comment or a cockpit *answer* block required a colon after `Q<n>`:

```ts
const sourceHadQuestionHeadings = /(?:^|\n)###\s+Q\d+:/.test(body);
```

The colon was deliberate (#949 Q5→C) — it separated the engine's `formatComment` shape (`### Q1: Topic`) from cockpit answer delimiters (`### Q1`, no colon). The assumption that broke is that **colon-less implies answer block**. A clarification batch posted as `### Q1 — Topic` is colon-less but is very much a question comment, so:

1. `sourceHadQuestionHeadings` stayed `false`, so `integrateGitHubAnswers` never took its fail-closed branch.
2. The opener grammar matched `### Q1` and the body capture swallowed ` — Topic`, so each question's **own topic** became its **answer**.
3. `clarifications.md` was written with `**Answer**: — <question title>` for every question.
4. Every question read as answered → `hasPendingClarifications` false → the `on-questions` gate was **skipped**.
5. plan → tasks → implement then ran on unanswered design questions.

Authorship cannot discriminate here: the cluster account authors both the questions and (when cockpit relays) the answers, so `viewerDidAuthor` is `true` on both sides.

Observed end-to-end on #1187 (gate skipped, em-dash headings) versus #1190 (gate held, colon headings) on the same engine and cluster ~1.5h apart — a clean natural experiment.

## Fix

Key the discriminator on **whether the `Q<n>` heading line carries trailing content**, which is the property that actually separates the two shapes:

```ts
const sourceHadQuestionHeadings =
  /(?:^|\n)#{1,6}[ \t]+(?:\*\*)?Q\d+(?:\*\*)?[ \t]*[^\s]/.test(body);
```

- A question comment always names its topic on the heading line — `### Q1: Topic`, `### Q1 — Topic`, `### Q1 Topic` — so all now match.
- A cockpit answer block writes a bare `### Q1` and puts the answer on the following line, so it still does **not** match (trailing whitespace included).

This preserves the no-false-positive property the colon was protecting, without depending on which punctuation the author happened to use.

## Tests

Three cases added; the first is a true regression test — it **fails** against the old regex and passes with the fix, while the other two pass both before and after (they pin the property that must not change):

- em-dash question comment sets `sourceHadQuestionHeadings` ← fails pre-fix
- bare `### Q1` / `### Q2  ` answer delimiters still do **not** set it, and still extract their answers
- the engine's own `### Q1: Topic` shape keeps setting it

`clarification-poster.test.ts` + `phase-loop.test.ts` + `tasks-md-fallback.test.ts`: 189 passed. `tsc --noEmit` clean.

## Deliberately not included

**A content-based veto** (rejecting any comment carrying `**Question**:` / `**Options**:` as an answer source) was proposed in #1189 and implemented first — it breaks pinned test **T017**, which asserts "content is not authorship" per #958 FR-001. That is an explicit prior decision, so it is left alone rather than silently reversed. The discriminator fix closes #1189 on its own. If the "authorship vs content" stance is worth revisiting as defence-in-depth, that deserves its own discussion.

**The agency-side half** is untouched: the clarify command hand-composed this comment rather than routing through `manage_clarifications`, so it also lacked the `<!-- generacy-clarification:batch-N -->` marker that would have deduped it out of the answer-candidate set. Fixing that would give a second, independent guard.

## Note on scope

Authored by hand rather than queued to the cluster: #1189 is a defect in the clarify gate itself, so running it through the pipeline would have exposed the fix to the very bug it repairs (a ~50% chance of its own clarifications being corrupted, unrecoverably, mid-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
